### PR TITLE
Fix calling OpenGL code on Netty thread

### DIFF
--- a/src/main/java/mods/eln/client/ConnectionListener.java
+++ b/src/main/java/mods/eln/client/ConnectionListener.java
@@ -9,6 +9,7 @@ import cpw.mods.fml.common.network.FMLNetworkEvent.ClientDisconnectionFromServer
 import mods.eln.Eln;
 import mods.eln.misc.Utils;
 import mods.eln.misc.UtilsClient;
+import net.minecraft.client.Minecraft;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -35,7 +36,7 @@ public class ConnectionListener {
     @SubscribeEvent
     public void onDisconnectedFromServerEvent(ClientDisconnectionFromServerEvent event) {
         Utils.println("Disconnected from server " + FMLCommonHandler.instance().getEffectiveSide());
-        UtilsClient.glDeleteListsAllSafe();
+        Minecraft.getMinecraft().func_152344_a(UtilsClient::glDeleteListsAllSafe);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
Fixes #308 . OpenGL in Minecraft is only guaranteed to have a context active on the main thread, not on the networking thread.

The method to queue code on the main thread was named on 1.8, but it was here in 1.7 too.