### PR TITLE
Localize all the visible strings in the game

### DIFF
--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -329,15 +329,15 @@ public class Eln {
         elnNetwork = NetworkRegistry.INSTANCE.newSimpleChannel("electrical-age");
         elnNetwork.registerMessage(AchievePacketHandler.class, AchievePacket.class, 0, Side.SERVER);
         elnNetwork.registerMessage(TransparentNodeRequestPacketHandler.class, TransparentNodeRequestPacket.class, 1,
-Side.SERVER);
-        elnNetwork.registerMessage(TransparentNodeResponsePacketHandler.class, TransparentNodeResponsePacket.class, 2
-        , Side.CLIENT);
+                Side.SERVER);
+        elnNetwork.registerMessage(TransparentNodeResponsePacketHandler.class, TransparentNodeResponsePacket.class, 2,
+                Side.CLIENT);
         elnNetwork.registerMessage(GhostNodeWailaRequestPacketHandler.class, GhostNodeWailaRequestPacket.class, 3,
                 Side.SERVER);
         elnNetwork.registerMessage(GhostNodeWailaResponsePacketHandler.class, GhostNodeWailaResponsePacket.class, 4,
                 Side.CLIENT);
         elnNetwork.registerMessage(SixNodeWailaRequestPacketHandler.class, SixNodeWailaRequestPacket.class, 5,
-Side.SERVER);
+                Side.SERVER);
         elnNetwork.registerMessage(SixNodeWailaResponsePacketHandler.class, SixNodeWailaResponsePacket.class, 6,
                 Side.CLIENT);
 
@@ -390,16 +390,16 @@ Side.SERVER);
         arcMetalBlock = new ArcMetalBlock();
 
         sharedItem =
-         (SharedItem) new SharedItem().setCreativeTab(creativeTab).setMaxStackSize(64).setUnlocalizedName("sharedItem");
+                (SharedItem) new SharedItem().setCreativeTab(creativeTab).setMaxStackSize(64).setUnlocalizedName("sharedItem");
 
         sharedItemStackOne =
-         (SharedItem) new SharedItem().setCreativeTab(creativeTab).setMaxStackSize(1).setUnlocalizedName(
-                 "sharedItemStackOne");
+                (SharedItem) new SharedItem().setCreativeTab(creativeTab).setMaxStackSize(1).setUnlocalizedName(
+                        "sharedItemStackOne");
 
         transparentNodeBlock = (TransparentNodeBlock) new TransparentNodeBlock(Material.iron,
- TransparentNodeEntity.class).setCreativeTab(creativeTab).setBlockTextureName("iron_block");
+                TransparentNodeEntity.class).setCreativeTab(creativeTab).setBlockTextureName("iron_block");
         sixNodeBlock =
-         (SixNodeBlock) new SixNodeBlock(Material.plants, SixNodeEntity.class).setCreativeTab(creativeTab).setBlockTextureName("iron_block");
+                (SixNodeBlock) new SixNodeBlock(Material.plants, SixNodeEntity.class).setCreativeTab(creativeTab).setBlockTextureName("iron_block");
 
         ghostBlock = (GhostBlock) new GhostBlock().setBlockTextureName("iron_block");
         lightBlock = new LightBlock();
@@ -448,7 +448,7 @@ Side.SERVER);
         if (Other.ccLoaded) {
             PeripheralHandler.register();
         }
-        CraftingRecipes.INSTANCE.recipeMaceratorModOres();
+        CraftingRecipes.INSTANCE.itemCrafting();
     }
 
     @EventHandler
@@ -465,7 +465,7 @@ Side.SERVER);
         FMLCommonHandler.instance().bus().register(new ElnFMLEventsHandler());
         MinecraftForge.EVENT_BUS.register(this);
         FMLInterModComms.sendMessage("Waila", "register", "mods.eln.integration.waila.WailaIntegration" +
- ".callbackRegister");
+                ".callbackRegister");
         Utils.println("Electrical age init done");
     }
 

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -329,15 +329,15 @@ public class Eln {
         elnNetwork = NetworkRegistry.INSTANCE.newSimpleChannel("electrical-age");
         elnNetwork.registerMessage(AchievePacketHandler.class, AchievePacket.class, 0, Side.SERVER);
         elnNetwork.registerMessage(TransparentNodeRequestPacketHandler.class, TransparentNodeRequestPacket.class, 1,
-                Side.SERVER);
-        elnNetwork.registerMessage(TransparentNodeResponsePacketHandler.class, TransparentNodeResponsePacket.class, 2,
-                Side.CLIENT);
+Side.SERVER);
+        elnNetwork.registerMessage(TransparentNodeResponsePacketHandler.class, TransparentNodeResponsePacket.class, 2
+        , Side.CLIENT);
         elnNetwork.registerMessage(GhostNodeWailaRequestPacketHandler.class, GhostNodeWailaRequestPacket.class, 3,
                 Side.SERVER);
         elnNetwork.registerMessage(GhostNodeWailaResponsePacketHandler.class, GhostNodeWailaResponsePacket.class, 4,
                 Side.CLIENT);
         elnNetwork.registerMessage(SixNodeWailaRequestPacketHandler.class, SixNodeWailaRequestPacket.class, 5,
-                Side.SERVER);
+Side.SERVER);
         elnNetwork.registerMessage(SixNodeWailaResponsePacketHandler.class, SixNodeWailaResponsePacket.class, 6,
                 Side.CLIENT);
 
@@ -390,16 +390,16 @@ public class Eln {
         arcMetalBlock = new ArcMetalBlock();
 
         sharedItem =
-                (SharedItem) new SharedItem().setCreativeTab(creativeTab).setMaxStackSize(64).setUnlocalizedName("sharedItem");
+         (SharedItem) new SharedItem().setCreativeTab(creativeTab).setMaxStackSize(64).setUnlocalizedName("sharedItem");
 
         sharedItemStackOne =
-                (SharedItem) new SharedItem().setCreativeTab(creativeTab).setMaxStackSize(1).setUnlocalizedName(
-                        "sharedItemStackOne");
+         (SharedItem) new SharedItem().setCreativeTab(creativeTab).setMaxStackSize(1).setUnlocalizedName(
+                 "sharedItemStackOne");
 
         transparentNodeBlock = (TransparentNodeBlock) new TransparentNodeBlock(Material.iron,
-                TransparentNodeEntity.class).setCreativeTab(creativeTab).setBlockTextureName("iron_block");
+ TransparentNodeEntity.class).setCreativeTab(creativeTab).setBlockTextureName("iron_block");
         sixNodeBlock =
-                (SixNodeBlock) new SixNodeBlock(Material.plants, SixNodeEntity.class).setCreativeTab(creativeTab).setBlockTextureName("iron_block");
+         (SixNodeBlock) new SixNodeBlock(Material.plants, SixNodeEntity.class).setCreativeTab(creativeTab).setBlockTextureName("iron_block");
 
         ghostBlock = (GhostBlock) new GhostBlock().setBlockTextureName("iron_block");
         lightBlock = new LightBlock();
@@ -448,7 +448,7 @@ public class Eln {
         if (Other.ccLoaded) {
             PeripheralHandler.register();
         }
-        CraftingRecipes.INSTANCE.itemCrafting();
+        CraftingRecipes.INSTANCE.recipeMaceratorModOres();
     }
 
     @EventHandler
@@ -465,7 +465,7 @@ public class Eln {
         FMLCommonHandler.instance().bus().register(new ElnFMLEventsHandler());
         MinecraftForge.EVENT_BUS.register(this);
         FMLInterModComms.sendMessage("Waila", "register", "mods.eln.integration.waila.WailaIntegration" +
-                ".callbackRegister");
+ ".callbackRegister");
         Utils.println("Electrical age init done");
     }
 

--- a/src/main/java/mods/eln/sixnode/currentrelay/CurrentRelay.kt
+++ b/src/main/java/mods/eln/sixnode/currentrelay/CurrentRelay.kt
@@ -5,7 +5,7 @@ import mods.eln.cable.CableRenderDescriptor
 import mods.eln.gui.GuiHelper
 import mods.eln.gui.GuiScreenEln
 import mods.eln.gui.IGuiObject
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.IConfigurable
 import mods.eln.misc.*
 import mods.eln.misc.LRDU.Companion.fromInt
@@ -95,11 +95,11 @@ class CurrentRelayDescriptor(
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
         list.addAll(
-            I18N.tr("A relay is an electrical\ncontact that conducts\ncurrent when a signal\nvoltage is applied.")
+            tr("A relay is an electrical\ncontact that conducts\ncurrent when a signal\nvoltage is applied.")
                 .split("\n".toRegex()).dropLastWhile { it.isEmpty() }
         )
         list.addAll(
-            I18N.tr("The relay's input behaves\nlike a Schmitt Trigger.").split("\n".toRegex())
+            tr("The relay's input behaves\nlike a Schmitt Trigger.").split("\n".toRegex())
                 .dropLastWhile { it.isEmpty() }
         )
     }
@@ -244,15 +244,15 @@ class CurrentRelayElement(sixNode: SixNode, side: Direction, descriptor: SixNode
 
     override fun getWaila(): Map<String, String> {
         val info: MutableMap<String, String> = HashMap()
-        info[I18N.tr("Position")] = if (switchState) I18N.tr("Closed") else I18N.tr("Open")
-        info[I18N.tr("Current")] = plotAmpere("", aLoad.current)
-        info[I18N.tr("Temperature")] = Utils.plotCelsius("", thermalLoad.temperatureCelsius)
+        info[tr("Position")] = if (switchState) tr("Closed") else tr("Open")
+        info[tr("Current")] = plotAmpere("", aLoad.current)
+        info[tr("Temperature")] = Utils.plotCelsius("", thermalLoad.temperatureCelsius)
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Default position")] = if (defaultOutput) I18N.tr("Closed") else I18N.tr("Open")
-            info[I18N.tr("Voltages")] =
+            info[tr("Default position")] = if (defaultOutput) tr("Closed") else tr("Open")
+            info[tr("Voltages")] =
                 plotVolt("", aLoad.voltage) + plotVolt(" ", bLoad.voltage)
         }
-        info[I18N.tr("Subsystem Matrix Size")] = renderSubSystemWaila(switchResistor.subSystem)
+        info[tr("Subsystem Matrix Size")] = renderSubSystemWaila(switchResistor.subSystem)
         return info
     }
 
@@ -340,7 +340,7 @@ class CurrentRelayGui(val render: CurrentRelayRender): GuiScreenEln() {
 
     override fun initGui() {
         super.initGui()
-        toggleDefaultOutput = newGuiButton(6, 32 / 2 - 10, 115, I18N.tr("Toggle switch"))
+        toggleDefaultOutput = newGuiButton(6, 32 / 2 - 10, 115, tr("Toggle switch"))
     }
 
     override fun guiObjectEvent(`object`: IGuiObject?) {
@@ -353,7 +353,7 @@ class CurrentRelayGui(val render: CurrentRelayRender): GuiScreenEln() {
     override fun preDraw(f: Float, x: Int, y: Int) {
         super.preDraw(f, x, y)
         if (render.defaultOutput) toggleDefaultOutput.displayString =
-            I18N.tr("Normally closed") else toggleDefaultOutput.displayString = I18N.tr("Normally open")
+            tr("Normally closed") else toggleDefaultOutput.displayString = tr("Normally open")
     }
 
     override fun newHelper(): GuiHelper {

--- a/src/main/java/mods/eln/sixnode/electricaldigitaldisplay/ElectricalDigitalDisplayElement.java
+++ b/src/main/java/mods/eln/sixnode/electricaldigitaldisplay/ElectricalDigitalDisplayElement.java
@@ -1,6 +1,7 @@
 package mods.eln.sixnode.electricaldigitaldisplay;
 
 import mods.eln.generic.GenericItemUsingDamageDescriptor;
+import mods.eln.i18n.I18N;
 import mods.eln.item.BrushDescriptor;
 import mods.eln.item.IConfigurable;
 import mods.eln.misc.Direction;
@@ -167,9 +168,9 @@ public class ElectricalDigitalDisplayElement extends SixNodeElement implements I
     @Override
     public Map<String, String> getWaila() {
         HashMap<String, String> info = new HashMap<>();
-        info.put("Input: ", Utils.plotVolt(input.getVoltage()));
-        info.put("Min: ", String.format("%.2f", min));
-        info.put("Max: ", String.format("%.2f", max));
+        info.put(I18N.tr("Input"), Utils.plotVolt(input.getVoltage()));
+        info.put(I18N.tr("Min"), String.format("%.2f", min));
+        info.put(I18N.tr("Max"), String.format("%.2f", max));
         return info;
     }
 

--- a/src/main/java/mods/eln/sixnode/electricaldigitaldisplay/ElectricalDigitalDisplayElement.java
+++ b/src/main/java/mods/eln/sixnode/electricaldigitaldisplay/ElectricalDigitalDisplayElement.java
@@ -1,7 +1,6 @@
 package mods.eln.sixnode.electricaldigitaldisplay;
 
 import mods.eln.generic.GenericItemUsingDamageDescriptor;
-import mods.eln.i18n.I18N;
 import mods.eln.item.BrushDescriptor;
 import mods.eln.item.IConfigurable;
 import mods.eln.misc.Direction;
@@ -168,9 +167,9 @@ public class ElectricalDigitalDisplayElement extends SixNodeElement implements I
     @Override
     public Map<String, String> getWaila() {
         HashMap<String, String> info = new HashMap<>();
-        info.put(I18N.tr("Input"), Utils.plotVolt(input.getVoltage()));
-        info.put(I18N.tr("Min"), String.format("%.2f", min));
-        info.put(I18N.tr("Max"), String.format("%.2f", max));
+        info.put("Input: ", Utils.plotVolt(input.getVoltage()));
+        info.put("Min: ", String.format("%.2f", min));
+        info.put("Max: ", String.format("%.2f", max));
         return info;
     }
 

--- a/src/main/java/mods/eln/sixnode/lampsocket/LampSocketElement.java
+++ b/src/main/java/mods/eln/sixnode/lampsocket/LampSocketElement.java
@@ -221,8 +221,9 @@ public class LampSocketElement extends SixNodeElement implements IConfigurable {
     public Map<String, String> getWaila() {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Power consumption"), Utils.plotPower("", lampResistor.getCurrent() * lampResistor.getVoltage()));
-        if (lampDescriptor != null) {
-            info.put(I18N.tr("Bulb"), lampDescriptor.name);
+        ItemStack lampStack = acceptingInventory.getInventory().getStackInSlot(0);
+        if (lampDescriptor != null && lampStack != null) {
+            info.put(I18N.tr("Bulb"), lampStack.getDisplayName());
         } else {
             info.put(I18N.tr("Bulb"), I18N.tr("None"));
         }
@@ -231,7 +232,6 @@ public class LampSocketElement extends SixNodeElement implements IConfigurable {
                 info.put(I18N.tr("Channel"), channel);
             }
             info.put(I18N.tr("Voltage"), Utils.plotVolt("", positiveLoad.getVoltage()));
-            ItemStack lampStack = acceptingInventory.getInventory().getStackInSlot(0);
             if (lampStack != null && lampDescriptor != null) {
                 info.put(I18N.tr("Life Left: "), Utils.plotValue(lampDescriptor.getLifeInTag(lampStack)) + " Hours");
             }

--- a/src/main/java/mods/eln/sixnode/lampsocket/LampSocketElement.java
+++ b/src/main/java/mods/eln/sixnode/lampsocket/LampSocketElement.java
@@ -221,9 +221,8 @@ public class LampSocketElement extends SixNodeElement implements IConfigurable {
     public Map<String, String> getWaila() {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Power consumption"), Utils.plotPower("", lampResistor.getCurrent() * lampResistor.getVoltage()));
-        ItemStack lampStack = acceptingInventory.getInventory().getStackInSlot(0);
-        if (lampDescriptor != null && lampStack != null) {
-            info.put(I18N.tr("Bulb"), lampStack.getDisplayName());
+        if (lampDescriptor != null) {
+            info.put(I18N.tr("Bulb"), lampDescriptor.name);
         } else {
             info.put(I18N.tr("Bulb"), I18N.tr("None"));
         }
@@ -232,6 +231,7 @@ public class LampSocketElement extends SixNodeElement implements IConfigurable {
                 info.put(I18N.tr("Channel"), channel);
             }
             info.put(I18N.tr("Voltage"), Utils.plotVolt("", positiveLoad.getVoltage()));
+            ItemStack lampStack = acceptingInventory.getInventory().getStackInSlot(0);
             if (lampStack != null && lampDescriptor != null) {
                 info.put(I18N.tr("Life Left: "), Utils.plotValue(lampDescriptor.getLifeInTag(lampStack)) + " Hours");
             }

--- a/src/main/java/mods/eln/sixnode/thermalcable/ThermalCableDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/thermalcable/ThermalCableDescriptor.java
@@ -109,8 +109,8 @@ public class ThermalCableDescriptor extends SixNodeDescriptor {
         list.add(tr("Serial resistance: %1$K/W", Utils.plotValue(thermalRs * 2)));
         list.add(tr("Parallel resistance: %1$K/W", Utils.plotValue(thermalRp)));
         list.add("");
-        Collections.addAll(list, tr("Low serial resistance\n ⇨ High conductivity.").split("\n"));
-        Collections.addAll(list, tr("High parallel resistance\n ⇨ Low power dissipation.").split("\n"));
+        Collections.addAll(list, tr("Low serial resistance\n => High conductivity.").split("\n"));
+        Collections.addAll(list, tr("High parallel resistance\n => Low power dissipation.").split("\n"));
     }
 
     @Override

--- a/src/main/java/mods/eln/sixnode/thermalcable/ThermalCableDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/thermalcable/ThermalCableDescriptor.java
@@ -109,8 +109,8 @@ public class ThermalCableDescriptor extends SixNodeDescriptor {
         list.add(tr("Serial resistance: %1$K/W", Utils.plotValue(thermalRs * 2)));
         list.add(tr("Parallel resistance: %1$K/W", Utils.plotValue(thermalRp)));
         list.add("");
-        Collections.addAll(list, tr("Low serial resistance\n => High conductivity.").split("\n"));
-        Collections.addAll(list, tr("High parallel resistance\n => Low power dissipation.").split("\n"));
+        Collections.addAll(list, tr("Low serial resistance\n ⇨ High conductivity.").split("\n"));
+        Collections.addAll(list, tr("High parallel resistance\n ⇨ Low power dissipation.").split("\n"));
     }
 
     @Override

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/WirelessSignalAnalyserItemDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/WirelessSignalAnalyserItemDescriptor.java
@@ -1,6 +1,7 @@
 package mods.eln.sixnode.wirelesssignal;
 
 import mods.eln.generic.GenericItemUsingDamageDescriptor;
+import mods.eln.i18n.I18N;
 import mods.eln.misc.Coordinate;
 import mods.eln.misc.Direction;
 import mods.eln.misc.Utils;
@@ -42,11 +43,11 @@ public class WirelessSignalAnalyserItemDescriptor extends GenericItemUsingDamage
                 double temp = txStrength.get(oneTx);
                 if (temp < strength) strength = temp;
             }
-            Utils.addChatMessage(player, entrySet.getKey() + " Strength=" + String.format("%2.1f", strength) + " Value=" + String.format("%3.0f", aggregator.aggregate(set) * 100) + "%");
+            Utils.addChatMessage(player, entrySet.getKey() + I18N.tr(" Strength")+"=" + String.format("%2.1f", strength) + I18N.tr(" Value")+"=" + String.format("%3.0f", aggregator.aggregate(set) * 100) + "%");
         }
 
         if (txSet.isEmpty()) {
-            Utils.addChatMessage(player, "No wireless signal in area!");
+            Utils.addChatMessage(player, I18N.tr("No wireless signal in area!"));
         }
         /*ArrayList<WirelessSignalInfo> list = WirelessSignalRxProcess.getTxList(c);
 		int idx = 0;

--- a/src/main/java/mods/eln/sixnode/wirelesssignal/WirelessSignalAnalyserItemDescriptor.java
+++ b/src/main/java/mods/eln/sixnode/wirelesssignal/WirelessSignalAnalyserItemDescriptor.java
@@ -1,7 +1,6 @@
 package mods.eln.sixnode.wirelesssignal;
 
 import mods.eln.generic.GenericItemUsingDamageDescriptor;
-import mods.eln.i18n.I18N;
 import mods.eln.misc.Coordinate;
 import mods.eln.misc.Direction;
 import mods.eln.misc.Utils;
@@ -43,11 +42,11 @@ public class WirelessSignalAnalyserItemDescriptor extends GenericItemUsingDamage
                 double temp = txStrength.get(oneTx);
                 if (temp < strength) strength = temp;
             }
-            Utils.addChatMessage(player, entrySet.getKey() + I18N.tr(" Strength")+"=" + String.format("%2.1f", strength) + I18N.tr(" Value")+"=" + String.format("%3.0f", aggregator.aggregate(set) * 100) + "%");
+            Utils.addChatMessage(player, entrySet.getKey() + " Strength=" + String.format("%2.1f", strength) + " Value=" + String.format("%3.0f", aggregator.aggregate(set) * 100) + "%");
         }
 
         if (txSet.isEmpty()) {
-            Utils.addChatMessage(player, I18N.tr("No wireless signal in area!"));
+            Utils.addChatMessage(player, "No wireless signal in area!");
         }
         /*ArrayList<WirelessSignalInfo> list = WirelessSignalRxProcess.getTxList(c);
 		int idx = 0;

--- a/src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineElement.java
+++ b/src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineElement.java
@@ -156,7 +156,7 @@ public class WaterTurbineElement extends TransparentNodeElement {
         wailaList.put(I18N.tr("Generating"), slowProcess.getWaterFactor() > 0 ? I18N.tr("Yes") : I18N.tr("No"));
         wailaList.put(I18N.tr("Produced power"), Utils.plotPower("", powerSource.getEffectivePower()));
         if (Eln.wailaEasyMode) {
-            wailaList.put("Voltage", Utils.plotVolt("", powerSource.getVoltage()));
+            wailaList.put(I18N.tr("Voltage"), Utils.plotVolt("", powerSource.getVoltage()));
         }
         return wailaList;
     }

--- a/src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineElement.java
+++ b/src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineElement.java
@@ -156,7 +156,7 @@ public class WaterTurbineElement extends TransparentNodeElement {
         wailaList.put(I18N.tr("Generating"), slowProcess.getWaterFactor() > 0 ? I18N.tr("Yes") : I18N.tr("No"));
         wailaList.put(I18N.tr("Produced power"), Utils.plotPower("", powerSource.getEffectivePower()));
         if (Eln.wailaEasyMode) {
-            wailaList.put(I18N.tr("Voltage"), Utils.plotVolt("", powerSource.getVoltage()));
+            wailaList.put("Voltage", Utils.plotVolt("", powerSource.getVoltage()));
         }
         return wailaList;
     }

--- a/src/main/java/mods/eln/transparentnode/windturbine/WindTurbineElement.java
+++ b/src/main/java/mods/eln/transparentnode/windturbine/WindTurbineElement.java
@@ -129,7 +129,7 @@ public class WindTurbineElement extends TransparentNodeElement {
         wailaList.put(I18N.tr("Generating"), slowProcess.getWind() > 0 ? I18N.tr("Yes") : I18N.tr("No"));
         wailaList.put(I18N.tr("Produced power"), Utils.plotPower("", powerSource.getEffectivePower()));
         if (Eln.wailaEasyMode) {
-            wailaList.put("Voltage", Utils.plotVolt("", powerSource.getVoltage()));
+            wailaList.put(I18N.tr("Voltage"), Utils.plotVolt("", powerSource.getVoltage()));
         }
         return wailaList;
     }

--- a/src/main/java/mods/eln/transparentnode/windturbine/WindTurbineElement.java
+++ b/src/main/java/mods/eln/transparentnode/windturbine/WindTurbineElement.java
@@ -129,7 +129,7 @@ public class WindTurbineElement extends TransparentNodeElement {
         wailaList.put(I18N.tr("Generating"), slowProcess.getWind() > 0 ? I18N.tr("Yes") : I18N.tr("No"));
         wailaList.put(I18N.tr("Produced power"), Utils.plotPower("", powerSource.getEffectivePower()));
         if (Eln.wailaEasyMode) {
-            wailaList.put(I18N.tr("Voltage"), Utils.plotVolt("", powerSource.getVoltage()));
+            wailaList.put("Voltage", Utils.plotVolt("", powerSource.getVoltage()));
         }
         return wailaList;
     }

--- a/src/main/kotlin/mods/eln/Achievements.kt
+++ b/src/main/kotlin/mods/eln/Achievements.kt
@@ -1,6 +1,7 @@
 package mods.eln
 
 import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import net.minecraft.init.Items
 import net.minecraft.stats.Achievement
 import net.minecraftforge.common.AchievementPage
@@ -15,21 +16,21 @@ object Achievements {
     @JvmStatic
     fun init() {
         openGuide = Achievement(
-            I18N.TR("achievement.open_guide"),
+            tr("achievement.open_guide"),
             "open_guide", 0, 0, Items.book, null
         ).registerStat()
 
         I18N.TR_DESC(I18N.Type.ACHIEVEMENT, "open_guide")
 
         craft50VMacerator = Achievement(
-            I18N.TR("achievement.craft_50v_macerator"),
+            tr("achievement.craft_50v_macerator"),
             "craft_50v_macerator", 0, 2, Eln.findItemStack("50V Macerator", 0), openGuide
         ).registerStat()
 
         I18N.TR_DESC(I18N.Type.ACHIEVEMENT, "craft_50v_macerator")
 
         achievementPageEln = AchievementPage(
-            I18N.tr("Electrical Age [WIP]"),
+            tr("Electrical Age [WIP]"),
             openGuide, craft50VMacerator
         )
 

--- a/src/main/kotlin/mods/eln/craft/CraftingRecipes.kt
+++ b/src/main/kotlin/mods/eln/craft/CraftingRecipes.kt
@@ -18,6 +18,8 @@ import net.minecraft.launchwrapper.LogWrapper
 import net.minecraftforge.oredict.OreDictionary
 import net.minecraftforge.oredict.ShapedOreRecipe
 import net.minecraftforge.oredict.ShapelessOreRecipe
+import java.util.*
+import kotlin.collections.HashSet
 
 object CraftingRecipes {
 
@@ -116,6 +118,14 @@ object CraftingRecipes {
         recipeECoal()
 
         recipeGridDevices(Eln.oreNames)
+        recipeMaceratorModOres()
+        craftBrush()
+        val cal: Calendar = Calendar.getInstance()
+        val month: Int = cal.get(Calendar.MONTH) + 1
+        val day: Int = cal.get(Calendar.DAY_OF_MONTH)
+        if(month == 12 && day == 25) {
+            recipeChristmas()
+        }
 
         checkRecipe()
     }
@@ -371,6 +381,10 @@ object CraftingRecipes {
             findItemStack("Coal Dust")
         )
         addRecipe(
+            findItemStack("Thermistor"), "   ", "cCc", "   ", 'c', findItemStack("Copper Cable"), 'C',
+            findItemStack("Copper Ingot")
+        )
+        addRecipe(
             findItemStack("Rheostat"), " R ", " MS", "cmc", 'R', findItemStack("Power Resistor"), 'c',
             findItemStack("Copper Cable"), 'm', findItemStack("Machine Block"), 'M', findItemStack("Electrical Motor"),
             'S', findItemStack("Signal Cable")
@@ -433,6 +447,24 @@ object CraftingRecipes {
             findItemStack("Signal Relay"), "GGG", "OIO", "CRC", 'R', ItemStack(Items.redstone), 'O',
             findItemStack("Iron Cable"), 'G', ItemStack(Blocks.glass_pane), 'I', findItemStack("Copper Cable"), 'C',
             findItemStack("Signal Cable")
+        )
+        addRecipe(
+            findItemStack("Low Current Relay"), "GGG", "OIO", "CRC", 'R', ItemStack(Items.redstone), 'O',
+            findItemStack("Iron Cable"), 'G', ItemStack(Blocks.glass_pane), 'A', "itemRubber", 'I', findItemStack(
+                "Copper Cable"
+            ), 'C', findItemStack("Low Current Cable")
+        )
+        addRecipe(
+            findItemStack("Medium Current Relay"), "GGG", "OIO", "CRC", 'R', ItemStack(Items.redstone), 'O',
+            findItemStack("Iron Cable"), 'G', ItemStack(Blocks.glass_pane), 'A', "itemRubber", 'I', findItemStack(
+                "Copper Cable"
+            ), 'C', findItemStack("Medium Current Cable")
+        )
+        addRecipe(
+            findItemStack("High Current Relay"), "GGG", "OIO", "CRC", 'R', ItemStack(Items.redstone), 'O',
+            findItemStack("Iron Cable"), 'G', ItemStack(Blocks.glass_pane), 'A', "itemRubber", 'I', findItemStack(
+                "Copper Cable"
+            ), 'C', findItemStack("High Current Cable")
         )
     }
 
@@ -510,6 +542,10 @@ object CraftingRecipes {
         addRecipe(
             findItemStack("Amplifier"), "  r", "cCc", "   ", 'r', ItemStack(Items.redstone), 'c',
             findItemStack("Copper Cable"), 'C', Eln.dictAdvancedChip
+        )
+        addRecipe(
+            findItemStack("Voltage controlled amplifier"), " sr", "cCc", "   ", 'r', ItemStack(Items.redstone), 'c',
+            findItemStack("Copper Cable"), 'C', Eln.dictAdvancedChip, 's', findItemStack("Signal Cable")
         )
         addRecipe(
             findItemStack("OpAmp"), "  r", "cCc", " c ", 'r', ItemStack(Items.redstone), 'c',
@@ -610,6 +646,7 @@ object CraftingRecipes {
             ), 'M', findItemStack("Advanced Machine Block")
         )
         addRecipe(findItemStack("Joint"), "   ", "iii", " m ", 'i', "ingotIron", 'm', findItemStack("Machine Block"))
+        addRecipe(findItemStack("Crank Shaft"), "  i", "iii", " m ", 'i', "ingotIron", 'm', findItemStack("Machine Block"))
         addRecipe(
             findItemStack("Joint hub"), " i ", "iii", " m ", 'i', "ingotIron", 'm', findItemStack(
                 "Machine " +
@@ -637,6 +674,10 @@ object CraftingRecipes {
             findItemStack("Fixed Shaft"), "iBi", " c ", 'i', "ingotIron", 'B', "blockIron", 'c', findItemStack(
                 "Machine Block"
             )
+        )
+        addRecipe(
+            findItemStack("Rolling Shaft Machine"), "IiI", "IcI", "IiI", 'i', "ingotIron", 'I', "plateIron", 'c', findItemStack(
+                "Machine Block")
         )
     }
 
@@ -1365,6 +1406,10 @@ object CraftingRecipes {
             findItemStack("Monster Filter"), " g", "gc", " g", 'g', ItemStack(Blocks.glass_pane), 'c',
             ItemStack(Items.dye, 1, 1)
         )
+        addRecipe(
+            findItemStack("Animal Filter"), " g", "gc", " g", 'g', ItemStack(Blocks.glass_pane), 'c',
+            ItemStack(Items.dye, 1, 4)
+        )
         addRecipe(Eln.findItemStack("Casing", 1), "ppp", "p p", "ppp", 'p', findItemStack("Iron Cable"))
         addRecipe(findItemStack("Iron Clutch Plate"), " t ", "tIt", " t ", 'I', "plateIron", 't', Eln.dictTungstenDust)
         addRecipe(findItemStack("Gold Clutch Plate"), " t ", "tGt", " t ", 'G', "plateGold", 't', Eln.dictTungstenDust)
@@ -1780,7 +1825,7 @@ object CraftingRecipes {
         ) //hardcoded 7MJ to prevent overunity
     }
 
-    public fun recipeMaceratorModOres() {
+    private fun recipeMaceratorModOres() {
         val f = 4000f
         recipeMaceratorModOre(f * 3f, "oreCertusQuartz", "dustCertusQuartz", 3)
         recipeMaceratorModOre(f * 1.5f, "crystalCertusQuartz", "dustCertusQuartz", 1)
@@ -2106,23 +2151,21 @@ object CraftingRecipes {
     }
 
     private fun recipeElectricalVuMeter() {
-        for (idx in 0..3) {
-            addRecipe(
-                Eln.findItemStack("Analog vuMeter", 1), "WWW", "RIr", "WSW", 'W', ItemStack(
-                    Blocks.planks, 1,
-                    idx
-                ), 'R', ItemStack(Items.redstone), 'I', findItemStack("Iron Cable"), 'r', ItemStack(
-                    Items.dye,
-                    1, 1
-                ), 'S', findItemStack("Signal Cable")
-            )
-        }
-        for (idx in 0..3) {
-            addRecipe(
-                Eln.findItemStack("LED vuMeter", 1), " W ", "WTW", " S ", 'W', ItemStack(Blocks.planks, 1, idx),
-                'T', ItemStack(Blocks.redstone_torch), 'S', findItemStack("Signal Cable")
-            )
-        }
+        addRecipe(
+            Eln.findItemStack("Analog vuMeter", 1), "WWW", "RIr", "WSW", 'W', "plankWood",
+            'R', ItemStack(Items.redstone), 'I', findItemStack("Iron Cable"), 'r', ItemStack(
+                Items.dye,
+                1, 1
+            ), 'S', findItemStack("Signal Cable")
+        )
+        addRecipe(
+            Eln.findItemStack("LED vuMeter", 1), " W ", "WTW", " S ", 'W', "plankWood",
+            'T', ItemStack(Blocks.redstone_torch), 'S', findItemStack("Signal Cable")
+        )
+        addRecipe(
+            Eln.findItemStack("Multicolor LED vuMeter", 1), " W ", "WRW", " S ", 'W', "plankWood",
+            'R', ItemStack(Items.redstone), 'S', findItemStack("Signal Cable")
+        )
     }
 
     private fun recipeElectricalBreaker() {
@@ -2368,6 +2411,13 @@ object CraftingRecipes {
         ReplicatorEntity.dropList.add(ItemStack(Items.glowstone_dust))
         // EntityRegistry.addSpawn(ReplicatorEntity.class, 1, 1, 2, EnumCreatureType.monster, BiomeGenBase.plains);
     }
-
+    private fun recipeChristmas(){
+        addShapelessRecipe(Eln.findItemStack("Christmas Tree", 1), findItemStack("String Lights"), ItemStack(Blocks.sapling, 1, 1), findItemStack("String Lights"))
+        addRecipe(
+            Eln.findItemStack("Holiday Candle", 1), " g ", "gbg", " i ", 'g', ItemStack(Blocks.glass_pane), 'b',
+            findItemStack("200V LED Bulb"), 'i', "ingotIron"
+        )
+        addShapelessRecipe(Eln.findItemStack("String Lights", 2), findItemStack("200V LED Bulb"), "materialString")
+    }
 
 }

--- a/src/main/kotlin/mods/eln/craft/CraftingRecipes.kt
+++ b/src/main/kotlin/mods/eln/craft/CraftingRecipes.kt
@@ -18,8 +18,6 @@ import net.minecraft.launchwrapper.LogWrapper
 import net.minecraftforge.oredict.OreDictionary
 import net.minecraftforge.oredict.ShapedOreRecipe
 import net.minecraftforge.oredict.ShapelessOreRecipe
-import java.util.*
-import kotlin.collections.HashSet
 
 object CraftingRecipes {
 
@@ -118,14 +116,6 @@ object CraftingRecipes {
         recipeECoal()
 
         recipeGridDevices(Eln.oreNames)
-        recipeMaceratorModOres()
-        craftBrush()
-        val cal: Calendar = Calendar.getInstance()
-        val month: Int = cal.get(Calendar.MONTH) + 1
-        val day: Int = cal.get(Calendar.DAY_OF_MONTH)
-        if(month == 12 && day == 25) {
-            recipeChristmas()
-        }
 
         checkRecipe()
     }
@@ -381,10 +371,6 @@ object CraftingRecipes {
             findItemStack("Coal Dust")
         )
         addRecipe(
-            findItemStack("Thermistor"), "   ", "cCc", "   ", 'c', findItemStack("Copper Cable"), 'C',
-            findItemStack("Copper Ingot")
-        )
-        addRecipe(
             findItemStack("Rheostat"), " R ", " MS", "cmc", 'R', findItemStack("Power Resistor"), 'c',
             findItemStack("Copper Cable"), 'm', findItemStack("Machine Block"), 'M', findItemStack("Electrical Motor"),
             'S', findItemStack("Signal Cable")
@@ -447,24 +433,6 @@ object CraftingRecipes {
             findItemStack("Signal Relay"), "GGG", "OIO", "CRC", 'R', ItemStack(Items.redstone), 'O',
             findItemStack("Iron Cable"), 'G', ItemStack(Blocks.glass_pane), 'I', findItemStack("Copper Cable"), 'C',
             findItemStack("Signal Cable")
-        )
-        addRecipe(
-            findItemStack("Low Current Relay"), "GGG", "OIO", "CRC", 'R', ItemStack(Items.redstone), 'O',
-            findItemStack("Iron Cable"), 'G', ItemStack(Blocks.glass_pane), 'A', "itemRubber", 'I', findItemStack(
-                "Copper Cable"
-            ), 'C', findItemStack("Low Current Cable")
-        )
-        addRecipe(
-            findItemStack("Medium Current Relay"), "GGG", "OIO", "CRC", 'R', ItemStack(Items.redstone), 'O',
-            findItemStack("Iron Cable"), 'G', ItemStack(Blocks.glass_pane), 'A', "itemRubber", 'I', findItemStack(
-                "Copper Cable"
-            ), 'C', findItemStack("Medium Current Cable")
-        )
-        addRecipe(
-            findItemStack("High Current Relay"), "GGG", "OIO", "CRC", 'R', ItemStack(Items.redstone), 'O',
-            findItemStack("Iron Cable"), 'G', ItemStack(Blocks.glass_pane), 'A', "itemRubber", 'I', findItemStack(
-                "Copper Cable"
-            ), 'C', findItemStack("High Current Cable")
         )
     }
 
@@ -542,10 +510,6 @@ object CraftingRecipes {
         addRecipe(
             findItemStack("Amplifier"), "  r", "cCc", "   ", 'r', ItemStack(Items.redstone), 'c',
             findItemStack("Copper Cable"), 'C', Eln.dictAdvancedChip
-        )
-        addRecipe(
-            findItemStack("Voltage controlled amplifier"), " sr", "cCc", "   ", 'r', ItemStack(Items.redstone), 'c',
-            findItemStack("Copper Cable"), 'C', Eln.dictAdvancedChip, 's', findItemStack("Signal Cable")
         )
         addRecipe(
             findItemStack("OpAmp"), "  r", "cCc", " c ", 'r', ItemStack(Items.redstone), 'c',
@@ -646,7 +610,6 @@ object CraftingRecipes {
             ), 'M', findItemStack("Advanced Machine Block")
         )
         addRecipe(findItemStack("Joint"), "   ", "iii", " m ", 'i', "ingotIron", 'm', findItemStack("Machine Block"))
-        addRecipe(findItemStack("Crank Shaft"), "  i", "iii", " m ", 'i', "ingotIron", 'm', findItemStack("Machine Block"))
         addRecipe(
             findItemStack("Joint hub"), " i ", "iii", " m ", 'i', "ingotIron", 'm', findItemStack(
                 "Machine " +
@@ -674,10 +637,6 @@ object CraftingRecipes {
             findItemStack("Fixed Shaft"), "iBi", " c ", 'i', "ingotIron", 'B', "blockIron", 'c', findItemStack(
                 "Machine Block"
             )
-        )
-        addRecipe(
-            findItemStack("Rolling Shaft Machine"), "IiI", "IcI", "IiI", 'i', "ingotIron", 'I', "plateIron", 'c', findItemStack(
-                "Machine Block")
         )
     }
 
@@ -1406,10 +1365,6 @@ object CraftingRecipes {
             findItemStack("Monster Filter"), " g", "gc", " g", 'g', ItemStack(Blocks.glass_pane), 'c',
             ItemStack(Items.dye, 1, 1)
         )
-        addRecipe(
-            findItemStack("Animal Filter"), " g", "gc", " g", 'g', ItemStack(Blocks.glass_pane), 'c',
-            ItemStack(Items.dye, 1, 4)
-        )
         addRecipe(Eln.findItemStack("Casing", 1), "ppp", "p p", "ppp", 'p', findItemStack("Iron Cable"))
         addRecipe(findItemStack("Iron Clutch Plate"), " t ", "tIt", " t ", 'I', "plateIron", 't', Eln.dictTungstenDust)
         addRecipe(findItemStack("Gold Clutch Plate"), " t ", "tGt", " t ", 'G', "plateGold", 't', Eln.dictTungstenDust)
@@ -1825,7 +1780,7 @@ object CraftingRecipes {
         ) //hardcoded 7MJ to prevent overunity
     }
 
-    private fun recipeMaceratorModOres() {
+    public fun recipeMaceratorModOres() {
         val f = 4000f
         recipeMaceratorModOre(f * 3f, "oreCertusQuartz", "dustCertusQuartz", 3)
         recipeMaceratorModOre(f * 1.5f, "crystalCertusQuartz", "dustCertusQuartz", 1)
@@ -2151,21 +2106,23 @@ object CraftingRecipes {
     }
 
     private fun recipeElectricalVuMeter() {
-        addRecipe(
-            Eln.findItemStack("Analog vuMeter", 1), "WWW", "RIr", "WSW", 'W', "plankWood",
-            'R', ItemStack(Items.redstone), 'I', findItemStack("Iron Cable"), 'r', ItemStack(
-                Items.dye,
-                1, 1
-            ), 'S', findItemStack("Signal Cable")
-        )
-        addRecipe(
-            Eln.findItemStack("LED vuMeter", 1), " W ", "WTW", " S ", 'W', "plankWood",
-            'T', ItemStack(Blocks.redstone_torch), 'S', findItemStack("Signal Cable")
-        )
-        addRecipe(
-            Eln.findItemStack("Multicolor LED vuMeter", 1), " W ", "WRW", " S ", 'W', "plankWood",
-            'R', ItemStack(Items.redstone), 'S', findItemStack("Signal Cable")
-        )
+        for (idx in 0..3) {
+            addRecipe(
+                Eln.findItemStack("Analog vuMeter", 1), "WWW", "RIr", "WSW", 'W', ItemStack(
+                    Blocks.planks, 1,
+                    idx
+                ), 'R', ItemStack(Items.redstone), 'I', findItemStack("Iron Cable"), 'r', ItemStack(
+                    Items.dye,
+                    1, 1
+                ), 'S', findItemStack("Signal Cable")
+            )
+        }
+        for (idx in 0..3) {
+            addRecipe(
+                Eln.findItemStack("LED vuMeter", 1), " W ", "WTW", " S ", 'W', ItemStack(Blocks.planks, 1, idx),
+                'T', ItemStack(Blocks.redstone_torch), 'S', findItemStack("Signal Cable")
+            )
+        }
     }
 
     private fun recipeElectricalBreaker() {
@@ -2411,13 +2368,6 @@ object CraftingRecipes {
         ReplicatorEntity.dropList.add(ItemStack(Items.glowstone_dust))
         // EntityRegistry.addSpawn(ReplicatorEntity.class, 1, 1, 2, EnumCreatureType.monster, BiomeGenBase.plains);
     }
-    private fun recipeChristmas(){
-        addShapelessRecipe(Eln.findItemStack("Christmas Tree", 1), findItemStack("String Lights"), ItemStack(Blocks.sapling, 1, 1), findItemStack("String Lights"))
-        addRecipe(
-            Eln.findItemStack("Holiday Candle", 1), " g ", "gbg", " i ", 'g', ItemStack(Blocks.glass_pane), 'b',
-            findItemStack("200V LED Bulb"), 'i', "ingotIron"
-        )
-        addShapelessRecipe(Eln.findItemStack("String Lights", 2), findItemStack("200V LED Bulb"), "materialString")
-    }
+
 
 }

--- a/src/main/kotlin/mods/eln/gridnode/GridSwitch.kt
+++ b/src/main/kotlin/mods/eln/gridnode/GridSwitch.kt
@@ -1,6 +1,7 @@
 package mods.eln.gridnode
 
 import mods.eln.Eln
+import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.TransparentNode
@@ -286,13 +287,13 @@ class GridSwitchElement(node: TransparentNode, descriptor: TransparentNodeDescri
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
         if (Eln.wailaEasyMode) {
-            info["Left"] = Utils.plotUIP(grida.voltage, grida.current)
-            info["Right"] = Utils.plotUIP(gridb.voltage, gridb.current)
-            info["Transfer"] = Utils.plotPower(transfer.power)
+            info[I18N.tr("Left")] = Utils.plotUIP(grida.voltage, grida.current)
+            info[I18N.tr("Right")] = Utils.plotUIP(gridb.voltage, gridb.current)
+            info[I18N.tr("Transfer")] = Utils.plotPower(transfer.power)
         }
-        info["Drive"] = Utils.plotUIP(power.voltage, power.current, powerSink.resistance) + " " + Utils.plotOhm(powerSink.resistance)
-        info["Signal"] = Utils.plotSignal(control.voltage)
-        info["Closed?"] = if(closed) { "Yes" } else { "No" }
+        info[I18N.tr("Drive")] = Utils.plotUIP(power.voltage, power.current, powerSink.resistance) + " " + Utils.plotOhm(powerSink.resistance)
+        info[I18N.tr("Signal")] = Utils.plotSignal(control.voltage)
+        info[I18N.tr("Closed?")] = if(closed) { "Yes" } else { "No" }
         return info
     }
 }

--- a/src/main/kotlin/mods/eln/gridnode/GridSwitch.kt
+++ b/src/main/kotlin/mods/eln/gridnode/GridSwitch.kt
@@ -1,7 +1,7 @@
 package mods.eln.gridnode
 
 import mods.eln.Eln
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.TransparentNode
@@ -287,13 +287,13 @@ class GridSwitchElement(node: TransparentNode, descriptor: TransparentNodeDescri
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Left")] = Utils.plotUIP(grida.voltage, grida.current)
-            info[I18N.tr("Right")] = Utils.plotUIP(gridb.voltage, gridb.current)
-            info[I18N.tr("Transfer")] = Utils.plotPower(transfer.power)
+            info[tr("Left")] = Utils.plotUIP(grida.voltage, grida.current)
+            info[tr("Right")] = Utils.plotUIP(gridb.voltage, gridb.current)
+            info[tr("Transfer")] = Utils.plotPower(transfer.power)
         }
-        info[I18N.tr("Drive")] = Utils.plotUIP(power.voltage, power.current, powerSink.resistance) + " " + Utils.plotOhm(powerSink.resistance)
-        info[I18N.tr("Signal")] = Utils.plotSignal(control.voltage)
-        info[I18N.tr("Closed?")] = if(closed) { "Yes" } else { "No" }
+        info[tr("Drive")] = Utils.plotUIP(power.voltage, power.current, powerSink.resistance) + " " + Utils.plotOhm(powerSink.resistance)
+        info[tr("Signal")] = Utils.plotSignal(control.voltage)
+        info[tr("Closed?")] = if(closed) { "Yes" } else { "No" }
         return info
     }
 }

--- a/src/main/kotlin/mods/eln/gridnode/GridSwitch.kt
+++ b/src/main/kotlin/mods/eln/gridnode/GridSwitch.kt
@@ -1,7 +1,6 @@
 package mods.eln.gridnode
 
 import mods.eln.Eln
-import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.TransparentNode
@@ -287,13 +286,13 @@ class GridSwitchElement(node: TransparentNode, descriptor: TransparentNodeDescri
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Left")] = Utils.plotUIP(grida.voltage, grida.current)
-            info[I18N.tr("Right")] = Utils.plotUIP(gridb.voltage, gridb.current)
-            info[I18N.tr("Transfer")] = Utils.plotPower(transfer.power)
+            info["Left"] = Utils.plotUIP(grida.voltage, grida.current)
+            info["Right"] = Utils.plotUIP(gridb.voltage, gridb.current)
+            info["Transfer"] = Utils.plotPower(transfer.power)
         }
-        info[I18N.tr("Drive")] = Utils.plotUIP(power.voltage, power.current, powerSink.resistance) + " " + Utils.plotOhm(powerSink.resistance)
-        info[I18N.tr("Signal")] = Utils.plotSignal(control.voltage)
-        info[I18N.tr("Closed?")] = if(closed) { "Yes" } else { "No" }
+        info["Drive"] = Utils.plotUIP(power.voltage, power.current, powerSink.resistance) + " " + Utils.plotOhm(powerSink.resistance)
+        info["Signal"] = Utils.plotSignal(control.voltage)
+        info["Closed?"] = if(closed) { "Yes" } else { "No" }
         return info
     }
 }

--- a/src/main/kotlin/mods/eln/item/CaseItemDescriptor.kt
+++ b/src/main/kotlin/mods/eln/item/CaseItemDescriptor.kt
@@ -1,12 +1,12 @@
 package mods.eln.item
 
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
 
 class CaseItemDescriptor(name: String) : GenericItemUsingDamageDescriptorUpgrade(name) {
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list.add(I18N.tr("Can be used to encase EA items that support it"))
+        list.add(tr("Can be used to encase EA items that support it"))
     }
 }

--- a/src/main/kotlin/mods/eln/item/FuelBurnerDescriptor.kt
+++ b/src/main/kotlin/mods/eln/item/FuelBurnerDescriptor.kt
@@ -1,7 +1,7 @@
 package mods.eln.item
 
 import mods.eln.generic.GenericItemUsingDamage
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Utils
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
@@ -25,7 +25,7 @@ class FuelBurnerDescriptor(name: String, val producedHeatPower: Double, val type
 
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list.add(I18N.tr("Burn unit for the gas heat furnace."))
-        list.add(Utils.plotPower(I18N.tr("Produced heat power: "), producedHeatPower))
+        list.add(tr("Burn unit for the gas heat furnace."))
+        list.add(Utils.plotPower(tr("Produced heat power: "), producedHeatPower))
     }
 }

--- a/src/main/kotlin/mods/eln/item/LampDescriptor.kt
+++ b/src/main/kotlin/mods/eln/item/LampDescriptor.kt
@@ -2,6 +2,7 @@ package mods.eln.item
 
 import mods.eln.Eln
 import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.IConfigSharing
 import mods.eln.misc.Utils
 import mods.eln.misc.VoltageLevelColor
@@ -75,22 +76,22 @@ class LampDescriptor(
 
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list.add(I18N.tr("Technology: %1$", type))
-        list.add(I18N.tr("Range: %1$ blocks", (nominalLight * 15).toInt()))
-        list.add(I18N.tr("Power: %1\$W", Utils.plotValue(nominalP)))
-        list.add(I18N.tr("Resistance: %1$\u2126", Utils.plotValue(r)))
-        list.add(I18N.tr("Nominal lifetime: %1\$h", serverNominalLife))
+        list.add(tr("Technology: %1$", type))
+        list.add(tr("Range: %1$ blocks", (nominalLight * 15).toInt()))
+        list.add(tr("Power: %1\$W", Utils.plotValue(nominalP)))
+        list.add(tr("Resistance: %1$\u2126", Utils.plotValue(r)))
+        list.add(tr("Nominal lifetime: %1\$h", serverNominalLife))
         if (itemStack != null) {
             if (!itemStack.hasTagCompound() || !itemStack.tagCompound.hasKey("life")) {
-                list.add(I18N.tr("Condition:") + " " + I18N.tr("New"))
+                list.add(tr("Condition:") + " " + tr("New"))
             } else if (getLifeInTag(itemStack) > 0.5) {
-                list.add(I18N.tr("Condition:") + " " + I18N.tr("Good"))
+                list.add(tr("Condition:") + " " + tr("Good"))
             } else if (getLifeInTag(itemStack) > 0.2) {
-                list.add(I18N.tr("Condition:") + " " + I18N.tr("Used"))
+                list.add(tr("Condition:") + " " + tr("Used"))
             } else if (getLifeInTag(itemStack) > 0.1) {
-                list.add(I18N.tr("Condition:") + " " + I18N.tr("End of life"))
+                list.add(tr("Condition:") + " " + tr("End of life"))
             } else {
-                list.add(I18N.tr("Condition:") + " " + I18N.tr("Bad"))
+                list.add(tr("Condition:") + " " + tr("Bad"))
             }
             if (Eln.debugEnabled)
                 list.add("Life: ${getLifeInTag(itemStack)}")

--- a/src/main/kotlin/mods/eln/item/electricalitem/BatteryItem.kt
+++ b/src/main/kotlin/mods/eln/item/electricalitem/BatteryItem.kt
@@ -1,7 +1,7 @@
 package mods.eln.item.electricalitem
 
 import mods.eln.generic.GenericItemUsingDamageDescriptor
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.electricalinterface.IItemEnergyBattery
 import mods.eln.misc.Utils
 import mods.eln.misc.UtilsClient
@@ -29,10 +29,10 @@ class BatteryItem(name: String, var energyStorage: Double, var chargePower: Doub
 
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list.add(I18N.tr("Charge power: %1\$W", Utils.plotValue(chargePower)))
-        list.add(I18N.tr("Discharge power: %1\$W", Utils.plotValue(dischargePower)))
+        list.add(tr("Charge power: %1\$W", Utils.plotValue(chargePower)))
+        list.add(tr("Discharge power: %1\$W", Utils.plotValue(dischargePower)))
         if (itemStack != null) {
-            list.add(I18N.tr("Stored energy: %1\$J (%2$%)", Utils.plotValue(getEnergy(itemStack)),
+            list.add(tr("Stored energy: %1\$J (%2$%)", Utils.plotValue(getEnergy(itemStack)),
                 (getEnergy(itemStack) / energyStorage * 100).toInt()))
         }
     }

--- a/src/main/kotlin/mods/eln/item/electricalitem/ElectricalArmor.kt
+++ b/src/main/kotlin/mods/eln/item/electricalitem/ElectricalArmor.kt
@@ -1,7 +1,7 @@
 package mods.eln.item.electricalitem
 
 import mods.eln.generic.genericArmorItem
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.electricalinterface.IItemEnergyBattery
 import mods.eln.misc.Utils
 import mods.eln.wiki.Data
@@ -77,8 +77,8 @@ class ElectricalArmor(
 
     override fun addInformation(itemStack: ItemStack, entityPlayer: EntityPlayer?, list: MutableList<Any?>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list.add(I18N.tr("Charge power: %1\$W", chargePower.toInt()))
-        list.add(I18N.tr("Stored energy: %1\$J (%2$%)", getEnergy(itemStack),
+        list.add(tr("Charge power: %1\$W", chargePower.toInt()))
+        list.add(tr("Stored energy: %1\$J (%2$%)", getEnergy(itemStack),
             (getEnergy(itemStack) / energyStorage * 100).toInt()))
         //list.add("Power button is " + (getPowerOn(itemStack) ? "ON" : "OFF"));
     }

--- a/src/main/kotlin/mods/eln/item/electricalitem/ElectricalLampItem.kt
+++ b/src/main/kotlin/mods/eln/item/electricalitem/ElectricalLampItem.kt
@@ -1,6 +1,6 @@
 package mods.eln.item.electricalitem
 
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.electricalinterface.IItemEnergyBattery
 import mods.eln.misc.Utils
 import mods.eln.misc.UtilsClient
@@ -90,11 +90,11 @@ class ElectricalLampItem(name: String, var lightMin: Int, var rangeMin: Int, dis
 
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list.add(I18N.tr("Discharge power: %1\$W", Utils.plotValue(dischargeMin)))
+        list.add(tr("Discharge power: %1\$W", Utils.plotValue(dischargeMin)))
         if (itemStack != null) {
-            list.add(I18N.tr("Stored Energy: %1\$J (%2$%)", Utils.plotValue(getEnergy(itemStack)),
+            list.add(tr("Stored Energy: %1\$J (%2$%)", Utils.plotValue(getEnergy(itemStack)),
                 (getEnergy(itemStack) / energyStorage * 100).toInt()))
-            list.add(I18N.tr("State:") + " " + if (getLightState(itemStack) != 0) I18N.tr("On") else I18N.tr("Off"))
+            list.add(tr("State:") + " " + if (getLightState(itemStack) != 0) tr("On") else tr("Off"))
         }
     }
 

--- a/src/main/kotlin/mods/eln/item/electricalitem/ElectricalTool.kt
+++ b/src/main/kotlin/mods/eln/item/electricalitem/ElectricalTool.kt
@@ -2,7 +2,7 @@ package mods.eln.item.electricalitem
 
 import mods.eln.Eln
 import mods.eln.generic.GenericItemUsingDamageDescriptor
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.electricalinterface.IItemEnergyBattery
 import mods.eln.misc.Utils
 import mods.eln.misc.UtilsClient
@@ -64,7 +64,7 @@ open class ElectricalTool(name: String, var strengthOn: Float, var strengthOff: 
 
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        if (itemStack != null) list.add(I18N.tr("Stored energy: %1\$J (%2$%)", Utils.plotValue(getEnergy(itemStack)),
+        if (itemStack != null) list.add(tr("Stored energy: %1\$J (%2$%)", Utils.plotValue(getEnergy(itemStack)),
             (getEnergy(itemStack) / energyStorage * 100).toInt()))
     }
 

--- a/src/main/kotlin/mods/eln/item/electricalitem/PortableOreScannerItem.kt
+++ b/src/main/kotlin/mods/eln/item/electricalitem/PortableOreScannerItem.kt
@@ -2,7 +2,7 @@ package mods.eln.item.electricalitem
 
 import mods.eln.Eln
 import mods.eln.generic.GenericItemUsingDamageDescriptor
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.electricalinterface.IItemEnergyBattery
 import mods.eln.misc.Obj3D
 import mods.eln.misc.Obj3D.Obj3DPart
@@ -101,9 +101,9 @@ class PortableOreScannerItem(name: String?, private val obj: Obj3D,
 
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list.add(I18N.tr("Discharge power: %1\$W", Utils.plotValue(dischargePower)))
+        list.add(tr("Discharge power: %1\$W", Utils.plotValue(dischargePower)))
         if (itemStack != null) {
-            list.add(I18N.tr("Stored energy: %1\$J (%2$%)", Utils.plotValue(getEnergy(itemStack)),
+            list.add(tr("Stored energy: %1\$J (%2$%)", Utils.plotValue(getEnergy(itemStack)),
                 (getEnergy(itemStack) / energyStorage * 100).toInt()))
         }
     }

--- a/src/main/kotlin/mods/eln/mechanical/Clutch.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Clutch.kt
@@ -407,10 +407,10 @@ class ClutchElement(node: TransparentNode, desc_: TransparentNodeDescriptor) : S
     override fun getWaila(): MutableMap<String, String> {
         val info = mutableMapOf<String, String>()
         val entries = mapOf(Pair(front.left(), leftShaft), Pair(front.right(), rightShaft)).entries
-        info.put("Speeds", entries.map {
+        info.put(tr("Speeds"), entries.map {
             Utils.plotRads("", it.value.rads)
         }.joinToString(", "))
-        info.put("Energies", entries.map {
+        info.put(tr("Energies"), entries.map {
             Utils.plotEnergy("", it.value.energy)
         }.joinToString(", "))
         if(Eln.wailaEasyMode) {
@@ -422,7 +422,7 @@ class ClutchElement(node: TransparentNode, desc_: TransparentNodeDescriptor) : S
             if (desc != null && stack != null)
                 info.put("Wear", String.format("%.6f", desc.getWear(stack)))
         }
-        info.put("Clutching", Utils.plotVolt(inputGate.signalVoltage))
+        info.put(tr("Clutching"), Utils.plotVolt(inputGate.signalVoltage))
         if(Eln.wailaEasyMode) {
             info.put("Slipping", if (slipping) {
                 "YES"

--- a/src/main/kotlin/mods/eln/mechanical/Clutch.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Clutch.kt
@@ -407,10 +407,10 @@ class ClutchElement(node: TransparentNode, desc_: TransparentNodeDescriptor) : S
     override fun getWaila(): MutableMap<String, String> {
         val info = mutableMapOf<String, String>()
         val entries = mapOf(Pair(front.left(), leftShaft), Pair(front.right(), rightShaft)).entries
-        info.put(tr("Speeds"), entries.map {
+        info.put("Speeds", entries.map {
             Utils.plotRads("", it.value.rads)
         }.joinToString(", "))
-        info.put(tr("Energies"), entries.map {
+        info.put("Energies", entries.map {
             Utils.plotEnergy("", it.value.energy)
         }.joinToString(", "))
         if(Eln.wailaEasyMode) {
@@ -422,7 +422,7 @@ class ClutchElement(node: TransparentNode, desc_: TransparentNodeDescriptor) : S
             if (desc != null && stack != null)
                 info.put("Wear", String.format("%.6f", desc.getWear(stack)))
         }
-        info.put(tr("Clutching"), Utils.plotVolt(inputGate.signalVoltage))
+        info.put("Clutching", Utils.plotVolt(inputGate.signalVoltage))
         if(Eln.wailaEasyMode) {
             info.put("Slipping", if (slipping) {
                 "YES"

--- a/src/main/kotlin/mods/eln/mechanical/CrankableShaft.kt
+++ b/src/main/kotlin/mods/eln/mechanical/CrankableShaft.kt
@@ -1,6 +1,6 @@
 package mods.eln.mechanical
 
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
 import mods.eln.node.transparent.EntityMetaTag
 import mods.eln.node.transparent.TransparentNode
@@ -18,9 +18,9 @@ class CrankableShaftDescriptor(name: String, override val obj: Obj3D, private va
     override val rotating = arrayOf(obj.getPart("Shaft"))
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-        list.add(I18N.tr("Player crankable shaft"))
-        list.add(I18N.tr("Can rotate slowly"))
-        list.add(I18N.tr("Max rads:  %1$",Utils.plotRads("", nominalRads.toDouble())))
+        list.add(tr("Player crankable shaft"))
+        list.add(tr("Can rotate slowly"))
+        list.add(Utils.plotRads(tr("Max rads:  "), nominalRads.toDouble()))
     }
 }
 
@@ -61,8 +61,8 @@ class CrankableShaftElement(node: TransparentNode, desc_: TransparentNodeDescrip
 
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
-        info[I18N.tr("Energy")] = Utils.plotEnergy("", shaft.energy)
-        info[I18N.tr("Speed")] = Utils.plotRads("", shaft.rads)
+        info[tr("Energy")] = Utils.plotEnergy("", shaft.energy)
+        info[tr("Speed")] = Utils.plotRads("", shaft.rads)
         return info
     }
 

--- a/src/main/kotlin/mods/eln/mechanical/CrankableShaft.kt
+++ b/src/main/kotlin/mods/eln/mechanical/CrankableShaft.kt
@@ -1,6 +1,5 @@
 package mods.eln.mechanical
 
-import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.node.transparent.EntityMetaTag
 import mods.eln.node.transparent.TransparentNode
@@ -18,9 +17,9 @@ class CrankableShaftDescriptor(name: String, override val obj: Obj3D, private va
     override val rotating = arrayOf(obj.getPart("Shaft"))
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-        list.add(I18N.tr("Player crankable shaft"))
-        list.add(I18N.tr("Can rotate slowly"))
-        list.add(I18N.tr("Max rads:  %1$",Utils.plotRads("", nominalRads.toDouble())))
+        list.add("Player crankable shaft")
+        list.add("Can rotate slowly")
+        list.add(Utils.plotRads("Max rads:  ", nominalRads.toDouble()))
     }
 }
 
@@ -61,8 +60,8 @@ class CrankableShaftElement(node: TransparentNode, desc_: TransparentNodeDescrip
 
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
-        info[I18N.tr("Energy")] = Utils.plotEnergy("", shaft.energy)
-        info[I18N.tr("Speed")] = Utils.plotRads("", shaft.rads)
+        info["Energy"] = Utils.plotEnergy("", shaft.energy)
+        info["Speed"] = Utils.plotRads("", shaft.rads)
         return info
     }
 

--- a/src/main/kotlin/mods/eln/mechanical/CrankableShaft.kt
+++ b/src/main/kotlin/mods/eln/mechanical/CrankableShaft.kt
@@ -1,5 +1,6 @@
 package mods.eln.mechanical
 
+import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.node.transparent.EntityMetaTag
 import mods.eln.node.transparent.TransparentNode
@@ -17,9 +18,9 @@ class CrankableShaftDescriptor(name: String, override val obj: Obj3D, private va
     override val rotating = arrayOf(obj.getPart("Shaft"))
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-        list.add("Player crankable shaft")
-        list.add("Can rotate slowly")
-        list.add(Utils.plotRads("Max rads:  ", nominalRads.toDouble()))
+        list.add(I18N.tr("Player crankable shaft"))
+        list.add(I18N.tr("Can rotate slowly"))
+        list.add(I18N.tr("Max rads:  %1$",Utils.plotRads("", nominalRads.toDouble())))
     }
 }
 
@@ -60,8 +61,8 @@ class CrankableShaftElement(node: TransparentNode, desc_: TransparentNodeDescrip
 
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
-        info["Energy"] = Utils.plotEnergy("", shaft.energy)
-        info["Speed"] = Utils.plotRads("", shaft.rads)
+        info[I18N.tr("Energy")] = Utils.plotEnergy("", shaft.energy)
+        info[I18N.tr("Speed")] = Utils.plotRads("", shaft.rads)
         return info
     }
 

--- a/src/main/kotlin/mods/eln/mechanical/Flywheel.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Flywheel.kt
@@ -1,6 +1,7 @@
 package mods.eln.mechanical
 
 import mods.eln.Eln
+import mods.eln.i18n.I18N
 import mods.eln.misc.Direction
 import mods.eln.misc.LinearFunction
 import mods.eln.misc.Obj3D
@@ -97,8 +98,8 @@ class FlyWheelElement(node: TransparentNode, desc_: TransparentNodeDescriptor) :
 
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
-        info.put("Speed", Utils.plotRads("", shaft.rads))
-        info.put("Energy", Utils.plotEnergy("", shaft.energy))
+        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
+        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
         return info
     }
 }

--- a/src/main/kotlin/mods/eln/mechanical/Flywheel.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Flywheel.kt
@@ -1,7 +1,7 @@
 package mods.eln.mechanical
 
 import mods.eln.Eln
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Direction
 import mods.eln.misc.LinearFunction
 import mods.eln.misc.Obj3D
@@ -98,8 +98,8 @@ class FlyWheelElement(node: TransparentNode, desc_: TransparentNodeDescriptor) :
 
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
-        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
-        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
+        info.put(tr("Speed"), Utils.plotRads("", shaft.rads))
+        info.put(tr("Energy"), Utils.plotEnergy("", shaft.energy))
         return info
     }
 }

--- a/src/main/kotlin/mods/eln/mechanical/Flywheel.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Flywheel.kt
@@ -1,7 +1,6 @@
 package mods.eln.mechanical
 
 import mods.eln.Eln
-import mods.eln.i18n.I18N
 import mods.eln.misc.Direction
 import mods.eln.misc.LinearFunction
 import mods.eln.misc.Obj3D
@@ -98,8 +97,8 @@ class FlyWheelElement(node: TransparentNode, desc_: TransparentNodeDescriptor) :
 
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
-        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
-        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
+        info.put("Speed", Utils.plotRads("", shaft.rads))
+        info.put("Energy", Utils.plotEnergy("", shaft.energy))
         return info
     }
 }

--- a/src/main/kotlin/mods/eln/mechanical/Generator.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Generator.kt
@@ -2,6 +2,7 @@ package mods.eln.mechanical
 
 import mods.eln.Eln
 import mods.eln.cable.CableRenderDescriptor
+import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.EntityMetaTag
@@ -72,13 +73,12 @@ class GeneratorDescriptor(
     ).requireNoNulls()
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-        list.add("Converts mechanical energy into ")
-        list.add("electricity, or (badly) vice versa.")
-        list.add("Nominal usage ->")
-        list.add(Utils.plotVolt("  Voltage out: ", nominalU.toDouble()))
-        list.add(Utils.plotPower("  Power out: ", nominalP.toDouble()))
-        list.add(Utils.plotRads("  Rads: ", nominalRads.toDouble()))
-        list.add(Utils.plotRads("Max rads:  ", absoluteMaximumShaftSpeed))
+        list.add(I18N.tr("Converts mechanical energy into electricity, or (badly) vice versa."))
+        list.add(I18N.tr("Nominal usage ->"))
+        list.add("  "+I18N.tr("Voltage out: %1$",Utils.plotVolt("", nominalU.toDouble())))
+        list.add("  "+I18N.tr("Power out: %1$",Utils.plotPower("", nominalP.toDouble())))
+        list.add("  "+I18N.tr("Rads: %1$",Utils.plotRads("", nominalRads.toDouble())))
+        list.add(I18N.tr("Max rads:  %1$",Utils.plotRads("", absoluteMaximumShaftSpeed)))
     }
 }
 
@@ -285,12 +285,12 @@ class GeneratorElement(node: TransparentNode, desc_: TransparentNodeDescriptor) 
 
     override fun getWaila(): Map<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put("Energy", Utils.plotEnergy("", shaft.energy))
-        info.put("Speed", Utils.plotRads("", shaft.rads))
+        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
+        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
         if (Eln.wailaEasyMode) {
-            info.put("Voltage", Utils.plotVolt("", electricalPowerSource.getVoltage()))
-            info.put("Current", Utils.plotAmpere("", electricalPowerSource.getCurrent()))
-            info.put("Temperature", Utils.plotCelsius("", thermal.temperature))
+            info.put(I18N.tr("Voltage"), Utils.plotVolt("", electricalPowerSource.getVoltage()))
+            info.put(I18N.tr("Current"), Utils.plotAmpere("", electricalPowerSource.getCurrent()))
+            info.put(I18N.tr("Temperature"), Utils.plotCelsius("", thermal.temperature))
         }
         return info
     }

--- a/src/main/kotlin/mods/eln/mechanical/Generator.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Generator.kt
@@ -2,7 +2,6 @@ package mods.eln.mechanical
 
 import mods.eln.Eln
 import mods.eln.cable.CableRenderDescriptor
-import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.EntityMetaTag
@@ -73,12 +72,13 @@ class GeneratorDescriptor(
     ).requireNoNulls()
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-        list.add(I18N.tr("Converts mechanical energy into electricity, or (badly) vice versa."))
-        list.add(I18N.tr("Nominal usage ->"))
-        list.add("  "+I18N.tr("Voltage out: %1$",Utils.plotVolt("", nominalU.toDouble())))
-        list.add("  "+I18N.tr("Power out: %1$",Utils.plotPower("", nominalP.toDouble())))
-        list.add("  "+I18N.tr("Rads: %1$",Utils.plotRads("", nominalRads.toDouble())))
-        list.add(I18N.tr("Max rads:  %1$",Utils.plotRads("", absoluteMaximumShaftSpeed)))
+        list.add("Converts mechanical energy into ")
+        list.add("electricity, or (badly) vice versa.")
+        list.add("Nominal usage ->")
+        list.add(Utils.plotVolt("  Voltage out: ", nominalU.toDouble()))
+        list.add(Utils.plotPower("  Power out: ", nominalP.toDouble()))
+        list.add(Utils.plotRads("  Rads: ", nominalRads.toDouble()))
+        list.add(Utils.plotRads("Max rads:  ", absoluteMaximumShaftSpeed))
     }
 }
 
@@ -285,12 +285,12 @@ class GeneratorElement(node: TransparentNode, desc_: TransparentNodeDescriptor) 
 
     override fun getWaila(): Map<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
-        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
+        info.put("Energy", Utils.plotEnergy("", shaft.energy))
+        info.put("Speed", Utils.plotRads("", shaft.rads))
         if (Eln.wailaEasyMode) {
-            info.put(I18N.tr("Voltage"), Utils.plotVolt("", electricalPowerSource.getVoltage()))
-            info.put(I18N.tr("Current"), Utils.plotAmpere("", electricalPowerSource.getCurrent()))
-            info.put(I18N.tr("Temperature"), Utils.plotCelsius("", thermal.temperature))
+            info.put("Voltage", Utils.plotVolt("", electricalPowerSource.getVoltage()))
+            info.put("Current", Utils.plotAmpere("", electricalPowerSource.getCurrent()))
+            info.put("Temperature", Utils.plotCelsius("", thermal.temperature))
         }
         return info
     }

--- a/src/main/kotlin/mods/eln/mechanical/Generator.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Generator.kt
@@ -2,7 +2,7 @@ package mods.eln.mechanical
 
 import mods.eln.Eln
 import mods.eln.cable.CableRenderDescriptor
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.EntityMetaTag
@@ -73,12 +73,12 @@ class GeneratorDescriptor(
     ).requireNoNulls()
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-        list.add(I18N.tr("Converts mechanical energy into electricity, or (badly) vice versa."))
-        list.add(I18N.tr("Nominal usage ->"))
-        list.add("  "+I18N.tr("Voltage out: %1$",Utils.plotVolt("", nominalU.toDouble())))
-        list.add("  "+I18N.tr("Power out: %1$",Utils.plotPower("", nominalP.toDouble())))
-        list.add("  "+I18N.tr("Rads: %1$",Utils.plotRads("", nominalRads.toDouble())))
-        list.add(I18N.tr("Max rads:  %1$",Utils.plotRads("", absoluteMaximumShaftSpeed)))
+        list.add(tr("Converts mechanical energy into electricity, or (badly) vice versa."))
+        list.add(tr("Nominal usage ->"))
+        list.add(Utils.plotVolt(tr("  Voltage out: "), nominalU.toDouble()))
+        list.add(Utils.plotPower(tr("  Power out: "), nominalP.toDouble()))
+        list.add(Utils.plotRads(tr("  Rads: "), nominalRads.toDouble()))
+        list.add(Utils.plotRads(tr("Max rads:  "), absoluteMaximumShaftSpeed))
     }
 }
 
@@ -285,12 +285,12 @@ class GeneratorElement(node: TransparentNode, desc_: TransparentNodeDescriptor) 
 
     override fun getWaila(): Map<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
-        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
+        info.put(tr("Energy"), Utils.plotEnergy("", shaft.energy))
+        info.put(tr("Speed"), Utils.plotRads("", shaft.rads))
         if (Eln.wailaEasyMode) {
-            info.put(I18N.tr("Voltage"), Utils.plotVolt("", electricalPowerSource.getVoltage()))
-            info.put(I18N.tr("Current"), Utils.plotAmpere("", electricalPowerSource.getCurrent()))
-            info.put(I18N.tr("Temperature"), Utils.plotCelsius("", thermal.temperature))
+            info.put(tr("Voltage"), Utils.plotVolt("", electricalPowerSource.getVoltage()))
+            info.put(tr("Current"), Utils.plotAmpere("", electricalPowerSource.getCurrent()))
+            info.put(tr("Temperature"), Utils.plotCelsius("", thermal.temperature))
         }
         return info
     }

--- a/src/main/kotlin/mods/eln/mechanical/JointHub.kt
+++ b/src/main/kotlin/mods/eln/mechanical/JointHub.kt
@@ -1,6 +1,7 @@
 package mods.eln.mechanical
 
 import mods.eln.cable.CableRenderDescriptor
+import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.node.transparent.EntityMetaTag
 import mods.eln.node.transparent.TransparentNode
@@ -95,8 +96,8 @@ class JointHubElement(node: TransparentNode, desc_: TransparentNodeDescriptor) :
 
     override fun getWaila(): Map<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put("Speed", Utils.plotRads("", shaft.rads))
-        info.put("Energy", Utils.plotEnergy("", shaft.energy))
+        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
+        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
         return info
     }
 

--- a/src/main/kotlin/mods/eln/mechanical/JointHub.kt
+++ b/src/main/kotlin/mods/eln/mechanical/JointHub.kt
@@ -1,7 +1,6 @@
 package mods.eln.mechanical
 
 import mods.eln.cable.CableRenderDescriptor
-import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.node.transparent.EntityMetaTag
 import mods.eln.node.transparent.TransparentNode
@@ -96,8 +95,8 @@ class JointHubElement(node: TransparentNode, desc_: TransparentNodeDescriptor) :
 
     override fun getWaila(): Map<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
-        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
+        info.put("Speed", Utils.plotRads("", shaft.rads))
+        info.put("Energy", Utils.plotEnergy("", shaft.energy))
         return info
     }
 

--- a/src/main/kotlin/mods/eln/mechanical/JointHub.kt
+++ b/src/main/kotlin/mods/eln/mechanical/JointHub.kt
@@ -1,7 +1,7 @@
 package mods.eln.mechanical
 
 import mods.eln.cable.CableRenderDescriptor
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
 import mods.eln.node.transparent.EntityMetaTag
 import mods.eln.node.transparent.TransparentNode
@@ -96,8 +96,8 @@ class JointHubElement(node: TransparentNode, desc_: TransparentNodeDescriptor) :
 
     override fun getWaila(): Map<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
-        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
+        info.put(tr("Speed"), Utils.plotRads("", shaft.rads))
+        info.put(tr("Energy"), Utils.plotEnergy("", shaft.energy))
         return info
     }
 

--- a/src/main/kotlin/mods/eln/mechanical/Motor.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Motor.kt
@@ -2,7 +2,6 @@ package mods.eln.mechanical
 
 import mods.eln.Eln
 import mods.eln.cable.CableRenderDescriptor
-import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.EntityMetaTag
@@ -82,12 +81,12 @@ class MotorDescriptor(
     }
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-        list.add(I18N.tr("Converts electricity into mechanical energy, or (badly) vice versa."))
-        list.add(I18N.tr("Nominal usage ->"))
-        list.add("  "+I18N.tr("Voltage in: %1$",Utils.plotVolt("", nominalU.toDouble())))
-        list.add("  "+I18N.tr("Power in: %1$",Utils.plotPower("", nominalP.toDouble())))
-        list.add("  "+I18N.tr("rad/s: %1$",Utils.plotRads("", nominalRads.toDouble())))
-        list.add(I18N.tr("Max rad/s: %1$",Utils.plotRads("", absoluteMaximumShaftSpeed)))
+        list.add("Converts electricity into mechanical energy, or (badly) vice versa.")
+        list.add("Nominal usage ->")
+        list.add(Utils.plotVolt("  Voltage in: ", nominalU.toDouble()))
+        list.add(Utils.plotPower("  Power in: ", nominalP.toDouble()))
+        list.add(Utils.plotRads("  rad/s: ", nominalRads.toDouble()))
+        list.add(Utils.plotRads("Max rad/s: ", absoluteMaximumShaftSpeed))
     }
 }
 
@@ -306,12 +305,12 @@ class MotorElement(node: TransparentNode, desc_: TransparentNodeDescriptor) :
 
     override fun getWaila(): MutableMap<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
-        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
+        info.put("Energy", Utils.plotEnergy("", shaft.energy))
+        info.put("Speed", Utils.plotRads("", shaft.rads))
         if(Eln.wailaEasyMode) {
-            info.put(I18N.tr("Voltage"), Utils.plotVolt("", powerSource.voltage))
-            info.put(I18N.tr("Current"), Utils.plotAmpere("", powerSource.current))
-            info.put(I18N.tr("Temperature"), Utils.plotCelsius("", thermal.temperature))
+            info.put("Voltage", Utils.plotVolt("", powerSource.voltage))
+            info.put("Current", Utils.plotAmpere("", powerSource.current))
+            info.put("Temperature", Utils.plotCelsius("", thermal.temperature))
         }
         return info
     }

--- a/src/main/kotlin/mods/eln/mechanical/Motor.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Motor.kt
@@ -2,6 +2,7 @@ package mods.eln.mechanical
 
 import mods.eln.Eln
 import mods.eln.cable.CableRenderDescriptor
+import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.EntityMetaTag
@@ -81,12 +82,12 @@ class MotorDescriptor(
     }
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-        list.add("Converts electricity into mechanical energy, or (badly) vice versa.")
-        list.add("Nominal usage ->")
-        list.add(Utils.plotVolt("  Voltage in: ", nominalU.toDouble()))
-        list.add(Utils.plotPower("  Power in: ", nominalP.toDouble()))
-        list.add(Utils.plotRads("  rad/s: ", nominalRads.toDouble()))
-        list.add(Utils.plotRads("Max rad/s: ", absoluteMaximumShaftSpeed))
+        list.add(I18N.tr("Converts electricity into mechanical energy, or (badly) vice versa."))
+        list.add(I18N.tr("Nominal usage ->"))
+        list.add("  "+I18N.tr("Voltage in: %1$",Utils.plotVolt("", nominalU.toDouble())))
+        list.add("  "+I18N.tr("Power in: %1$",Utils.plotPower("", nominalP.toDouble())))
+        list.add("  "+I18N.tr("rad/s: %1$",Utils.plotRads("", nominalRads.toDouble())))
+        list.add(I18N.tr("Max rad/s: %1$",Utils.plotRads("", absoluteMaximumShaftSpeed)))
     }
 }
 
@@ -305,12 +306,12 @@ class MotorElement(node: TransparentNode, desc_: TransparentNodeDescriptor) :
 
     override fun getWaila(): MutableMap<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put("Energy", Utils.plotEnergy("", shaft.energy))
-        info.put("Speed", Utils.plotRads("", shaft.rads))
+        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
+        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
         if(Eln.wailaEasyMode) {
-            info.put("Voltage", Utils.plotVolt("", powerSource.voltage))
-            info.put("Current", Utils.plotAmpere("", powerSource.current))
-            info.put("Temperature", Utils.plotCelsius("", thermal.temperature))
+            info.put(I18N.tr("Voltage"), Utils.plotVolt("", powerSource.voltage))
+            info.put(I18N.tr("Current"), Utils.plotAmpere("", powerSource.current))
+            info.put(I18N.tr("Temperature"), Utils.plotCelsius("", thermal.temperature))
         }
         return info
     }

--- a/src/main/kotlin/mods/eln/mechanical/Motor.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Motor.kt
@@ -2,7 +2,7 @@ package mods.eln.mechanical
 
 import mods.eln.Eln
 import mods.eln.cable.CableRenderDescriptor
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.EntityMetaTag
@@ -82,12 +82,12 @@ class MotorDescriptor(
     }
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-        list.add(I18N.tr("Converts electricity into mechanical energy, or (badly) vice versa."))
-        list.add(I18N.tr("Nominal usage ->"))
-        list.add("  "+I18N.tr("Voltage in: %1$",Utils.plotVolt("", nominalU.toDouble())))
-        list.add("  "+I18N.tr("Power in: %1$",Utils.plotPower("", nominalP.toDouble())))
-        list.add("  "+I18N.tr("rad/s: %1$",Utils.plotRads("", nominalRads.toDouble())))
-        list.add(I18N.tr("Max rad/s: %1$",Utils.plotRads("", absoluteMaximumShaftSpeed)))
+        list.add(tr("Converts electricity into mechanical energy, or (badly) vice versa."))
+        list.add(tr("Nominal usage ->"))
+        list.add(Utils.plotVolt(tr("  Voltage in: "), nominalU.toDouble()))
+        list.add(Utils.plotPower(tr("  Power in: "), nominalP.toDouble()))
+        list.add(Utils.plotRads(tr("  rad/s: "), nominalRads.toDouble()))
+        list.add(Utils.plotRads(tr("Max rad/s: "), absoluteMaximumShaftSpeed))
     }
 }
 
@@ -306,12 +306,12 @@ class MotorElement(node: TransparentNode, desc_: TransparentNodeDescriptor) :
 
     override fun getWaila(): MutableMap<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
-        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
+        info.put(tr("Energy"), Utils.plotEnergy("", shaft.energy))
+        info.put(tr("Speed"), Utils.plotRads("", shaft.rads))
         if(Eln.wailaEasyMode) {
-            info.put(I18N.tr("Voltage"), Utils.plotVolt("", powerSource.voltage))
-            info.put(I18N.tr("Current"), Utils.plotAmpere("", powerSource.current))
-            info.put(I18N.tr("Temperature"), Utils.plotCelsius("", thermal.temperature))
+            info.put(tr("Voltage"), Utils.plotVolt("", powerSource.voltage))
+            info.put(tr("Current"), Utils.plotAmpere("", powerSource.current))
+            info.put(tr("Temperature"), Utils.plotCelsius("", thermal.temperature))
         }
         return info
     }

--- a/src/main/kotlin/mods/eln/mechanical/RadialMotor.kt
+++ b/src/main/kotlin/mods/eln/mechanical/RadialMotor.kt
@@ -3,7 +3,7 @@ package mods.eln.mechanical
 import mods.eln.Eln
 import mods.eln.fluid.FuelRegistry
 import mods.eln.fluid.PreciseElementFluidHandler
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Direction
 import mods.eln.misc.INBTTReady
@@ -71,31 +71,19 @@ class RadialMotorDescriptor(baseName: String, obj: Obj3D) :
     override val obj: Obj3D = obj
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-//        list.add("Converts $fluidDescription into mechanical energy.")
-//        list.add("Nominal usage ->")
-//        list.add("  ${fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }} input: $fluidConsumption mB/s")
-//        if (power.isEmpty()) {
-//            list.add("  No valid fluids for this turbine!")
-//        } else if (power.size == 1) {
-//            list.add(Utils.plotPower("  Power out: ", power[0]))
-//        } else {
-//            list.add("  Power out: ${Utils.plotPower(minFluidPower  * GAS_GUZZLER_CONSTANT)}- ${Utils.plotPower(maxFluidPower * GAS_GUZZLER_CONSTANT)}")
-//        }
-//        list.add(Utils.plotRads("  Optimal rads: ", optimalRads))
-//        list.add(Utils.plotRads("Max rads:  ", absoluteMaximumShaftSpeed))
-
-        list.add(I18N.tr("Converts %1$ into mechanical energy.",fluidDescription))
-        list.add(I18N.tr("Nominal usage ->"))
-        list.add("  "+ I18N.tr("%1$ input: %2$ mB/s",fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },fluidConsumption))
+        list.add(tr("Converts %1$ into mechanical energy.",fluidDescription))
+        list.add(tr("Nominal usage ->"))
+        list.add("  "+ tr("%1$ input: %2$ mB/s",fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },fluidConsumption))
         if (power.isEmpty()) {
-            list.add("  "+ I18N.tr("No valid fluids for this turbine!"))
+            list.add("  "+ tr("No valid fluids for this turbine!"))
         } else if (power.size == 1) {
-            list.add("  "+ I18N.tr("Power out: %1$",Utils.plotPower(power[0])))
+            list.add(Utils.plotPower(tr("  Power out: "),power[0]))
+
         } else {
-            list.add("  "+ I18N.tr("Power out: %1$- %2$",Utils.plotPower(minFluidPower  * GAS_GUZZLER_CONSTANT),Utils.plotPower(maxFluidPower * GAS_GUZZLER_CONSTANT)))
+            list.add("  "+ tr("Power out: %1$- %2$",Utils.plotPower(minFluidPower  * GAS_GUZZLER_CONSTANT),Utils.plotPower(maxFluidPower * GAS_GUZZLER_CONSTANT)))
         }
-        list.add("  "+ I18N.tr("Optimal rads: %1$",Utils.plotRads("", optimalRads)))
-        list.add(I18N.tr("Max rads:  %1$",Utils.plotRads("",absoluteMaximumShaftSpeed)))
+        list.add(Utils.plotRads(tr("  Optimal rads: "), optimalRads))
+        list.add(Utils.plotRads(tr("Max rads:  "),absoluteMaximumShaftSpeed))
     }
 }
 
@@ -183,11 +171,11 @@ class RadialMotorElement(node: TransparentNode, transparentNodeDescriptor: Trans
 
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
-        info[I18N.tr("Speed")] = Utils.plotRads("", shaft.rads)
-        info[I18N.tr("Energy")] = Utils.plotEnergy("", shaft.energy)
+        info[tr("Speed")] = Utils.plotRads("", shaft.rads)
+        info[tr("Energy")] = Utils.plotEnergy("", shaft.energy)
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Efficiency")] = Utils.plotPercent("", efficiency.toDouble())
-            info[I18N.tr("Fuel usage")] = Utils.plotBuckets("", fluidRate / 1000.0) + "/s"
+            info[tr("Efficiency")] = Utils.plotPercent("", efficiency.toDouble())
+            info[tr("Fuel usage")] = Utils.plotBuckets("", fluidRate / 1000.0) + "/s"
         }
         return info
     }

--- a/src/main/kotlin/mods/eln/mechanical/RadialMotor.kt
+++ b/src/main/kotlin/mods/eln/mechanical/RadialMotor.kt
@@ -3,6 +3,7 @@ package mods.eln.mechanical
 import mods.eln.Eln
 import mods.eln.fluid.FuelRegistry
 import mods.eln.fluid.PreciseElementFluidHandler
+import mods.eln.i18n.I18N
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Direction
 import mods.eln.misc.INBTTReady
@@ -70,18 +71,31 @@ class RadialMotorDescriptor(baseName: String, obj: Obj3D) :
     override val obj: Obj3D = obj
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-        list.add("Converts $fluidDescription into mechanical energy.")
-        list.add("Nominal usage ->")
-        list.add("  ${fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }} input: $fluidConsumption mB/s")
+//        list.add("Converts $fluidDescription into mechanical energy.")
+//        list.add("Nominal usage ->")
+//        list.add("  ${fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }} input: $fluidConsumption mB/s")
+//        if (power.isEmpty()) {
+//            list.add("  No valid fluids for this turbine!")
+//        } else if (power.size == 1) {
+//            list.add(Utils.plotPower("  Power out: ", power[0]))
+//        } else {
+//            list.add("  Power out: ${Utils.plotPower(minFluidPower  * GAS_GUZZLER_CONSTANT)}- ${Utils.plotPower(maxFluidPower * GAS_GUZZLER_CONSTANT)}")
+//        }
+//        list.add(Utils.plotRads("  Optimal rads: ", optimalRads))
+//        list.add(Utils.plotRads("Max rads:  ", absoluteMaximumShaftSpeed))
+
+        list.add(I18N.tr("Converts %1$ into mechanical energy.",fluidDescription))
+        list.add(I18N.tr("Nominal usage ->"))
+        list.add("  "+ I18N.tr("%1$ input: %2$ mB/s",fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },fluidConsumption))
         if (power.isEmpty()) {
-            list.add("  No valid fluids for this turbine!")
+            list.add("  "+ I18N.tr("No valid fluids for this turbine!"))
         } else if (power.size == 1) {
-            list.add(Utils.plotPower("  Power out: ", power[0]))
+            list.add("  "+ I18N.tr("Power out: %1$",Utils.plotPower(power[0])))
         } else {
-            list.add("  Power out: ${Utils.plotPower(minFluidPower  * GAS_GUZZLER_CONSTANT)}- ${Utils.plotPower(maxFluidPower * GAS_GUZZLER_CONSTANT)}")
+            list.add("  "+ I18N.tr("Power out: %1$- %2$",Utils.plotPower(minFluidPower  * GAS_GUZZLER_CONSTANT),Utils.plotPower(maxFluidPower * GAS_GUZZLER_CONSTANT)))
         }
-        list.add(Utils.plotRads("  Optimal rads: ", optimalRads))
-        list.add(Utils.plotRads("Max rads:  ", absoluteMaximumShaftSpeed))
+        list.add("  "+ I18N.tr("Optimal rads: %1$",Utils.plotRads("", optimalRads)))
+        list.add(I18N.tr("Max rads:  %1$",Utils.plotRads("",absoluteMaximumShaftSpeed)))
     }
 }
 
@@ -169,11 +183,11 @@ class RadialMotorElement(node: TransparentNode, transparentNodeDescriptor: Trans
 
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
-        info["Speed"] = Utils.plotRads("", shaft.rads)
-        info["Energy"] = Utils.plotEnergy("", shaft.energy)
+        info[I18N.tr("Speed")] = Utils.plotRads("", shaft.rads)
+        info[I18N.tr("Energy")] = Utils.plotEnergy("", shaft.energy)
         if (Eln.wailaEasyMode) {
-            info["Efficiency"] = Utils.plotPercent("", efficiency.toDouble())
-            info["Fuel usage"] = Utils.plotBuckets("", fluidRate / 1000.0) + "/s"
+            info[I18N.tr("Efficiency")] = Utils.plotPercent("", efficiency.toDouble())
+            info[I18N.tr("Fuel usage")] = Utils.plotBuckets("", fluidRate / 1000.0) + "/s"
         }
         return info
     }

--- a/src/main/kotlin/mods/eln/mechanical/RadialMotor.kt
+++ b/src/main/kotlin/mods/eln/mechanical/RadialMotor.kt
@@ -3,7 +3,6 @@ package mods.eln.mechanical
 import mods.eln.Eln
 import mods.eln.fluid.FuelRegistry
 import mods.eln.fluid.PreciseElementFluidHandler
-import mods.eln.i18n.I18N
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Direction
 import mods.eln.misc.INBTTReady
@@ -71,31 +70,18 @@ class RadialMotorDescriptor(baseName: String, obj: Obj3D) :
     override val obj: Obj3D = obj
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-//        list.add("Converts $fluidDescription into mechanical energy.")
-//        list.add("Nominal usage ->")
-//        list.add("  ${fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }} input: $fluidConsumption mB/s")
-//        if (power.isEmpty()) {
-//            list.add("  No valid fluids for this turbine!")
-//        } else if (power.size == 1) {
-//            list.add(Utils.plotPower("  Power out: ", power[0]))
-//        } else {
-//            list.add("  Power out: ${Utils.plotPower(minFluidPower  * GAS_GUZZLER_CONSTANT)}- ${Utils.plotPower(maxFluidPower * GAS_GUZZLER_CONSTANT)}")
-//        }
-//        list.add(Utils.plotRads("  Optimal rads: ", optimalRads))
-//        list.add(Utils.plotRads("Max rads:  ", absoluteMaximumShaftSpeed))
-
-        list.add(I18N.tr("Converts %1$ into mechanical energy.",fluidDescription))
-        list.add(I18N.tr("Nominal usage ->"))
-        list.add("  "+ I18N.tr("%1$ input: %2$ mB/s",fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },fluidConsumption))
+        list.add("Converts $fluidDescription into mechanical energy.")
+        list.add("Nominal usage ->")
+        list.add("  ${fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }} input: $fluidConsumption mB/s")
         if (power.isEmpty()) {
-            list.add("  "+ I18N.tr("No valid fluids for this turbine!"))
+            list.add("  No valid fluids for this turbine!")
         } else if (power.size == 1) {
-            list.add("  "+ I18N.tr("Power out: %1$",Utils.plotPower(power[0])))
+            list.add(Utils.plotPower("  Power out: ", power[0]))
         } else {
-            list.add("  "+ I18N.tr("Power out: %1$- %2$",Utils.plotPower(minFluidPower  * GAS_GUZZLER_CONSTANT),Utils.plotPower(maxFluidPower * GAS_GUZZLER_CONSTANT)))
+            list.add("  Power out: ${Utils.plotPower(minFluidPower  * GAS_GUZZLER_CONSTANT)}- ${Utils.plotPower(maxFluidPower * GAS_GUZZLER_CONSTANT)}")
         }
-        list.add("  "+ I18N.tr("Optimal rads: %1$",Utils.plotRads("", optimalRads)))
-        list.add(I18N.tr("Max rads:  %1$",Utils.plotRads("",absoluteMaximumShaftSpeed)))
+        list.add(Utils.plotRads("  Optimal rads: ", optimalRads))
+        list.add(Utils.plotRads("Max rads:  ", absoluteMaximumShaftSpeed))
     }
 }
 
@@ -183,11 +169,11 @@ class RadialMotorElement(node: TransparentNode, transparentNodeDescriptor: Trans
 
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
-        info[I18N.tr("Speed")] = Utils.plotRads("", shaft.rads)
-        info[I18N.tr("Energy")] = Utils.plotEnergy("", shaft.energy)
+        info["Speed"] = Utils.plotRads("", shaft.rads)
+        info["Energy"] = Utils.plotEnergy("", shaft.energy)
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Efficiency")] = Utils.plotPercent("", efficiency.toDouble())
-            info[I18N.tr("Fuel usage")] = Utils.plotBuckets("", fluidRate / 1000.0) + "/s"
+            info["Efficiency"] = Utils.plotPercent("", efficiency.toDouble())
+            info["Fuel usage"] = Utils.plotBuckets("", fluidRate / 1000.0) + "/s"
         }
         return info
     }

--- a/src/main/kotlin/mods/eln/mechanical/RollingShaftMachine.kt
+++ b/src/main/kotlin/mods/eln/mechanical/RollingShaftMachine.kt
@@ -5,6 +5,7 @@ import mods.eln.gui.GuiContainerEln
 import mods.eln.gui.HelperStdContainer
 import mods.eln.gui.ISlotSkin.SlotSkin
 import mods.eln.gui.SlotWithSkinAndComment
+import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.misc.Direction.Companion.fromIntMinecraftSide
 import mods.eln.node.transparent.*
@@ -58,10 +59,10 @@ class RollingShaftMachineElement(node: TransparentNode, desc: TransparentNodeDes
 
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
-        info["Energy"] = Utils.plotEnergy("", shaft.energy)
-        info["Speed"] = Utils.plotRads("", shaft.rads)
-        info["Process State"] = Utils.plotPercent("", operationalProcess.getProcessState())
-        info["Can Process"] = if (operationalProcess.canSmelt()) "Yes" else "No"
+        info[I18N.tr("Energy")] = Utils.plotEnergy("", shaft.energy)
+        info[I18N.tr("Speed")] = Utils.plotRads("", shaft.rads)
+        info[I18N.tr("Process State")] = Utils.plotPercent("", operationalProcess.getProcessState())
+        info[I18N.tr("Can Process")] = if (operationalProcess.canSmelt()) "Yes" else "No"
         return info
     }
 

--- a/src/main/kotlin/mods/eln/mechanical/RollingShaftMachine.kt
+++ b/src/main/kotlin/mods/eln/mechanical/RollingShaftMachine.kt
@@ -5,7 +5,7 @@ import mods.eln.gui.GuiContainerEln
 import mods.eln.gui.HelperStdContainer
 import mods.eln.gui.ISlotSkin.SlotSkin
 import mods.eln.gui.SlotWithSkinAndComment
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
 import mods.eln.misc.Direction.Companion.fromIntMinecraftSide
 import mods.eln.node.transparent.*
@@ -59,10 +59,10 @@ class RollingShaftMachineElement(node: TransparentNode, desc: TransparentNodeDes
 
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
-        info[I18N.tr("Energy")] = Utils.plotEnergy("", shaft.energy)
-        info[I18N.tr("Speed")] = Utils.plotRads("", shaft.rads)
-        info[I18N.tr("Process State")] = Utils.plotPercent("", operationalProcess.getProcessState())
-        info[I18N.tr("Can Process")] = if (operationalProcess.canSmelt()) "Yes" else "No"
+        info[tr("Energy")] = Utils.plotEnergy("", shaft.energy)
+        info[tr("Speed")] = Utils.plotRads("", shaft.rads)
+        info[tr("Process State")] = Utils.plotPercent("", operationalProcess.getProcessState())
+        info[tr("Can Process")] = if (operationalProcess.canSmelt()) "Yes" else "No"
         return info
     }
 

--- a/src/main/kotlin/mods/eln/mechanical/RollingShaftMachine.kt
+++ b/src/main/kotlin/mods/eln/mechanical/RollingShaftMachine.kt
@@ -5,7 +5,6 @@ import mods.eln.gui.GuiContainerEln
 import mods.eln.gui.HelperStdContainer
 import mods.eln.gui.ISlotSkin.SlotSkin
 import mods.eln.gui.SlotWithSkinAndComment
-import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.misc.Direction.Companion.fromIntMinecraftSide
 import mods.eln.node.transparent.*
@@ -59,10 +58,10 @@ class RollingShaftMachineElement(node: TransparentNode, desc: TransparentNodeDes
 
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
-        info[I18N.tr("Energy")] = Utils.plotEnergy("", shaft.energy)
-        info[I18N.tr("Speed")] = Utils.plotRads("", shaft.rads)
-        info[I18N.tr("Process State")] = Utils.plotPercent("", operationalProcess.getProcessState())
-        info[I18N.tr("Can Process")] = if (operationalProcess.canSmelt()) "Yes" else "No"
+        info["Energy"] = Utils.plotEnergy("", shaft.energy)
+        info["Speed"] = Utils.plotRads("", shaft.rads)
+        info["Process State"] = Utils.plotPercent("", operationalProcess.getProcessState())
+        info["Can Process"] = if (operationalProcess.canSmelt()) "Yes" else "No"
         return info
     }
 

--- a/src/main/kotlin/mods/eln/mechanical/StraightJoint.kt
+++ b/src/main/kotlin/mods/eln/mechanical/StraightJoint.kt
@@ -1,5 +1,6 @@
 package mods.eln.mechanical
 
+import mods.eln.i18n.I18N
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
@@ -24,8 +25,8 @@ open class StraightJointElement(node: TransparentNode, desc_: TransparentNodeDes
 
     override fun getWaila(): Map<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put("Speed", Utils.plotRads("", shaft.rads))
-        info.put("Energy", Utils.plotEnergy("", shaft.energy))
+        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
+        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
         return info
     }
 

--- a/src/main/kotlin/mods/eln/mechanical/StraightJoint.kt
+++ b/src/main/kotlin/mods/eln/mechanical/StraightJoint.kt
@@ -1,6 +1,5 @@
 package mods.eln.mechanical
 
-import mods.eln.i18n.I18N
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
@@ -25,8 +24,8 @@ open class StraightJointElement(node: TransparentNode, desc_: TransparentNodeDes
 
     override fun getWaila(): Map<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
-        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
+        info.put("Speed", Utils.plotRads("", shaft.rads))
+        info.put("Energy", Utils.plotEnergy("", shaft.energy))
         return info
     }
 

--- a/src/main/kotlin/mods/eln/mechanical/StraightJoint.kt
+++ b/src/main/kotlin/mods/eln/mechanical/StraightJoint.kt
@@ -1,6 +1,6 @@
 package mods.eln.mechanical
 
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
@@ -25,8 +25,8 @@ open class StraightJointElement(node: TransparentNode, desc_: TransparentNodeDes
 
     override fun getWaila(): Map<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
-        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
+        info.put(tr("Speed"), Utils.plotRads("", shaft.rads))
+        info.put(tr("Energy"), Utils.plotEnergy("", shaft.energy))
         return info
     }
 

--- a/src/main/kotlin/mods/eln/mechanical/Tachometer.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Tachometer.kt
@@ -7,7 +7,7 @@ import mods.eln.gui.GuiHelper
 import mods.eln.gui.GuiScreenEln
 import mods.eln.gui.GuiTextFieldEln
 import mods.eln.gui.IGuiObject
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.IConfigurable
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Direction
@@ -154,7 +154,7 @@ class TachometerRender(entity: TransparentNodeEntity, desc: TransparentNodeDescr
 }
 
 class TachometerGui(val render: TachometerRender) : GuiScreenEln() {
-    val validate: GuiButton by lazy { newGuiButton(82, 12, 80, I18N.tr("Validate")) }
+    val validate: GuiButton by lazy { newGuiButton(82, 12, 80, tr("Validate")) }
     val lowValue: GuiTextFieldEln by lazy { newGuiTextField(8, 24, 70) }
     val highValue: GuiTextFieldEln by lazy { newGuiTextField(8, 8, 70) }
 
@@ -163,8 +163,8 @@ class TachometerGui(val render: TachometerRender) : GuiScreenEln() {
     override fun initGui() {
         super.initGui()
         validate.enabled = true
-        lowValue.setComment(I18N.tr("Rads/s corresponding\nto 0% output").split("\n".toRegex()).dropLastWhile({ it.isEmpty() }).toTypedArray())
-        highValue.setComment(I18N.tr("Rads/s corresponding\nto 100% output").split("\n".toRegex()).dropLastWhile({ it.isEmpty() }).toTypedArray())
+        lowValue.setComment(tr("Rads/s corresponding\nto 0% output").split("\n".toRegex()).dropLastWhile({ it.isEmpty() }).toTypedArray())
+        highValue.setComment(tr("Rads/s corresponding\nto 100% output").split("\n".toRegex()).dropLastWhile({ it.isEmpty() }).toTypedArray())
         lowValue.setText(render.minRads)
         highValue.setText(render.maxRads)
     }

--- a/src/main/kotlin/mods/eln/mechanical/Turbines.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Turbines.kt
@@ -3,6 +3,7 @@ package mods.eln.mechanical
 import mods.eln.Eln
 import mods.eln.fluid.FuelRegistry
 import mods.eln.fluid.PreciseElementFluidHandler
+import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
 import mods.eln.node.published
@@ -58,18 +59,18 @@ abstract class TurbineDescriptor(baseName: String, obj: Obj3D) :
     )
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-        list.add("Converts $fluidDescription into mechanical energy.")
-        list.add("Nominal usage ->")
-        list.add("  ${fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }} input: $fluidConsumption mB/s")
+        list.add(I18N.tr("Converts %1$ into mechanical energy.",fluidDescription))
+        list.add(I18N.tr("Nominal usage ->"))
+        list.add("  "+I18N.tr("%1$ input: %2$ mB/s",fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },fluidConsumption))
         if (power.isEmpty()) {
-            list.add("  No valid fluids for this turbine!")
+            list.add("  "+I18N.tr("No valid fluids for this turbine!"))
         } else if (power.size == 1) {
-            list.add(Utils.plotPower("  Power out: ", power[0]))
+            list.add("  "+I18N.tr("Power out: %1$",Utils.plotPower(power[0])))
         } else {
-            list.add("  Power out: ${Utils.plotPower(minFluidPower)}- ${Utils.plotPower(maxFluidPower)}")
+            list.add("  "+I18N.tr("Power out: %1$- %2$",Utils.plotPower(minFluidPower),Utils.plotPower(maxFluidPower)))
         }
-        list.add(Utils.plotRads("  Optimal rads: ", optimalRads))
-        list.add(Utils.plotRads("Max rads:  ", absoluteMaximumShaftSpeed))
+        list.add("  "+I18N.tr("Optimal rads: %1$",Utils.plotRads("", optimalRads)))
+        list.add(I18N.tr("Max rads:  %1$",Utils.plotRads("",absoluteMaximumShaftSpeed)))
     }
 }
 
@@ -187,11 +188,11 @@ class TurbineElement(node: TransparentNode, desc_: TransparentNodeDescriptor) :
 
     override fun getWaila(): Map<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put("Speed", Utils.plotRads("", shaft.rads))
-        info.put("Energy", Utils.plotEnergy("", shaft.energy))
+        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
+        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
         if (Eln.wailaEasyMode) {
-            info.put("Efficency", Utils.plotPercent("", efficiency.toDouble()))
-            info.put("Fuel usage", Utils.plotBuckets("", fluidRate / 1000.0) + "/s")
+            info.put(I18N.tr("Efficiency"), Utils.plotPercent("", efficiency.toDouble()))
+            info.put(I18N.tr("Fuel usage"), Utils.plotBuckets("", fluidRate / 1000.0) + "/s")
         }
         return info
     }

--- a/src/main/kotlin/mods/eln/mechanical/Turbines.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Turbines.kt
@@ -3,7 +3,6 @@ package mods.eln.mechanical
 import mods.eln.Eln
 import mods.eln.fluid.FuelRegistry
 import mods.eln.fluid.PreciseElementFluidHandler
-import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
 import mods.eln.node.published
@@ -59,18 +58,18 @@ abstract class TurbineDescriptor(baseName: String, obj: Obj3D) :
     )
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-        list.add(I18N.tr("Converts %1$ into mechanical energy.",fluidDescription))
-        list.add(I18N.tr("Nominal usage ->"))
-        list.add("  "+I18N.tr("%1$ input: %2$ mB/s",fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },fluidConsumption))
+        list.add("Converts $fluidDescription into mechanical energy.")
+        list.add("Nominal usage ->")
+        list.add("  ${fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }} input: $fluidConsumption mB/s")
         if (power.isEmpty()) {
-            list.add("  "+I18N.tr("No valid fluids for this turbine!"))
+            list.add("  No valid fluids for this turbine!")
         } else if (power.size == 1) {
-            list.add("  "+I18N.tr("Power out: %1$",Utils.plotPower(power[0])))
+            list.add(Utils.plotPower("  Power out: ", power[0]))
         } else {
-            list.add("  "+I18N.tr("Power out: %1$- %2$",Utils.plotPower(minFluidPower),Utils.plotPower(maxFluidPower)))
+            list.add("  Power out: ${Utils.plotPower(minFluidPower)}- ${Utils.plotPower(maxFluidPower)}")
         }
-        list.add("  "+I18N.tr("Optimal rads: %1$",Utils.plotRads("", optimalRads)))
-        list.add(I18N.tr("Max rads:  %1$",Utils.plotRads("",absoluteMaximumShaftSpeed)))
+        list.add(Utils.plotRads("  Optimal rads: ", optimalRads))
+        list.add(Utils.plotRads("Max rads:  ", absoluteMaximumShaftSpeed))
     }
 }
 
@@ -188,11 +187,11 @@ class TurbineElement(node: TransparentNode, desc_: TransparentNodeDescriptor) :
 
     override fun getWaila(): Map<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
-        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
+        info.put("Speed", Utils.plotRads("", shaft.rads))
+        info.put("Energy", Utils.plotEnergy("", shaft.energy))
         if (Eln.wailaEasyMode) {
-            info.put(I18N.tr("Efficiency"), Utils.plotPercent("", efficiency.toDouble()))
-            info.put(I18N.tr("Fuel usage"), Utils.plotBuckets("", fluidRate / 1000.0) + "/s")
+            info.put("Efficency", Utils.plotPercent("", efficiency.toDouble()))
+            info.put("Fuel usage", Utils.plotBuckets("", fluidRate / 1000.0) + "/s")
         }
         return info
     }

--- a/src/main/kotlin/mods/eln/mechanical/Turbines.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Turbines.kt
@@ -3,7 +3,7 @@ package mods.eln.mechanical
 import mods.eln.Eln
 import mods.eln.fluid.FuelRegistry
 import mods.eln.fluid.PreciseElementFluidHandler
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
 import mods.eln.node.published
@@ -59,18 +59,19 @@ abstract class TurbineDescriptor(baseName: String, obj: Obj3D) :
     )
 
     override fun addInformation(stack: ItemStack, player: EntityPlayer, list: MutableList<String>, par4: Boolean) {
-        list.add(I18N.tr("Converts %1$ into mechanical energy.",fluidDescription))
-        list.add(I18N.tr("Nominal usage ->"))
-        list.add("  "+I18N.tr("%1$ input: %2$ mB/s",fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },fluidConsumption))
+        list.add(tr("Converts %1$ into mechanical energy.",fluidDescription))
+        list.add(tr("Nominal usage ->"))
+        list.add("  "+tr("%1$ input: %2$ mB/s",fluidDescription.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },fluidConsumption))
         if (power.isEmpty()) {
-            list.add("  "+I18N.tr("No valid fluids for this turbine!"))
+            list.add("  "+tr("No valid fluids for this turbine!"))
         } else if (power.size == 1) {
-            list.add("  "+I18N.tr("Power out: %1$",Utils.plotPower(power[0])))
+            list.add(Utils.plotPower(tr("  Power out: "),power[0]))
         } else {
-            list.add("  "+I18N.tr("Power out: %1$- %2$",Utils.plotPower(minFluidPower),Utils.plotPower(maxFluidPower)))
+            list.add("  "+tr("Power out: %1$- %2$",Utils.plotPower(minFluidPower),Utils.plotPower(maxFluidPower)))
         }
-        list.add("  "+I18N.tr("Optimal rads: %1$",Utils.plotRads("", optimalRads)))
-        list.add(I18N.tr("Max rads:  %1$",Utils.plotRads("",absoluteMaximumShaftSpeed)))
+        list.add(Utils.plotRads(tr("  Optimal rads: "), optimalRads))
+        list.add(Utils.plotRads(tr("Max rads:  "),absoluteMaximumShaftSpeed))
+
     }
 }
 
@@ -188,11 +189,11 @@ class TurbineElement(node: TransparentNode, desc_: TransparentNodeDescriptor) :
 
     override fun getWaila(): Map<String, String> {
         var info = mutableMapOf<String, String>()
-        info.put(I18N.tr("Speed"), Utils.plotRads("", shaft.rads))
-        info.put(I18N.tr("Energy"), Utils.plotEnergy("", shaft.energy))
+        info.put(tr("Speed"), Utils.plotRads("", shaft.rads))
+        info.put(tr("Energy"), Utils.plotEnergy("", shaft.energy))
         if (Eln.wailaEasyMode) {
-            info.put(I18N.tr("Efficiency"), Utils.plotPercent("", efficiency.toDouble()))
-            info.put(I18N.tr("Fuel usage"), Utils.plotBuckets("", fluidRate / 1000.0) + "/s")
+            info.put(tr("Efficiency"), Utils.plotPercent("", efficiency.toDouble()))
+            info.put(tr("Fuel usage"), Utils.plotBuckets("", fluidRate / 1000.0) + "/s")
         }
         return info
     }

--- a/src/main/kotlin/mods/eln/misc/UtilsClient.kt
+++ b/src/main/kotlin/mods/eln/misc/UtilsClient.kt
@@ -4,7 +4,7 @@ package mods.eln.misc
 import cpw.mods.fml.common.network.internal.FMLProxyPacket
 import mods.eln.Eln
 import mods.eln.GuiHandler
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Obj3D.Obj3DPart
 import mods.eln.node.six.SixNodeEntity
 import mods.eln.node.transparent.TransparentNodeEntity
@@ -573,7 +573,7 @@ object UtilsClient {
             if (isShiftHeld()) {
                 dst.addAll(details)
             } else {
-                dst.add("§F§o${I18N.tr("Hold [shift] for details")}")
+                dst.add("§F§o${tr("Hold [shift] for details")}")
             }
         }
         if (realismDetails.isNotEmpty()) {
@@ -582,7 +582,7 @@ object UtilsClient {
             } else {
                 if (realisticEnum != null) {
                     if (realismDetails.isNotEmpty()) {
-                        dst.add("§F§o${I18N.tr("Hold [ctrl] for realism details")}")
+                        dst.add("§F§o${tr("Hold [ctrl] for realism details")}")
                     }
                 }
             }

--- a/src/main/kotlin/mods/eln/misc/Version.kt
+++ b/src/main/kotlin/mods/eln/misc/Version.kt
@@ -1,7 +1,7 @@
 package mods.eln.misc
 
 import mods.eln.Tags
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import org.semver4j.Semver
 
 /**
@@ -50,12 +50,12 @@ object Version {
     val simpleVersionName = if (!DIRTY) "$MAJOR.$MINOR.$REVISION" else "$MAJOR.$MINOR.$REVISION (Dirty)"
     @JvmStatic
     fun print(): String {
-        return I18N.tr("mod.name") + " " + simpleVersionName
+        return tr("mod.name") + " " + simpleVersionName
     }
 
     @JvmStatic
     fun printColor(): String {
-        return (FC.WHITE + I18N.tr("mod.name") + " version "
+        return (FC.WHITE + tr("mod.name") + " version "
                 + FC.ORANGE + simpleVersionName)
     }
 

--- a/src/main/kotlin/mods/eln/node/six/SixNodeDescriptor.kt
+++ b/src/main/kotlin/mods/eln/node/six/SixNodeDescriptor.kt
@@ -2,7 +2,7 @@ package mods.eln.node.six
 
 import mods.eln.generic.GenericItemBlockUsingDamageDescriptor
 import mods.eln.ghost.GhostGroup
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
@@ -69,7 +69,7 @@ open class SixNodeDescriptor : GenericItemBlockUsingDamageDescriptor, IItemRende
             for (d in placeDirection!!) {
                 if (d === side) return true
             }
-            addChatMessage(player!!, I18N.tr("You can't place this block at this side"))
+            addChatMessage(player!!, tr("You can't place this block at this side"))
             return false
         }
         return true
@@ -107,10 +107,10 @@ open class SixNodeDescriptor : GenericItemBlockUsingDamageDescriptor, IItemRende
                     break
                 }
             }
-            if (!ok) return I18N.tr("You can't place this block at this side")
+            if (!ok) return tr("You can't place this block at this side")
         }
         val ghostGroup = getGhostGroup(direction, front)
-        return if (ghostGroup != null && !ghostGroup.canBePloted(coord!!)) I18N.tr("Not enough space for this block") else null
+        return if (ghostGroup != null && !ghostGroup.canBePloted(coord!!)) tr("Not enough space for this block") else null
     }
 
     open fun getFrontFromPlace(side: Direction, player: EntityPlayer): LRDU? {

--- a/src/main/kotlin/mods/eln/node/transparent/TransparentNodeDescriptor.kt
+++ b/src/main/kotlin/mods/eln/node/transparent/TransparentNodeDescriptor.kt
@@ -2,7 +2,7 @@ package mods.eln.node.transparent
 
 import mods.eln.generic.GenericItemBlockUsingDamageDescriptor
 import mods.eln.ghost.GhostGroup
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Direction
 import mods.eln.misc.Obj3D
@@ -89,19 +89,19 @@ open class TransparentNodeDescriptor @JvmOverloads constructor(
             val temp = Coordinate(coord!!)
             temp.move(Direction.YN)
             block = temp.block
-            if (!block.isOpaqueCube && block !is BlockHopper) return I18N.tr("You can't place this block at this side")
+            if (!block.isOpaqueCube && block !is BlockHopper) return tr("You can't place this block at this side")
         }
         if (mustHaveCeiling()) {
             val temp = Coordinate(coord!!)
             temp.move(Direction.YP)
             block = temp.block
-            if (!block.isOpaqueCube) return I18N.tr("You can't place this block at this side")
+            if (!block.isOpaqueCube) return tr("You can't place this block at this side")
         }
         if (mustHaveWallFrontInverse()) {
             val temp = Coordinate(coord!!)
             temp.move(front.inverse)
             block = temp.block
-            if (!block.isOpaqueCube) return I18N.tr("You can't place this block at this side")
+            if (!block.isOpaqueCube) return tr("You can't place this block at this side")
         }
         if (mustHaveWall()) {
             var wall = false
@@ -121,10 +121,10 @@ open class TransparentNodeDescriptor @JvmOverloads constructor(
             temp.move(Direction.ZP)
             block = temp.block
             if (block.isOpaqueCube) wall = true
-            if (!wall) return I18N.tr("You can't place this block at this side")
+            if (!wall) return tr("You can't place this block at this side")
         }
         val ghostGroup = getGhostGroupFront(front)
-        return if (ghostGroup != null && !ghostGroup.canBePloted(coord!!)) I18N.tr("Not enough space for this block") else null
+        return if (ghostGroup != null && !ghostGroup.canBePloted(coord!!)) tr("Not enough space for this block") else null
     }
 
     open fun getFrontFromPlace(side: Direction, entityLiving: EntityLivingBase?): Direction? {

--- a/src/main/kotlin/mods/eln/registration/ItemRegistration.kt
+++ b/src/main/kotlin/mods/eln/registration/ItemRegistration.kt
@@ -8,6 +8,7 @@ import mods.eln.generic.GenericItemUsingDamageDescriptorWithComment
 import mods.eln.generic.genericArmorItem
 import mods.eln.generic.genericArmorItem.ArmourType
 import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.*
 import mods.eln.item.electricalitem.*
 import mods.eln.item.regulator.IRegulatorDescriptor
@@ -746,7 +747,7 @@ object ItemRegistration {
             name = I18N.TR_NAME(I18N.Type.NONE, "Ferrite Ingot")
             element = GenericItemUsingDamageDescriptorWithComment(
                 name,
-                arrayOf(I18N.tr("useless"), I18N.tr("Really useless"))
+                arrayOf(tr("useless"), tr("Really useless"))
             )
             Eln.sharedItem.addElement(completId, element)
             Data.addResource(element.newItemStack())
@@ -768,7 +769,7 @@ object ItemRegistration {
             completId = subId + (id shl 6)
             name = I18N.TR_NAME(I18N.Type.NONE, "Mercury")
             element =
-                GenericItemUsingDamageDescriptorWithComment(name, arrayOf(I18N.tr("useless"), I18N.tr("miaou")))
+                GenericItemUsingDamageDescriptorWithComment(name, arrayOf(tr("useless"), tr("miaou")))
             Eln.sharedItem.addElement(completId, element)
             Data.addResource(element.newItemStack())
             addToOre("quicksilver", element.newItemStack())
@@ -1497,7 +1498,7 @@ object ItemRegistration {
             subId = 48
             name = I18N.TR_NAME(I18N.Type.NONE, "Wrench")
             val desc = GenericItemUsingDamageDescriptorWithComment(name,
-                I18N.TR("Electrical age wrench,\nCan be used to turn\nsmall wall blocks")
+                tr("Electrical age wrench,\nCan be used to turn\nsmall wall blocks")
                     .split("\n".toRegex()).dropLastWhile { it.isEmpty() }
                     .toTypedArray())
             Eln.sharedItem.addElement(subId + (id shl 6), desc)

--- a/src/main/kotlin/mods/eln/registration/ItemRegistration.kt
+++ b/src/main/kotlin/mods/eln/registration/ItemRegistration.kt
@@ -746,7 +746,7 @@ object ItemRegistration {
             name = I18N.TR_NAME(I18N.Type.NONE, "Ferrite Ingot")
             element = GenericItemUsingDamageDescriptorWithComment(
                 name,
-                arrayOf(I18N.tr("useless"), I18N.tr("Really useless"))
+                arrayOf("useless", "Really useless")
             )
             Eln.sharedItem.addElement(completId, element)
             Data.addResource(element.newItemStack())
@@ -768,7 +768,7 @@ object ItemRegistration {
             completId = subId + (id shl 6)
             name = I18N.TR_NAME(I18N.Type.NONE, "Mercury")
             element =
-                GenericItemUsingDamageDescriptorWithComment(name, arrayOf(I18N.tr("useless"), I18N.tr("miaou")))
+                GenericItemUsingDamageDescriptorWithComment(name, arrayOf("useless", "miaou"))
             Eln.sharedItem.addElement(completId, element)
             Data.addResource(element.newItemStack())
             addToOre("quicksilver", element.newItemStack())

--- a/src/main/kotlin/mods/eln/registration/ItemRegistration.kt
+++ b/src/main/kotlin/mods/eln/registration/ItemRegistration.kt
@@ -746,7 +746,7 @@ object ItemRegistration {
             name = I18N.TR_NAME(I18N.Type.NONE, "Ferrite Ingot")
             element = GenericItemUsingDamageDescriptorWithComment(
                 name,
-                arrayOf("useless", "Really useless")
+                arrayOf(I18N.tr("useless"), I18N.tr("Really useless"))
             )
             Eln.sharedItem.addElement(completId, element)
             Data.addResource(element.newItemStack())
@@ -768,7 +768,7 @@ object ItemRegistration {
             completId = subId + (id shl 6)
             name = I18N.TR_NAME(I18N.Type.NONE, "Mercury")
             element =
-                GenericItemUsingDamageDescriptorWithComment(name, arrayOf("useless", "miaou"))
+                GenericItemUsingDamageDescriptorWithComment(name, arrayOf(I18N.tr("useless"), I18N.tr("miaou")))
             Eln.sharedItem.addElement(completId, element)
             Data.addResource(element.newItemStack())
             addToOre("quicksilver", element.newItemStack())

--- a/src/main/kotlin/mods/eln/sixnode/AnalogChips.kt
+++ b/src/main/kotlin/mods/eln/sixnode/AnalogChips.kt
@@ -212,8 +212,8 @@ abstract class AnalogFunction : INBTTReady {
     abstract fun process(inputs: Array<Double?>, deltaTime: Double): Double
 
     open fun getWaila(inputs: Array<Double?>, output: Double) = mutableMapOf(
-        Pair(I18N.tr("Inputs"), (1..inputCount).map { "${inputColors[it - 1]}${Utils.plotVolt("", inputs[it - 1] ?: 0.0)}" }.joinToString(" ")),
-        Pair(I18N.tr("Output"), Utils.plotVolt("", output))
+        Pair("Inputs", (1..inputCount).map { "${inputColors[it - 1]}${Utils.plotVolt("", inputs[it - 1] ?: 0.0)}" }.joinToString(" ")),
+        Pair("Output", Utils.plotVolt("", output))
     )
 
     override fun readFromNBT(nbt: NBTTagCompound, str: String) {}
@@ -474,7 +474,7 @@ class Amplifier : AnalogFunction() {
 
     override fun getWaila(inputs: Array<Double?>, output: Double): MutableMap<String, String> {
         val info = super.getWaila(inputs, output)
-        info[I18N.tr("Gain")] = Utils.plotValue(gain)
+        info["Gain"] = Utils.plotValue(gain)
         return info
     }
 }
@@ -585,7 +585,7 @@ class VoltageControlledAmplifier : AnalogFunction() {
 
     override fun getWaila(inputs: Array<Double?>, output: Double): MutableMap<String, String> {
         val info = super.getWaila(inputs, output)
-        info[I18N.tr("Gain")] = Utils.plotValue((inputs[1] ?: 5.0) / 5.0)
+        info["Gain"] = Utils.plotValue((inputs[1] ?: 5.0) / 5.0)
         return info
     }
 }
@@ -614,7 +614,7 @@ class SummingUnit : AnalogFunction() {
 
     override fun getWaila(inputs: Array<Double?>, output: Double): MutableMap<String, String> {
         val info = super.getWaila(inputs, output)
-        info[I18N.tr("Gains")] = (0..2).map { "${inputColors[it]}${Utils.plotValue(gains[it])}" }.joinToString(" ")
+        info["Gains"] = (0..2).map { "${inputColors[it]}${Utils.plotValue(gains[it])}" }.joinToString(" ")
         return info
     }
 }

--- a/src/main/kotlin/mods/eln/sixnode/AnalogChips.kt
+++ b/src/main/kotlin/mods/eln/sixnode/AnalogChips.kt
@@ -212,8 +212,8 @@ abstract class AnalogFunction : INBTTReady {
     abstract fun process(inputs: Array<Double?>, deltaTime: Double): Double
 
     open fun getWaila(inputs: Array<Double?>, output: Double) = mutableMapOf(
-        Pair("Inputs", (1..inputCount).map { "${inputColors[it - 1]}${Utils.plotVolt("", inputs[it - 1] ?: 0.0)}" }.joinToString(" ")),
-        Pair("Output", Utils.plotVolt("", output))
+        Pair(I18N.tr("Inputs"), (1..inputCount).map { "${inputColors[it - 1]}${Utils.plotVolt("", inputs[it - 1] ?: 0.0)}" }.joinToString(" ")),
+        Pair(I18N.tr("Output"), Utils.plotVolt("", output))
     )
 
     override fun readFromNBT(nbt: NBTTagCompound, str: String) {}
@@ -474,7 +474,7 @@ class Amplifier : AnalogFunction() {
 
     override fun getWaila(inputs: Array<Double?>, output: Double): MutableMap<String, String> {
         val info = super.getWaila(inputs, output)
-        info["Gain"] = Utils.plotValue(gain)
+        info[I18N.tr("Gain")] = Utils.plotValue(gain)
         return info
     }
 }
@@ -585,7 +585,7 @@ class VoltageControlledAmplifier : AnalogFunction() {
 
     override fun getWaila(inputs: Array<Double?>, output: Double): MutableMap<String, String> {
         val info = super.getWaila(inputs, output)
-        info["Gain"] = Utils.plotValue((inputs[1] ?: 5.0) / 5.0)
+        info[I18N.tr("Gain")] = Utils.plotValue((inputs[1] ?: 5.0) / 5.0)
         return info
     }
 }
@@ -614,7 +614,7 @@ class SummingUnit : AnalogFunction() {
 
     override fun getWaila(inputs: Array<Double?>, output: Double): MutableMap<String, String> {
         val info = super.getWaila(inputs, output)
-        info["Gains"] = (0..2).map { "${inputColors[it]}${Utils.plotValue(gains[it])}" }.joinToString(" ")
+        info[I18N.tr("Gains")] = (0..2).map { "${inputColors[it]}${Utils.plotValue(gains[it])}" }.joinToString(" ")
         return info
     }
 }

--- a/src/main/kotlin/mods/eln/sixnode/AnalogChips.kt
+++ b/src/main/kotlin/mods/eln/sixnode/AnalogChips.kt
@@ -3,7 +3,7 @@ package mods.eln.sixnode
 import mods.eln.Eln
 import mods.eln.cable.CableRenderDescriptor
 import mods.eln.gui.*
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.IConfigurable
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
@@ -152,7 +152,7 @@ open class AnalogChipElement(node: SixNode, side: Direction, sixNodeDescriptor: 
                 else if (pin.stateHigh()) "1" else "?").append(", ")
             }
         }
-        builder.append(I18N.tr(" O: ")).append(if (outputProcess.voltage == Eln.SVU) "1" else "0")
+        builder.append(tr(" O: ")).append(if (outputProcess.voltage == Eln.SVU) "1" else "0")
         return builder.toString()
     }
 
@@ -212,8 +212,8 @@ abstract class AnalogFunction : INBTTReady {
     abstract fun process(inputs: Array<Double?>, deltaTime: Double): Double
 
     open fun getWaila(inputs: Array<Double?>, output: Double) = mutableMapOf(
-        Pair(I18N.tr("Inputs"), (1..inputCount).map { "${inputColors[it - 1]}${Utils.plotVolt("", inputs[it - 1] ?: 0.0)}" }.joinToString(" ")),
-        Pair(I18N.tr("Output"), Utils.plotVolt("", output))
+        Pair(tr("Inputs"), (1..inputCount).map { "${inputColors[it - 1]}${Utils.plotVolt("", inputs[it - 1] ?: 0.0)}" }.joinToString(" ")),
+        Pair(tr("Output"), Utils.plotVolt("", output))
     )
 
     override fun readFromNBT(nbt: NBTTagCompound, str: String) {}
@@ -222,7 +222,7 @@ abstract class AnalogFunction : INBTTReady {
 
 class OpAmp : AnalogFunction() {
     override val inputCount = 2
-    override val infos: String = I18N.tr("Operational Amplifier - DC coupled\nhigh-gain voltage amplifier with\ndifferential input. Can be used to\ncompare voltages or as configurable amplifier.")
+    override val infos: String = tr("Operational Amplifier - DC coupled\nhigh-gain voltage amplifier with\ndifferential input. Can be used to\ncompare voltages or as configurable amplifier.")
 
     override fun process(inputs: Array<Double?>, deltaTime: Double): Double =
         10000 * ((inputs[0] ?: 0.0) - (inputs[1] ?: 0.0))
@@ -231,7 +231,7 @@ class OpAmp : AnalogFunction() {
 class PIDRegulator : AnalogFunction() {
     override val hasState = true
     override val inputCount = 2
-    override val infos = I18N.tr("Proportional–integral–derivative controller. A PID\ncontroller continuously calculates an error value as\nthe difference between a desired setpoint and a measured\nprocess variable and applies a correction based on\nproportional, integral, and derivative terms.")
+    override val infos = tr("Proportional–integral–derivative controller. A PID\ncontroller continuously calculates an error value as\nthe difference between a desired setpoint and a measured\nprocess variable and applies a correction based on\nproportional, integral, and derivative terms.")
 
     internal var Kp = 1.0
     internal var Ki = 0.0
@@ -264,9 +264,9 @@ class PIDRegulator : AnalogFunction() {
 
     override fun getWaila(inputs: Array<Double?>, output: Double): MutableMap<String, String> {
         val info = super.getWaila(inputs, output)
-        info[I18N.tr("Params")] = "Kp = $Kp, Ki = $Ki, Kd = $Kd"
+        info[tr("Params")] = "Kp = $Kp, Ki = $Ki, Kd = $Kd"
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("State")] = "Si = ${pid.iStack}"
+            info[tr("State")] = "Si = ${pid.iStack}"
         }
         return info
     }
@@ -420,7 +420,7 @@ class PIDRegulatorGui(val render: PIDRegulatorRender) : GuiScreenEln() {
 open class VoltageControlledSawtoothOscillator : AnalogFunction() {
     override val hasState = true
     override val inputCount = 1
-    override val infos = I18N.tr("A voltage-controlled oscillator or VCO is\nan electronic oscillator whose oscillation\nfrequency is controlled by a voltage input.")
+    override val infos = tr("A voltage-controlled oscillator or VCO is\nan electronic oscillator whose oscillation\nfrequency is controlled by a voltage input.")
 
     private var out = 0.0
 
@@ -458,7 +458,7 @@ class VoltageControlledSineOscillator : VoltageControlledSawtoothOscillator() {
 class Amplifier : AnalogFunction() {
     override val hasState = true
     override val inputCount = 1
-    override val infos = I18N.tr("An amplifier increases the voltage\nof an input signal by a configurable\ngain and outputs that voltage.")
+    override val infos = tr("An amplifier increases the voltage\nof an input signal by a configurable\ngain and outputs that voltage.")
 
     internal var gain = 1.0
 
@@ -474,7 +474,7 @@ class Amplifier : AnalogFunction() {
 
     override fun getWaila(inputs: Array<Double?>, output: Double): MutableMap<String, String> {
         val info = super.getWaila(inputs, output)
-        info[I18N.tr("Gain")] = Utils.plotValue(gain)
+        info[tr("Gain")] = Utils.plotValue(gain)
         return info
     }
 }
@@ -554,7 +554,7 @@ class AmplifierGui(val render: AmplifierRender) : GuiScreenEln() {
         super.initGui()
 
         gainTF = newGuiTextField(6, 6, 50)
-        gainTF?.setComment(0, I18N.tr("Gain"))
+        gainTF?.setComment(0, tr("Gain"))
         gainTF?.setText(render.gain)
         gainTF?.setObserver { _, text ->
             try {
@@ -579,13 +579,13 @@ class AmplifierGui(val render: AmplifierRender) : GuiScreenEln() {
 
 class VoltageControlledAmplifier : AnalogFunction() {
     override val inputCount = 2
-    override val infos = I18N.tr("A voltage-controlled amplifier (VCA)\nis an electronic amplifier that varies\nits gain depending on the control voltage.")
+    override val infos = tr("A voltage-controlled amplifier (VCA)\nis an electronic amplifier that varies\nits gain depending on the control voltage.")
 
     override fun process(inputs: Array<Double?>, deltaTime: Double) = (inputs[1] ?: 5.0) / 5.0 * (inputs[0] ?: 0.0)
 
     override fun getWaila(inputs: Array<Double?>, output: Double): MutableMap<String, String> {
         val info = super.getWaila(inputs, output)
-        info[I18N.tr("Gain")] = Utils.plotValue((inputs[1] ?: 5.0) / 5.0)
+        info[tr("Gain")] = Utils.plotValue((inputs[1] ?: 5.0) / 5.0)
         return info
     }
 }
@@ -593,7 +593,7 @@ class VoltageControlledAmplifier : AnalogFunction() {
 class SummingUnit : AnalogFunction() {
     override val hasState = true
     override val inputCount = 3
-    override val infos = I18N.tr("The summing unit outputs the sum of\nthe three weighted inputs.The\ngain for each input can be configured.")
+    override val infos = tr("The summing unit outputs the sum of\nthe three weighted inputs.The\ngain for each input can be configured.")
 
     internal val gains = arrayOf(1.0, 1.0, 1.0)
 
@@ -614,7 +614,7 @@ class SummingUnit : AnalogFunction() {
 
     override fun getWaila(inputs: Array<Double?>, output: Double): MutableMap<String, String> {
         val info = super.getWaila(inputs, output)
-        info[I18N.tr("Gains")] = (0..2).map { "${inputColors[it]}${Utils.plotValue(gains[it])}" }.joinToString(" ")
+        info[tr("Gains")] = (0..2).map { "${inputColors[it]}${Utils.plotValue(gains[it])}" }.joinToString(" ")
         return info
     }
 }
@@ -726,9 +726,9 @@ class SummingUnitGui(val render: SummingUnitRender) : GuiScreenEln() {
                 }
             }
         }
-        gainTFs[0]?.setComment(0, I18N.tr("Gain for input \u00a741"))
-        gainTFs[1]?.setComment(0, I18N.tr("Gain for input \u00a722"))
-        gainTFs[2]?.setComment(0, I18N.tr("Gain for input \u00a713"))
+        gainTFs[0]?.setComment(0, tr("Gain for input \u00a741"))
+        gainTFs[1]?.setComment(0, tr("Gain for input \u00a722"))
+        gainTFs[2]?.setComment(0, tr("Gain for input \u00a713"))
     }
 
     override fun newHelper() = GuiHelper(this, 62, 64)
@@ -737,7 +737,7 @@ class SummingUnitGui(val render: SummingUnitRender) : GuiScreenEln() {
 class SampleAndHold : AnalogFunction() {
     override val hasState = true
     override val inputCount = 2
-    override val infos = I18N.tr("Samples the voltage of a varying analog signal when\nthe clock input changes from 0 to 1 and holds its\noutput voltage at a constant level until next clock pulse.\nYou can see it as an analog D-Flipflop.")
+    override val infos = tr("Samples the voltage of a varying analog signal when\nthe clock input changes from 0 to 1 and holds its\noutput voltage at a constant level until next clock pulse.\nYou can see it as an analog D-Flipflop.")
     private var clock = false
     private var value = 0.0
 
@@ -762,7 +762,7 @@ class SampleAndHold : AnalogFunction() {
 class Filter: AnalogFunction() {
     override val hasState = true
     override val inputCount = 1
-    override val infos = I18N.tr("Lowpass filter - Passes signals with a\nfrequency lower than a certain cutoff frequency\nand attenuates signals with frequencies higher\nthan the cutoff frequency.")
+    override val infos = tr("Lowpass filter - Passes signals with a\nfrequency lower than a certain cutoff frequency\nand attenuates signals with frequencies higher\nthan the cutoff frequency.")
 
     internal var feedback = 2.0 * Math.PI * 5.0
     private var output = 0.0
@@ -881,7 +881,7 @@ class FilterGui(private var render: FilterRender) : GuiScreenEln() {
         if (render.cutOffFrequency.pending) {
             freq?.value = render.cutOffFrequency.value
         }
-        freq?.setComment(0, I18N.tr("Cut-off frequency %1$ Hz",
+        freq?.setComment(0, tr("Cut-off frequency %1$ Hz",
             String.format("%1.3f", freq?.value ?: Eln.instance.electricalFrequency / 4f)))
     }
 

--- a/src/main/kotlin/mods/eln/sixnode/ConduitCableDescriptor.kt
+++ b/src/main/kotlin/mods/eln/sixnode/ConduitCableDescriptor.kt
@@ -2,7 +2,7 @@ package mods.eln.sixnode
 
 import mods.eln.cable.CableRender
 import mods.eln.cable.CableRenderDescriptor
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
 import mods.eln.node.six.*
@@ -18,12 +18,12 @@ class ConduitCableDescriptor(
 
     override fun addInformation(itemStack: ItemStack, entityPlayer: EntityPlayer, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list.add(I18N.tr("A conduit to run your cables through"))
+        list.add(tr("A conduit to run your cables through"))
     }
 
     override fun addRealismContext(list: MutableList<String>): RealisticEnum {
-        list.add(I18N.tr("Has some caveats:"))
-        list.add(I18N.tr("  * Thermal Sim is disabled in the conduit"))
+        list.add(tr("Has some caveats:"))
+        list.add(tr("  * Thermal Sim is disabled in the conduit"))
         return RealisticEnum.REALISTIC
     }
 
@@ -54,7 +54,7 @@ class ConduitCableElement(
 
     override fun getWaila(): Map<String, String> {
         val info: MutableMap<String, String> = HashMap()
-        info[I18N.tr("Contained Cables")] = "0"
+        info[tr("Contained Cables")] = "0"
         return info
     }
 

--- a/src/main/kotlin/mods/eln/sixnode/CurrentSourceSix.kt
+++ b/src/main/kotlin/mods/eln/sixnode/CurrentSourceSix.kt
@@ -43,7 +43,7 @@ class CurrentSourceDescriptor(name: String, obj: Obj3D) : SixNodeDescriptor(name
 
     override fun addRealismContext(list: MutableList<String?>): RealisticEnum {
         super.addRealismContext(list)
-        list.add(I18N.tr("Acts as an ideal current source, with a small inline resistance"))
+        list.add(I18N.tr("Acts as an ideal voltage source, with a small inline resistance"))
         return RealisticEnum.IDEAL
     }
 

--- a/src/main/kotlin/mods/eln/sixnode/CurrentSourceSix.kt
+++ b/src/main/kotlin/mods/eln/sixnode/CurrentSourceSix.kt
@@ -43,7 +43,7 @@ class CurrentSourceDescriptor(name: String, obj: Obj3D) : SixNodeDescriptor(name
 
     override fun addRealismContext(list: MutableList<String?>): RealisticEnum {
         super.addRealismContext(list)
-        list.add(I18N.tr("Acts as an ideal voltage source, with a small inline resistance"))
+        list.add(I18N.tr("Acts as an ideal current source, with a small inline resistance"))
         return RealisticEnum.IDEAL
     }
 

--- a/src/main/kotlin/mods/eln/sixnode/CurrentSourceSix.kt
+++ b/src/main/kotlin/mods/eln/sixnode/CurrentSourceSix.kt
@@ -6,6 +6,7 @@ import mods.eln.gui.GuiHelper
 import mods.eln.gui.GuiScreenEln
 import mods.eln.gui.GuiTextFieldEln
 import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.IConfigurable
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
@@ -34,16 +35,16 @@ class CurrentSourceDescriptor(name: String, obj: Obj3D) : SixNodeDescriptor(name
 
     override fun addInformation(itemStack: ItemStack, entityPlayer: EntityPlayer, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        Collections.addAll<String>(list, *I18N.tr("Provides an ideal current source\nwithout energy or power limitation.").split("\n").toTypedArray())
+        Collections.addAll<String>(list, *tr("Provides an ideal current source\nwithout energy or power limitation.").split("\n").toTypedArray())
         list.add("")
-        list.add(I18N.tr("Internal resistance: %1$\u2126", Utils.plotValue(Eln.instance.lowVoltageCableDescriptor.electricalRs)))
+        list.add(tr("Internal resistance: %1$\u2126", Utils.plotValue(Eln.instance.lowVoltageCableDescriptor.electricalRs)))
         list.add("")
-        list.add(I18N.tr("Creative block."))
+        list.add(tr("Creative block."))
     }
 
     override fun addRealismContext(list: MutableList<String?>): RealisticEnum {
         super.addRealismContext(list)
-        list.add(I18N.tr("Acts as an ideal current source, with a small inline resistance"))
+        list.add(tr("Acts as an ideal current source, with a small inline resistance"))
         return RealisticEnum.IDEAL
     }
 
@@ -105,10 +106,10 @@ class CurrentSourceElement(sixNode: SixNode, side: Direction, descriptor: SixNod
 
     override fun getWaila(): Map<String, String> {
         val info: MutableMap<String, String> = HashMap()
-        info[I18N.tr("Voltage")] = Utils.plotVolt("", electricalLoad.voltage)
-        info[I18N.tr("Current")] = Utils.plotAmpere("", electricalLoad.current)
+        info[tr("Voltage")] = Utils.plotVolt("", electricalLoad.voltage)
+        info[tr("Current")] = Utils.plotAmpere("", electricalLoad.current)
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Power")] = Utils.plotPower("", electricalLoad.voltage * electricalLoad.current)
+            info[tr("Power")] = Utils.plotPower("", electricalLoad.voltage * electricalLoad.current)
         }
         return info
     }
@@ -178,7 +179,7 @@ class CurrentSourceGui(var render: CurrentSourceRender) : GuiScreenEln() {
         current = newGuiTextField(6, 6, 50)
         current!!.setText(render.current.toFloat())
         current!!.setObserver(this)
-        current!!.setComment(arrayOf(I18N.tr("Current sourced")))
+        current!!.setComment(arrayOf(tr("Current sourced")))
     }
 
     override fun textFieldNewValue(textField: GuiTextFieldEln, value: String) {

--- a/src/main/kotlin/mods/eln/sixnode/ElectricalFuse.kt
+++ b/src/main/kotlin/mods/eln/sixnode/ElectricalFuse.kt
@@ -2,7 +2,7 @@ package mods.eln.sixnode
 
 import mods.eln.Eln
 import mods.eln.generic.GenericItemUsingDamageDescriptor
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.ElectricalFuseDescriptor
 import mods.eln.misc.*
 import mods.eln.node.NodeBase
@@ -73,7 +73,7 @@ class ElectricalFuseHolderDescriptor(name: String, obj: Obj3D) :
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>?, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
         if (list != null) {
-            I18N.tr("Protects electrical components.\nFuse melts if current exceeds the\nfuse limit").split("\n").forEach { list.add(it) }
+            tr("Protects electrical components.\nFuse melts if current exceeds the\nfuse limit").split("\n").forEach { list.add(it) }
         }
     }
 
@@ -166,7 +166,7 @@ class ElectricalFuseHolderElement(sixNode: SixNode, side: Direction, descriptor:
     override fun multiMeterString() = Utils.plotAmpere("I:", Math.abs(aLoad.current))
 
     override fun getWaila(): MutableMap<String, String> {
-        return mutableMapOf(Pair(I18N.tr("Current"), Utils.plotAmpere("", Math.abs(aLoad.current))))
+        return mutableMapOf(Pair(tr("Current"), Utils.plotAmpere("", Math.abs(aLoad.current))))
     }
 
     override fun networkSerialize(stream: DataOutputStream) {

--- a/src/main/kotlin/mods/eln/sixnode/ElectricalVuMeter.kt
+++ b/src/main/kotlin/mods/eln/sixnode/ElectricalVuMeter.kt
@@ -2,7 +2,7 @@ package mods.eln.sixnode
 
 import mods.eln.Eln
 import mods.eln.cable.CableRenderDescriptor
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
 import mods.eln.misc.Obj3D
@@ -103,9 +103,9 @@ class ElectricalVuMeterDescriptor(name: String, objName: String, var onOffOnly: 
     override fun addInformation(itemStack: ItemStack, entityPlayer: EntityPlayer, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
         if (isRGB)
-            list.add(I18N.tr("Displays a color based on the value of a signal"))
+            list.add(tr("Displays a color based on the value of a signal"))
         else
-            list.add(I18N.tr("Displays the value of a signal."))
+            list.add(tr("Displays the value of a signal."))
     }
 
     override fun shouldUseRenderHelper(type: IItemRenderer.ItemRenderType, item: ItemStack, helper: IItemRenderer.ItemRendererHelper) = type != IItemRenderer.ItemRenderType.INVENTORY
@@ -188,9 +188,9 @@ class ElectricalVuMeterElement(sixNode: SixNode, side: Direction, descriptor: Si
     override fun getWaila(): Map<String, String> {
         val info: MutableMap<String, String> = HashMap()
         if (descriptor.isRGB)
-            info[I18N.tr("Input")] = Utils.plotVolt(inputGate.signalVoltage)
+            info[tr("Input")] = Utils.plotVolt(inputGate.signalVoltage)
         else
-            info[I18N.tr("Input")] = if (inputGate.stateHigh()) I18N.tr("ON") else I18N.tr("OFF")
+            info[tr("Input")] = if (inputGate.stateHigh()) tr("ON") else tr("OFF")
         return info
     }
 

--- a/src/main/kotlin/mods/eln/sixnode/EmergencyLamp.kt
+++ b/src/main/kotlin/mods/eln/sixnode/EmergencyLamp.kt
@@ -78,11 +78,11 @@ class EmergencyLampDescriptor(name: String, val cable: ElectricalCableDescriptor
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>,
                                 par4: Boolean) {
         with(list) {
-            add("As long as power is provided, the internal battery")
-            add("is charged and the lamp is off. On a power failure,")
-            add("the lamp turns on and runs on batteries.")
-            add(Utils.plotVolt("Nominal voltage:", cable.electricalNominalVoltage))
-            add(Utils.plotEnergy("Battery capacity:", batteryCapacity))
+            add(tr("As long as power is provided, the internal battery"))
+            add(tr("is charged and the lamp is off. On a power failure,"))
+            add(tr("the lamp turns on and runs on batteries."))
+            add(Utils.plotVolt(tr("Nominal voltage:"), cable.electricalNominalVoltage))
+            add(Utils.plotEnergy(tr("Battery capacity:"), batteryCapacity))
         }
     }
 }
@@ -182,13 +182,13 @@ class EmergencyLampElement(sixNode: SixNode, side: Direction, descriptor: SixNod
     }
     override fun thermoMeterString(): String = ""
     override fun getWaila() = mapOf(
-        "State" to when {
-            on -> "On"
-            chargingResistor.state -> "Charging..."
-            charge <= 0.0 -> "Batteries empty"
-            else -> "Fully charged"
+        tr("State") to when {
+            on -> tr("On")
+            chargingResistor.state -> tr("Charging...")
+            charge <= 0.0 -> tr("Batteries empty")
+            else -> tr("Fully charged")
         },
-        "Charge" to Utils.plotPercent("", charge / (sixNodeElementDescriptor as EmergencyLampDescriptor).batteryCapacity)
+        tr("Charge") to Utils.plotPercent("", charge / (sixNodeElementDescriptor as EmergencyLampDescriptor).batteryCapacity)
     )
 
     override fun networkSerialize(stream: DataOutputStream) {

--- a/src/main/kotlin/mods/eln/sixnode/EmergencyLamp.kt
+++ b/src/main/kotlin/mods/eln/sixnode/EmergencyLamp.kt
@@ -78,11 +78,11 @@ class EmergencyLampDescriptor(name: String, val cable: ElectricalCableDescriptor
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>,
                                 par4: Boolean) {
         with(list) {
-            add(tr("As long as power is provided, the internal battery"))
-            add(tr("is charged and the lamp is off. On a power failure,"))
-            add(tr("the lamp turns on and runs on batteries."))
-            add(Utils.plotVolt(tr("Nominal voltage:"), cable.electricalNominalVoltage))
-            add(Utils.plotEnergy(tr("Battery capacity:"), batteryCapacity))
+            add("As long as power is provided, the internal battery")
+            add("is charged and the lamp is off. On a power failure,")
+            add("the lamp turns on and runs on batteries.")
+            add(Utils.plotVolt("Nominal voltage:", cable.electricalNominalVoltage))
+            add(Utils.plotEnergy("Battery capacity:", batteryCapacity))
         }
     }
 }
@@ -182,13 +182,13 @@ class EmergencyLampElement(sixNode: SixNode, side: Direction, descriptor: SixNod
     }
     override fun thermoMeterString(): String = ""
     override fun getWaila() = mapOf(
-        tr("State") to when {
-            on -> tr("On")
-            chargingResistor.state -> tr("Charging...")
-            charge <= 0.0 -> tr("Batteries empty")
-            else -> tr("Fully charged")
+        "State" to when {
+            on -> "On"
+            chargingResistor.state -> "Charging..."
+            charge <= 0.0 -> "Batteries empty"
+            else -> "Fully charged"
         },
-        tr("Charge") to Utils.plotPercent("", charge / (sixNodeElementDescriptor as EmergencyLampDescriptor).batteryCapacity)
+        "Charge" to Utils.plotPercent("", charge / (sixNodeElementDescriptor as EmergencyLampDescriptor).batteryCapacity)
     )
 
     override fun networkSerialize(stream: DataOutputStream) {

--- a/src/main/kotlin/mods/eln/sixnode/LogicGate.kt
+++ b/src/main/kotlin/mods/eln/sixnode/LogicGate.kt
@@ -210,8 +210,8 @@ abstract class LogicFunction : INBTTReady {
     open fun process(inputs: List<Boolean?>): Boolean = false
 
     open fun getWaila(inputs: Array<Double?>, output: Double) = mutableMapOf(
-        Pair(tr("Inputs"), (1..inputCount).map { "${AnalogFunction.inputColors[it - 1]}${inputs[it - 1].toDigitalString()}" }.joinToString(" ")),
-        Pair(tr("Output"), output.toDigitalString())
+        Pair("Inputs", (1..inputCount).map { "${AnalogFunction.inputColors[it - 1]}${inputs[it - 1].toDigitalString()}" }.joinToString(" ")),
+        Pair("Output", output.toDigitalString())
     )
 
     override fun readFromNBT(nbt: NBTTagCompound, str: String) {}
@@ -325,8 +325,8 @@ class Oscillator : LogicFunction() {
     }
 
     override fun getWaila(inputs: Array<Double?>, output: Double) = mutableMapOf(
-        Pair(tr("Inputs"), "${AnalogFunction.inputColors[0]} ${Utils.plotVolt("", inputs[0] ?: 0.0)}"),
-        Pair(tr("Output"), output.toDigitalString())
+        Pair("Inputs", "${AnalogFunction.inputColors[0]} ${Utils.plotVolt("", inputs[0] ?: 0.0)}"),
+        Pair("Output", output.toDigitalString())
     )
 
     override fun readFromNBT(nbt: NBTTagCompound, str: String) {

--- a/src/main/kotlin/mods/eln/sixnode/LogicGate.kt
+++ b/src/main/kotlin/mods/eln/sixnode/LogicGate.kt
@@ -210,8 +210,8 @@ abstract class LogicFunction : INBTTReady {
     open fun process(inputs: List<Boolean?>): Boolean = false
 
     open fun getWaila(inputs: Array<Double?>, output: Double) = mutableMapOf(
-        Pair("Inputs", (1..inputCount).map { "${AnalogFunction.inputColors[it - 1]}${inputs[it - 1].toDigitalString()}" }.joinToString(" ")),
-        Pair("Output", output.toDigitalString())
+        Pair(tr("Inputs"), (1..inputCount).map { "${AnalogFunction.inputColors[it - 1]}${inputs[it - 1].toDigitalString()}" }.joinToString(" ")),
+        Pair(tr("Output"), output.toDigitalString())
     )
 
     override fun readFromNBT(nbt: NBTTagCompound, str: String) {}
@@ -325,8 +325,8 @@ class Oscillator : LogicFunction() {
     }
 
     override fun getWaila(inputs: Array<Double?>, output: Double) = mutableMapOf(
-        Pair("Inputs", "${AnalogFunction.inputColors[0]} ${Utils.plotVolt("", inputs[0] ?: 0.0)}"),
-        Pair("Output", output.toDigitalString())
+        Pair(tr("Inputs"), "${AnalogFunction.inputColors[0]} ${Utils.plotVolt("", inputs[0] ?: 0.0)}"),
+        Pair(tr("Output"), output.toDigitalString())
     )
 
     override fun readFromNBT(nbt: NBTTagCompound, str: String) {

--- a/src/main/kotlin/mods/eln/sixnode/LogicGate.kt
+++ b/src/main/kotlin/mods/eln/sixnode/LogicGate.kt
@@ -199,9 +199,9 @@ abstract class LogicFunction : INBTTReady {
 
     protected fun Double?.toDigitalString(): String = when {
         this == null -> "-"
-        this >= 0.6 -> I18N.tr("ON")
-        this <= 0.2 -> I18N.tr("OFF")
-        else -> I18N.tr("UNDEF")
+        this >= 0.6 -> tr("ON")
+        this <= 0.2 -> tr("OFF")
+        else -> tr("UNDEF")
     }
 
     private fun Array<Double?>.toDigital(): List<Boolean?> = this.map { it?.toDigital() }

--- a/src/main/kotlin/mods/eln/sixnode/PowerCapacitor.kt
+++ b/src/main/kotlin/mods/eln/sixnode/PowerCapacitor.kt
@@ -178,11 +178,11 @@ class PowerCapacitorSixElement(SixNode: SixNode, side: Direction, descriptor: Si
 
     override fun getWaila(): Map<String, String> {
         val info: MutableMap<String, String> = HashMap()
-        info[I18N.tr("Capacity")] = Utils.plotValue(capacitor.coulombs, "F")
-        info[I18N.tr("Charge")] = Utils.plotEnergy("", capacitor.energy)
+        info[tr("Capacity")] = Utils.plotValue(capacitor.coulombs, "F")
+        info[tr("Charge")] = Utils.plotEnergy("", capacitor.energy)
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Voltage drop")] = Utils.plotVolt("", Math.abs(capacitor.voltage))
-            info[I18N.tr("Current")] = Utils.plotAmpere("", Math.abs(capacitor.current))
+            info[tr("Voltage drop")] = Utils.plotVolt("", Math.abs(capacitor.voltage))
+            info[tr("Current")] = Utils.plotAmpere("", Math.abs(capacitor.current))
         }
         return info
     }
@@ -319,8 +319,8 @@ class PowerCapacitorSixGui(player: EntityPlayer, inventory: IInventory, var rend
     }
 
     override fun postDraw(f: Float, x: Int, y: Int) {
-        helper.drawString(8, 8, -0x1000000, I18N.tr("Capacity: %1\$F", Utils.plotValue(render.descriptor.getCValue(render.inventory))))
-        helper.drawString(8, 8 + 8 + 1, -0x1000000, I18N.tr("Nominal voltage: %1\$V", Utils.plotValue(render.descriptor.getUNominalValue(render.inventory))))
+        helper.drawString(8, 8, -0x1000000, tr("Capacity: %1\$F", Utils.plotValue(render.descriptor.getCValue(render.inventory))))
+        helper.drawString(8, 8 + 8 + 1, -0x1000000, tr("Nominal voltage: %1\$V", Utils.plotValue(render.descriptor.getUNominalValue(render.inventory))))
         super.postDraw(f, x, y)
     }
 
@@ -331,9 +331,9 @@ class PowerCapacitorSixGui(player: EntityPlayer, inventory: IInventory, var rend
 
 class PowerCapacitorSixContainer(player: EntityPlayer, inventory: IInventory) : BasicContainer(player, inventory, arrayOf(
     SlotFilter(inventory, redId, 132, 8, 13, arrayOf(ItemStackFilter(Items.redstone)),
-        ISlotSkin.SlotSkin.medium, arrayOf(I18N.tr("Redstone slot"), I18N.tr("(Increases capacity)"))),
+        ISlotSkin.SlotSkin.medium, arrayOf(tr("Redstone slot"), tr("(Increases capacity)"))),
     GenericItemUsingDamageSlot(inventory, dielectricId, 132 + 20, 8, 20, DielectricItem::class.java,
-        ISlotSkin.SlotSkin.medium, arrayOf(I18N.tr("Dielectric slot"), I18N.tr("(Increases maximum voltage)")))
+        ISlotSkin.SlotSkin.medium, arrayOf(tr("Dielectric slot"), tr("(Increases maximum voltage)")))
 )) {
     companion object {
         const val redId = 0

--- a/src/main/kotlin/mods/eln/sixnode/PowerInductorSix.kt
+++ b/src/main/kotlin/mods/eln/sixnode/PowerInductorSix.kt
@@ -7,7 +7,7 @@ import mods.eln.gui.GuiContainerEln
 import mods.eln.gui.GuiHelperContainer
 import mods.eln.gui.IGuiObject
 import mods.eln.gui.ISlotSkin
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.CopperCableDescriptor
 import mods.eln.item.FerromagneticCoreDescriptor
 import mods.eln.item.IConfigurable
@@ -100,13 +100,13 @@ class PowerInductorSixDescriptor(name: String,
         par4: Boolean
     ) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list?.add(I18N.tr("Provides inductance. Use with iron cores and bare copper cables"))
+        list?.add(tr("Provides inductance. Use with iron cores and bare copper cables"))
     }
 
     override fun addRealismContext(list: MutableList<String>?): RealisticEnum {
         super.addRealismContext(list)
-        list?.add(I18N.tr("It doesn't really behave well for DC"))
-        list?.add(I18N.tr("* Missing an inductive voltage spike on field collapse"))
+        list?.add(tr("It doesn't really behave well for DC"))
+        list?.add(tr("* Missing an inductive voltage spike on field collapse"))
         return RealisticEnum.UNREALISTIC
     }
 
@@ -152,11 +152,11 @@ class PowerInductorSixElement(SixNode: SixNode, side: Direction, descriptor: Six
 
     override fun getWaila(): Map<String, String> {
         val info: MutableMap<String, String> = HashMap()
-        info[I18N.tr("Inductance")] = Utils.plotValue(inductor.inductance, "H")
-        info[I18N.tr("Charge")] = Utils.plotEnergy("", inductor.energy)
+        info[tr("Inductance")] = Utils.plotValue(inductor.inductance, "H")
+        info[tr("Charge")] = Utils.plotEnergy("", inductor.energy)
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Voltage drop")] = Utils.plotVolt("", abs(inductor.voltage))
-            info[I18N.tr("Current")] = Utils.plotAmpere("", abs(inductor.current))
+            info[tr("Voltage drop")] = Utils.plotVolt("", abs(inductor.voltage))
+            info[tr("Current")] = Utils.plotAmpere("", abs(inductor.current))
         }
         return info
     }
@@ -294,7 +294,7 @@ class PowerInductorSixGui(player: EntityPlayer, inventory: IInventory, var rende
     }
 
     override fun postDraw(f: Float, x: Int, y: Int) {
-        helper.drawString(8, 12, -0x1000000, I18N.tr("Inductance: %1\$H", Utils.plotValue(render.descriptor.getlValue(render.inventory))))
+        helper.drawString(8, 12, -0x1000000, tr("Inductance: %1\$H", Utils.plotValue(render.descriptor.getlValue(render.inventory))))
         super.postDraw(f, x, y)
     }
 
@@ -306,9 +306,9 @@ class PowerInductorSixGui(player: EntityPlayer, inventory: IInventory, var rende
 
 class PowerInductorSixContainer(player: EntityPlayer, inventory: IInventory) : BasicContainer(player, inventory, arrayOf<Slot>(
     GenericItemUsingDamageSlot(inventory, cableId, 132, 8, 19, CopperCableDescriptor::class.java,
-        ISlotSkin.SlotSkin.medium, arrayOf(I18N.tr("Copper cable slot"), I18N.tr("(Increases inductance)"))),
+        ISlotSkin.SlotSkin.medium, arrayOf(tr("Copper cable slot"), tr("(Increases inductance)"))),
     GenericItemUsingDamageSlot(inventory, coreId, 132 + 20, 8, 1, FerromagneticCoreDescriptor::class.java,
-        ISlotSkin.SlotSkin.medium, arrayOf(I18N.tr("Ferromagnetic core slot")))
+        ISlotSkin.SlotSkin.medium, arrayOf(tr("Ferromagnetic core slot")))
 )) {
     companion object {
         const val cableId = 0

--- a/src/main/kotlin/mods/eln/sixnode/PowerSinkSix.kt
+++ b/src/main/kotlin/mods/eln/sixnode/PowerSinkSix.kt
@@ -5,7 +5,7 @@ import mods.eln.cable.CableRenderDescriptor
 import mods.eln.gui.GuiHelper
 import mods.eln.gui.GuiScreenEln
 import mods.eln.gui.GuiTextFieldEln
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.IConfigurable
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
@@ -43,11 +43,11 @@ class PowerSinkDescriptor(name: String, obj: Obj3D) : SixNodeDescriptor(name, Po
 
     override fun addInformation(itemStack: ItemStack, entityPlayer: EntityPlayer, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        Collections.addAll<String>(list, *I18N.tr("Provides an ideal power sink\nwithout energy or power limitation.").split("\n").toTypedArray())
+        Collections.addAll<String>(list, *tr("Provides an ideal power sink\nwithout energy or power limitation.").split("\n").toTypedArray())
         list.add("")
-        list.add(I18N.tr("Internal resistance: %1$\u2126", Utils.plotValue(Eln.instance.lowVoltageCableDescriptor.electricalRs)))
+        list.add(tr("Internal resistance: %1$\u2126", Utils.plotValue(Eln.instance.lowVoltageCableDescriptor.electricalRs)))
         list.add("")
-        list.add(I18N.tr("Creative block."))
+        list.add(tr("Creative block."))
     }
 
     override fun handleRenderType(item: ItemStack, type: IItemRenderer.ItemRenderType): Boolean {
@@ -108,10 +108,10 @@ class PowerSinkElement(sixNode: SixNode, side: Direction, descriptor: SixNodeDes
 
     override fun getWaila(): Map<String, String> {
         val info: MutableMap<String, String> = HashMap()
-        info[I18N.tr("Voltage")] = Utils.plotVolt("", electricalLoad.voltage)
-        info[I18N.tr("Current")] = Utils.plotAmpere("", electricalLoad.current)
+        info[tr("Voltage")] = Utils.plotVolt("", electricalLoad.voltage)
+        info[tr("Current")] = Utils.plotAmpere("", electricalLoad.current)
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Power")] = Utils.plotPower("", electricalLoad.voltage * electricalLoad.current)
+            info[tr("Power")] = Utils.plotPower("", electricalLoad.voltage * electricalLoad.current)
         }
         return info
     }
@@ -181,7 +181,7 @@ class PowerSinkGui(var render: PowerSinkRender) : GuiScreenEln() {
         current = newGuiTextField(6, 6, 50)
         current!!.setText(render.current.toFloat())
         current!!.setObserver(this)
-        current!!.setComment(arrayOf(I18N.tr("Power sourced")))
+        current!!.setComment(arrayOf(tr("Power sourced")))
     }
 
     override fun textFieldNewValue(textField: GuiTextFieldEln, value: String) {

--- a/src/main/kotlin/mods/eln/sixnode/PowerSourceSix.kt
+++ b/src/main/kotlin/mods/eln/sixnode/PowerSourceSix.kt
@@ -5,7 +5,7 @@ import mods.eln.cable.CableRenderDescriptor
 import mods.eln.gui.GuiHelper
 import mods.eln.gui.GuiScreenEln
 import mods.eln.gui.GuiTextFieldEln
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.IConfigurable
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
@@ -43,11 +43,11 @@ class PowerSourceDescriptor(name: String, obj: Obj3D) : SixNodeDescriptor(name, 
 
     override fun addInformation(itemStack: ItemStack, entityPlayer: EntityPlayer, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        Collections.addAll<String>(list, *I18N.tr("Provides an ideal power source\nwithout energy or power limitation.").split("\n").toTypedArray())
+        Collections.addAll<String>(list, *tr("Provides an ideal power source\nwithout energy or power limitation.").split("\n").toTypedArray())
         list.add("")
-        list.add(I18N.tr("Internal resistance: %1$\u2126", Utils.plotValue(Eln.instance.lowVoltageCableDescriptor.electricalRs)))
+        list.add(tr("Internal resistance: %1$\u2126", Utils.plotValue(Eln.instance.lowVoltageCableDescriptor.electricalRs)))
         list.add("")
-        list.add(I18N.tr("Creative block."))
+        list.add(tr("Creative block."))
     }
 
     override fun handleRenderType(item: ItemStack, type: IItemRenderer.ItemRenderType): Boolean {
@@ -108,10 +108,10 @@ class PowerSourceElement(sixNode: SixNode, side: Direction, descriptor: SixNodeD
 
     override fun getWaila(): Map<String, String> {
         val info: MutableMap<String, String> = HashMap()
-        info[I18N.tr("Voltage")] = Utils.plotVolt("", electricalLoad.voltage)
-        info[I18N.tr("Current")] = Utils.plotAmpere("", electricalLoad.current)
+        info[tr("Voltage")] = Utils.plotVolt("", electricalLoad.voltage)
+        info[tr("Current")] = Utils.plotAmpere("", electricalLoad.current)
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Power")] = Utils.plotPower("", electricalLoad.voltage * electricalLoad.current)
+            info[tr("Power")] = Utils.plotPower("", electricalLoad.voltage * electricalLoad.current)
         }
         return info
     }
@@ -181,7 +181,7 @@ class PowerSourceGui(var render: PowerSourceRender) : GuiScreenEln() {
         current = newGuiTextField(6, 6, 50)
         current!!.setText(render.current.toFloat())
         current!!.setObserver(this)
-        current!!.setComment(arrayOf(I18N.tr("Power sourced")))
+        current!!.setComment(arrayOf(tr("Power sourced")))
     }
 
     override fun textFieldNewValue(textField: GuiTextFieldEln, value: String) {

--- a/src/main/kotlin/mods/eln/sixnode/currentcable/CurrentCable.kt
+++ b/src/main/kotlin/mods/eln/sixnode/currentcable/CurrentCable.kt
@@ -4,7 +4,7 @@ import mods.eln.Eln
 import mods.eln.cable.CableRender
 import mods.eln.cable.CableRenderDescriptor
 import mods.eln.generic.GenericItemUsingDamageDescriptor.Companion.getDescriptor
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.BrushDescriptor
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
@@ -101,19 +101,19 @@ class CurrentCableDescriptor(
 
     override fun addInformation(itemStack: ItemStack, entityPlayer: EntityPlayer, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list.add(I18N.tr("Nominal Ratings:"))
-        list.add("  " + I18N.tr("Voltage: %1\$V", plotValue(electricalNominalVoltage)))
-        list.add("  " + I18N.tr("Current: %1\$A", plotValue(electricalNominalPower / electricalNominalVoltage)))
-        list.add("  " + I18N.tr("Power: %1\$W", plotValue(electricalNominalPower)))
-        list.add("  " + I18N.tr("Serial resistance: %1$\u2126", plotValue(electricalRs * 2)))
+        list.add(tr("Nominal Ratings:"))
+        list.add("  " + tr("Voltage: %1\$V", plotValue(electricalNominalVoltage)))
+        list.add("  " + tr("Current: %1\$A", plotValue(electricalNominalPower / electricalNominalVoltage)))
+        list.add("  " + tr("Power: %1\$W", plotValue(electricalNominalPower)))
+        list.add("  " + tr("Serial resistance: %1$\u2126", plotValue(electricalRs * 2)))
     }
 
     override fun addRealismContext(list: MutableList<String>): RealisticEnum? {
-        list.add(I18N.tr("Has some caveats:"))
-        list.add(I18N.tr("  * Wire resistance is much higher than normal"))
-        list.add(I18N.tr("  * Wire resistance is not impacted by temperature"))
-        list.add(I18N.tr("  * Wire voltage limits are arbitrary values, picked to within reasonable simulator error"))
-        list.add(I18N.tr("  * Wire current limits are arbitrary values, added as a gameplay mechanic"))
+        list.add(tr("Has some caveats:"))
+        list.add(tr("  * Wire resistance is much higher than normal"))
+        list.add(tr("  * Wire resistance is not impacted by temperature"))
+        list.add(tr("  * Wire voltage limits are arbitrary values, picked to within reasonable simulator error"))
+        list.add(tr("  * Wire current limits are arbitrary values, added as a gameplay mechanic"))
         return RealisticEnum.REALISTIC
     }
 
@@ -192,12 +192,12 @@ open class CurrentCableElement(sixNode: SixNode?, side: Direction?, descriptor: 
 
     override fun getWaila(): Map<String, String> {
         val info: MutableMap<String, String> = HashMap()
-        info[I18N.tr("Current")] = plotAmpere("", electricalLoad.current)
-        info[I18N.tr("Temperature")] = plotCelsius("", thermalLoad.temperature)
+        info[tr("Current")] = plotAmpere("", electricalLoad.current)
+        info[tr("Temperature")] = plotCelsius("", thermalLoad.temperature)
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Voltage")] = plotVolt("", electricalLoad.voltage)
+            info[tr("Voltage")] = plotVolt("", electricalLoad.voltage)
         }
-        info[I18N.tr("Subsystem Matrix Size")] = renderSubSystemWaila(electricalLoad.subSystem)
+        info[tr("Subsystem Matrix Size")] = renderSubSystemWaila(electricalLoad.subSystem)
         return info
     }
 

--- a/src/main/kotlin/mods/eln/sixnode/powersocket/PowerSocketDescriptor.kt
+++ b/src/main/kotlin/mods/eln/sixnode/powersocket/PowerSocketDescriptor.kt
@@ -1,6 +1,6 @@
 package mods.eln.sixnode.powersocket
 
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
 import mods.eln.misc.Obj3D.Obj3DPart
 import mods.eln.misc.Utils.setGlColorFromDye
@@ -81,14 +81,14 @@ class PowerSocketDescriptor(subID: Int, name: String, obj: Obj3D) :
     ) {
         super.addInformation(itemStack, entityPlayer, list, par4)
 
-        list?.addAll(I18N.tr("Supplies any device\nplugged in with energy.").split("\n".toRegex())
+        list?.addAll(tr("Supplies any device\nplugged in with energy.").split("\n".toRegex())
             .dropLastWhile { it.isEmpty() }
             .toTypedArray())
     }
 
     override fun addRealismContext(list: MutableList<String?>): RealisticEnum {
         super.addRealismContext(list)
-        list.add(I18N.tr("Homes have power sockets. These are not them."))
+        list.add(tr("Homes have power sockets. These are not them."))
         return RealisticEnum.UNREALISTIC
     }
 

--- a/src/main/kotlin/mods/eln/sixnode/powersocket/PowerSocketGui.kt
+++ b/src/main/kotlin/mods/eln/sixnode/powersocket/PowerSocketGui.kt
@@ -4,7 +4,7 @@ import mods.eln.gui.GuiHelperContainer
 import mods.eln.gui.GuiScreenEln
 import mods.eln.gui.GuiTextFieldEln
 import mods.eln.gui.IGuiObject
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.inventory.IInventory
 
@@ -17,7 +17,7 @@ class PowerSocketGui(private val render: PowerSocketRender, player: EntityPlayer
 
         device = newGuiTextField(8, 8, 138)
         device?.setText(render.channel)
-        device?.setComment(0, I18N.tr("Specify the power channel"))
+        device?.setComment(0, tr("Specify the power channel"))
     }
 
     override fun newHelper(): GuiHelperContainer {

--- a/src/main/kotlin/mods/eln/transparentnode/DcDc.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/DcDc.kt
@@ -336,10 +336,10 @@ class DcDcElement(transparentNode: TransparentNode, descriptor: TransparentNodeD
         val info = HashMap<String, String>()
         info[I18N.tr("Ratio")] = Utils.plotValue(interSystemProcess.ratio)
         if (Eln.wailaEasyMode) {
-            info["Voltages"] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
+            info[I18N.tr("Voltages")] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
                 "\u00A7e" + Utils.plotVolt("", secondaryLoad.voltage)
         }
-        info[I18N.tr("Subsystem Matrix Size: ")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
+        info[I18N.tr("Subsystem Matrix Size")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
         return info
     }
 

--- a/src/main/kotlin/mods/eln/transparentnode/DcDc.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/DcDc.kt
@@ -336,10 +336,10 @@ class DcDcElement(transparentNode: TransparentNode, descriptor: TransparentNodeD
         val info = HashMap<String, String>()
         info[I18N.tr("Ratio")] = Utils.plotValue(interSystemProcess.ratio)
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Voltages")] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
+            info["Voltages"] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
                 "\u00A7e" + Utils.plotVolt("", secondaryLoad.voltage)
         }
-        info[I18N.tr("Subsystem Matrix Size")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
+        info[I18N.tr("Subsystem Matrix Size: ")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
         return info
     }
 

--- a/src/main/kotlin/mods/eln/transparentnode/DcDc.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/DcDc.kt
@@ -9,7 +9,7 @@ import mods.eln.generic.GenericItemUsingDamageSlot
 import mods.eln.gui.GuiContainerEln
 import mods.eln.gui.GuiHelperContainer
 import mods.eln.gui.ISlotSkin.SlotSkin
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.CaseItemDescriptor
 import mods.eln.item.ConfigCopyToolDescriptor
 import mods.eln.item.CopperCableDescriptor
@@ -83,12 +83,12 @@ class DcDcDescriptor(name: String, objM: Obj3D, coreM: Obj3D, casingM: Obj3D, va
 
     override fun addInformation(itemStack: ItemStack, entityPlayer: EntityPlayer, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        Collections.addAll(list, *I18N.tr("Transforms an input voltage to\nan output voltage.")!!.split("\n".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray())
+        Collections.addAll(list, *tr("Transforms an input voltage to\nan output voltage.")!!.split("\n".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray())
     }
 
     override fun addRealismContext(list: MutableList<String>?): RealisticEnum {
-        list?.add(I18N.tr("This DC/DC has unrealistic capacitance effects and can sink/source power that violates Newton's laws"))
-        list?.add(I18N.tr("It is made this way to improve the performance of the simulator in large power networks"))
+        list?.add(tr("This DC/DC has unrealistic capacitance effects and can sink/source power that violates Newton's laws"))
+        list?.add(tr("It is made this way to improve the performance of the simulator in large power networks"))
         return RealisticEnum.UNREALISTIC
     }
 
@@ -334,12 +334,12 @@ class DcDcElement(transparentNode: TransparentNode, descriptor: TransparentNodeD
 
     override fun getWaila(): Map<String, String> {
         val info = HashMap<String, String>()
-        info[I18N.tr("Ratio")] = Utils.plotValue(interSystemProcess.ratio)
+        info[tr("Ratio")] = Utils.plotValue(interSystemProcess.ratio)
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Voltages")] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
+            info[tr("Voltages")] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
                 "\u00A7e" + Utils.plotVolt("", secondaryLoad.voltage)
         }
-        info[I18N.tr("Subsystem Matrix Size")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
+        info[tr("Subsystem Matrix Size")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
         return info
     }
 
@@ -526,16 +526,16 @@ class DcDcContainer(player: EntityPlayer, inventory: IInventory) : BasicContaine
     arrayOf(
         GenericItemUsingDamageSlot(inventory, primaryCableSlotId, 58, 30, 16,
             arrayOf<Class<*>>(CopperCableDescriptor::class.java),
-            SlotSkin.medium, arrayOf(I18N.tr("Copper cable slot"))),
+            SlotSkin.medium, arrayOf(tr("Copper cable slot"))),
         GenericItemUsingDamageSlot(inventory, secondaryCableSlotId, 100, 30, 16,
             arrayOf<Class<*>>(CopperCableDescriptor::class.java),
-            SlotSkin.medium, arrayOf(I18N.tr("Copper cable slot"))),
+            SlotSkin.medium, arrayOf(tr("Copper cable slot"))),
         GenericItemUsingDamageSlot(inventory, ferromagneticSlotId, 58 + (100 - 58) / 2, 30, 1,
             arrayOf<Class<*>>(FerromagneticCoreDescriptor::class.java),
-            SlotSkin.medium, arrayOf(I18N.tr("Ferromagnetic core slot"))),
+            SlotSkin.medium, arrayOf(tr("Ferromagnetic core slot"))),
         GenericItemUsingDamageSlot(inventory, CasingSlotId, 130, 74, 1,
             arrayOf<Class<*>>(CaseItemDescriptor::class.java),
-            SlotSkin.medium, arrayOf(I18N.tr("Casing slot")))))
+            SlotSkin.medium, arrayOf(tr("Casing slot")))))
     {
     companion object {
         const val primaryCableSlotId = 0

--- a/src/main/kotlin/mods/eln/transparentnode/Fabricator.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/Fabricator.kt
@@ -4,7 +4,6 @@ import mods.eln.Eln
 import mods.eln.generic.GenericItemUsingDamageDescriptor
 import mods.eln.gui.*
 import mods.eln.gui.ISlotSkin.SlotSkin
-import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.node.INodeContainer
 import mods.eln.node.NodeBase
@@ -59,8 +58,8 @@ class FabricatorDescriptor(
 
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>?, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list?.addAll(I18N.tr("The Fabricator creates chips\nfrom silicon and copper plates").split("\n"))
-        list?.add(I18N.tr("Nominal Ohms: %1$",Utils.plotOhm(40.0)))
+        list?.addAll("The Fabricator creates chips\nfrom silicon and copper plates".split("\n"))
+        list?.add("Nominal Ohms: ${Utils.plotOhm(40.0)}")
     }
 }
 
@@ -90,7 +89,7 @@ class FabricatorElement(node: TransparentNode, descriptor: TransparentNodeDescri
     override fun thermoMeterString(side: Direction): String = ""
 
     override fun getWaila(): Map<String, String> {
-        return mapOf(Pair(I18N.tr("Operation"), operation?.outputItem?.displayName ?: "None"))
+        return mapOf(Pair("Operation", operation?.opName?: "None"))
     }
 
     override fun initialize() {

--- a/src/main/kotlin/mods/eln/transparentnode/Fabricator.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/Fabricator.kt
@@ -4,6 +4,7 @@ import mods.eln.Eln
 import mods.eln.generic.GenericItemUsingDamageDescriptor
 import mods.eln.gui.*
 import mods.eln.gui.ISlotSkin.SlotSkin
+import mods.eln.i18n.I18N
 import mods.eln.misc.*
 import mods.eln.node.INodeContainer
 import mods.eln.node.NodeBase
@@ -58,8 +59,8 @@ class FabricatorDescriptor(
 
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>?, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list?.addAll("The Fabricator creates chips\nfrom silicon and copper plates".split("\n"))
-        list?.add("Nominal Ohms: ${Utils.plotOhm(40.0)}")
+        list?.addAll(I18N.tr("The Fabricator creates chips\nfrom silicon and copper plates").split("\n"))
+        list?.add(I18N.tr("Nominal Ohms: %1$",Utils.plotOhm(40.0)))
     }
 }
 
@@ -89,7 +90,7 @@ class FabricatorElement(node: TransparentNode, descriptor: TransparentNodeDescri
     override fun thermoMeterString(side: Direction): String = ""
 
     override fun getWaila(): Map<String, String> {
-        return mapOf(Pair("Operation", operation?.opName?: "None"))
+        return mapOf(Pair(I18N.tr("Operation"), operation?.outputItem?.displayName ?: "None"))
     }
 
     override fun initialize() {

--- a/src/main/kotlin/mods/eln/transparentnode/Fabricator.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/Fabricator.kt
@@ -4,7 +4,7 @@ import mods.eln.Eln
 import mods.eln.generic.GenericItemUsingDamageDescriptor
 import mods.eln.gui.*
 import mods.eln.gui.ISlotSkin.SlotSkin
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
 import mods.eln.node.INodeContainer
 import mods.eln.node.NodeBase
@@ -59,8 +59,8 @@ class FabricatorDescriptor(
 
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>?, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list?.addAll(I18N.tr("The Fabricator creates chips\nfrom silicon and copper plates").split("\n"))
-        list?.add(I18N.tr("Nominal Ohms: %1$",Utils.plotOhm(40.0)))
+        list?.addAll(tr("The Fabricator creates chips\nfrom silicon and copper plates").split("\n"))
+        list?.add(tr("Nominal Ohms: %1$",Utils.plotOhm(40.0)))
     }
 }
 
@@ -90,7 +90,7 @@ class FabricatorElement(node: TransparentNode, descriptor: TransparentNodeDescri
     override fun thermoMeterString(side: Direction): String = ""
 
     override fun getWaila(): Map<String, String> {
-        return mapOf(Pair(I18N.tr("Operation"), operation?.outputItem?.displayName ?: "None"))
+        return mapOf(Pair(tr("Operation"), operation?.outputItem?.displayName ?: "None"))
     }
 
     override fun initialize() {

--- a/src/main/kotlin/mods/eln/transparentnode/FuelGenerator.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/FuelGenerator.kt
@@ -222,10 +222,10 @@ class FuelGeneratorElement(transparentNode: TransparentNode, descriptor_: Transp
     }
 
     override fun getWaila(): Map<String, String> = mutableMapOf(
-        Pair(I18N.tr("State"), if (on) I18N.tr("ON") else I18N.tr("OFF")),
-        Pair(I18N.tr("Fuel level"), Utils.plotPercent("", tankLevel)),
-        Pair(I18N.tr("Generated power"), Utils.plotPower("", powerSource.effectivePower)),
-        Pair(I18N.tr("Voltage"), Utils.plotVolt("", powerSource.voltage))
+        Pair(tr("State"), if (on) tr("ON") else tr("OFF")),
+        Pair(tr("Fuel level"), Utils.plotPercent("", tankLevel)),
+        Pair(tr("Generated power"), Utils.plotPower("", powerSource.effectivePower)),
+        Pair(tr("Voltage"), Utils.plotVolt("", powerSource.voltage))
     )
 }
 

--- a/src/main/kotlin/mods/eln/transparentnode/FuelHeatFurnace.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/FuelHeatFurnace.kt
@@ -6,7 +6,7 @@ import mods.eln.fluid.PreciseElementFluidHandler
 import mods.eln.generic.GenericItemUsingDamageSlot
 import mods.eln.gui.*
 import mods.eln.gui.ISlotSkin.SlotSkin
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.FuelBurnerDescriptor
 import mods.eln.item.regulator.IRegulatorDescriptor
 import mods.eln.item.regulator.IRegulatorDescriptor.RegulatorType
@@ -85,8 +85,8 @@ class FuelHeatFurnaceDescriptor(name: String, model: Obj3D, val thermal: Thermal
 
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list.add(I18N.tr("Generates heat when supplied with fuel."))
-        list.add(Utils.plotCelsius(I18N.tr("  Max. temperature: "), thermal.maximumTemperature))
+        list.add(tr("Generates heat when supplied with fuel."))
+        list.add(Utils.plotCelsius(tr("  Max. temperature: "), thermal.maximumTemperature))
     }
 }
 
@@ -246,8 +246,8 @@ class FuelHeatFurnaceElement(transparentNode: TransparentNode, descriptor: Trans
 
     override fun getWaila(): MutableMap<String, String> {
         val info = HashMap<String, String>()
-        info.put(I18N.tr("Temperature"), Utils.plotCelsius("", thermalLoad.temperatureCelsius))
-        info.put(I18N.tr("Power"), Utils.plotPower("", actualHeatPower))
+        info.put(tr("Temperature"), Utils.plotCelsius("", thermalLoad.temperatureCelsius))
+        info.put(tr("Power"), Utils.plotPower("", actualHeatPower))
         return info
     }
 
@@ -316,9 +316,9 @@ class FuelHeatFurnaceRender(tileEntity: TransparentNodeEntity, descriptor: Trans
 class FuelHeatFurnaceContainer(val base: NodeBase?, player: EntityPlayer, inventory: IInventory) :
     BasicContainer(player, inventory,
         arrayOf(GenericItemUsingDamageSlot(inventory, FuelBurnerSlot, 26, 58, 1, FuelBurnerDescriptor::class.java,
-            SlotSkin.medium, arrayOf(I18N.tr("Fuel burner slot"))),
+            SlotSkin.medium, arrayOf(tr("Fuel burner slot"))),
             RegulatorSlot(inventory, RegulatorSlot, 8, 58, 1, arrayOf(RegulatorType.Analog),
-                SlotSkin.medium, I18N.tr("Analog regulator slot")))), INodeContainer {
+                SlotSkin.medium, tr("Analog regulator slot")))), INodeContainer {
     companion object {
         val FuelBurnerSlot = 0
         val RegulatorSlot = 1
@@ -358,14 +358,14 @@ class FuelHeatFurnaceGui(player: EntityPlayer, val inventory: IInventory, val re
         super.preDraw(f, x, y)
 
         if (!render.externalControlled)
-            externalControlled.displayString = I18N.tr("Internal control")
+            externalControlled.displayString = tr("Internal control")
         else
-            externalControlled.displayString = I18N.tr("External control")
+            externalControlled.displayString = tr("External control")
 
         if (render.mainSwitch)
-            mainSwitch.displayString = I18N.tr("Furnace is on")
+            mainSwitch.displayString = tr("Furnace is on")
         else
-            mainSwitch.displayString = I18N.tr("Furnace is off")
+            mainSwitch.displayString = tr("Furnace is off")
         mainSwitch.enabled = inventory.getStackInSlot(FuelHeatFurnaceContainer.FuelBurnerSlot) != null
 
         if (render.manualControl.pending) {
@@ -373,8 +373,8 @@ class FuelHeatFurnaceGui(player: EntityPlayer, val inventory: IInventory, val re
         }
         manualControl.setEnable(inventory.getStackInSlot(FuelHeatFurnaceContainer.RegulatorSlot) == null &&
             !render.externalControlled)
-        manualControl.setComment(0, I18N.tr("Control value at %1$", Utils.plotPercent("", manualControl.value.toDouble())))
-        manualControl.setComment(1, I18N.tr("Heat Power: %1$", Utils.plotPower("", render.heatPower.toDouble())))
+        manualControl.setComment(0, Utils.plotPercent(tr("Control value at "), manualControl.value.toDouble()))
+        manualControl.setComment(1, Utils.plotPower(tr("Heat Power: "), render.heatPower.toDouble()))
 
         if (render.setTemperature.pending) {
             setTemperature.value = render.setTemperature.value
@@ -382,10 +382,10 @@ class FuelHeatFurnaceGui(player: EntityPlayer, val inventory: IInventory, val re
         setTemperature.setEnable(inventory.getStackInSlot(FuelHeatFurnaceContainer.RegulatorSlot) != null &&
             !render.externalControlled)
         setTemperature.temperatureHit = Math.max(0f, render.actualTemperature)
-        setTemperature.setComment(0, I18N.tr("Temperature"))
-        setTemperature.setComment(1, I18N.tr("Actual: %1$", Utils.plotCelsius("", render.actualTemperature.toDouble())))
+        setTemperature.setComment(0, tr("Temperature"))
+        setTemperature.setComment(1, Utils.plotCelsius(tr("Actual: "), render.actualTemperature.toDouble()))
         if (!render.externalControlled)
-            setTemperature.setComment(2, I18N.tr("Set point: %1$", Utils.plotCelsius("", setTemperature.value.toDouble())))
+            setTemperature.setComment(2, Utils.plotCelsius(tr("Set point: "), setTemperature.value.toDouble()))
     }
 
     override fun guiObjectEvent(sender: IGuiObject?) {

--- a/src/main/kotlin/mods/eln/transparentnode/LargeRheostat.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/LargeRheostat.kt
@@ -195,9 +195,9 @@ class LargeRheostatElement(node: TransparentNode, desc_: TransparentNodeDescript
     override fun newContainer(side: Direction, player: EntityPlayer) = ResistorContainer(player, inventory)
 
     override fun getWaila(): Map<String, String> = mutableMapOf(
-        Pair(I18N.tr("Resistance"), Utils.plotOhm("", resistor.resistance)),
-        Pair(I18N.tr("Temperature"), Utils.plotCelsius("", thermalLoad.temperature)),
-        Pair(I18N.tr("Power loss"), Utils.plotPower("", resistor.power))
+        Pair(tr("Resistance"), Utils.plotOhm("", resistor.resistance)),
+        Pair(tr("Temperature"), Utils.plotCelsius("", thermalLoad.temperature)),
+        Pair(tr("Power loss"), Utils.plotPower("", resistor.power))
     )
 }
 

--- a/src/main/kotlin/mods/eln/transparentnode/LargeRheostat.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/LargeRheostat.kt
@@ -253,7 +253,7 @@ class LargeRheostatGUI(player: EntityPlayer, inventory: IInventory, internal var
     GuiContainerEln(ResistorContainer(player, inventory)) {
 
     override fun postDraw(f: Float, x: Int, y: Int) {
-        helper.drawString(8, 12, -16777216, tr("Nom. Resistance: %1$", Utils.plotValue(render.desc.getRsValue(render.inventory), "Ω")))
+        helper.drawString(8, 12, -16777216, tr("Nom. Resistance: %1$", Utils.plotValue(render.desc.getRsValue(render.inventory), "Ohm")))
         super.postDraw(f, x, y)
     }
 

--- a/src/main/kotlin/mods/eln/transparentnode/LargeRheostat.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/LargeRheostat.kt
@@ -253,7 +253,7 @@ class LargeRheostatGUI(player: EntityPlayer, inventory: IInventory, internal var
     GuiContainerEln(ResistorContainer(player, inventory)) {
 
     override fun postDraw(f: Float, x: Int, y: Int) {
-        helper.drawString(8, 12, -16777216, tr("Nom. Resistance: %1$", Utils.plotValue(render.desc.getRsValue(render.inventory), "Ohm")))
+        helper.drawString(8, 12, -16777216, tr("Nom. Resistance: %1$", Utils.plotValue(render.desc.getRsValue(render.inventory), "Ω")))
         super.postDraw(f, x, y)
     }
 

--- a/src/main/kotlin/mods/eln/transparentnode/LegacyDcDc.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/LegacyDcDc.kt
@@ -343,10 +343,10 @@ class LegacyDcDcElement(transparentNode: TransparentNode, descriptor: Transparen
         val info = HashMap<String, String>()
         info[I18N.tr("Ratio")] = Utils.plotValue(interSystemProcess.ratio)
         if (Eln.wailaEasyMode) {
-            info["Voltages"] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
+            info[I18N.tr("Voltages")] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
                 "\u00A7e" + Utils.plotVolt("", secondaryLoad.voltage)
         }
-        info[I18N.tr("Subsystem Matrix Size: ")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
+        info[I18N.tr("Subsystem Matrix Size")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
         return info
     }
 

--- a/src/main/kotlin/mods/eln/transparentnode/LegacyDcDc.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/LegacyDcDc.kt
@@ -9,7 +9,7 @@ import mods.eln.generic.GenericItemUsingDamageSlot
 import mods.eln.gui.GuiContainerEln
 import mods.eln.gui.GuiHelperContainer
 import mods.eln.gui.ISlotSkin.SlotSkin
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.item.CaseItemDescriptor
 import mods.eln.item.ConfigCopyToolDescriptor
 import mods.eln.item.FerromagneticCoreDescriptor
@@ -92,7 +92,7 @@ class LegacyDcDcDescriptor(name: String, objM: Obj3D, coreM: Obj3D, casingM: Obj
 
     override fun addInformation(itemStack: ItemStack, entityPlayer: EntityPlayer, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        Collections.addAll(list, *I18N.tr("Transforms an input voltage to\nan output voltage.")!!.split("\n".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray())
+        Collections.addAll(list, *tr("Transforms an input voltage to\nan output voltage.")!!.split("\n".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray())
     }
 
     override fun shouldUseRenderHelper(type: IItemRenderer.ItemRenderType, item: ItemStack, helper: IItemRenderer.ItemRendererHelper): Boolean {
@@ -341,12 +341,12 @@ class LegacyDcDcElement(transparentNode: TransparentNode, descriptor: Transparen
 
     override fun getWaila(): Map<String, String> {
         val info = HashMap<String, String>()
-        info[I18N.tr("Ratio")] = Utils.plotValue(interSystemProcess.ratio)
+        info[tr("Ratio")] = Utils.plotValue(interSystemProcess.ratio)
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Voltages")] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
+            info[tr("Voltages")] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
                 "\u00A7e" + Utils.plotVolt("", secondaryLoad.voltage)
         }
-        info[I18N.tr("Subsystem Matrix Size")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
+        info[tr("Subsystem Matrix Size")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
         return info
     }
 
@@ -533,16 +533,16 @@ class LegacyDcDcContainer(player: EntityPlayer, inventory: IInventory) : BasicCo
     arrayOf(
         SixNodeItemSlot(inventory, primaryCableSlotId, 58, 30, 16,
             arrayOf<Class<*>>(ElectricalCableDescriptor::class.java),
-            SlotSkin.medium, arrayOf(I18N.tr("Electrical cable slot"))),
+            SlotSkin.medium, arrayOf(tr("Electrical cable slot"))),
         SixNodeItemSlot(inventory, secondaryCableSlotId, 100, 30, 16,
             arrayOf<Class<*>>(ElectricalCableDescriptor::class.java),
-            SlotSkin.medium, arrayOf(I18N.tr("Electrical cable slot"))),
+            SlotSkin.medium, arrayOf(tr("Electrical cable slot"))),
         GenericItemUsingDamageSlot(inventory, ferromagneticSlotId, 58 + (100 - 58) / 2, 30, 1,
             arrayOf<Class<*>>(FerromagneticCoreDescriptor::class.java),
-            SlotSkin.medium, arrayOf(I18N.tr("Ferromagnetic core slot"))),
+            SlotSkin.medium, arrayOf(tr("Ferromagnetic core slot"))),
         GenericItemUsingDamageSlot(inventory, CasingSlotId, 130, 74, 1,
             arrayOf<Class<*>>(CaseItemDescriptor::class.java),
-            SlotSkin.medium, arrayOf(I18N.tr("Casing slot")))))
+            SlotSkin.medium, arrayOf(tr("Casing slot")))))
      {
     companion object {
         const val primaryCableSlotId = 0

--- a/src/main/kotlin/mods/eln/transparentnode/LegacyDcDc.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/LegacyDcDc.kt
@@ -343,10 +343,10 @@ class LegacyDcDcElement(transparentNode: TransparentNode, descriptor: Transparen
         val info = HashMap<String, String>()
         info[I18N.tr("Ratio")] = Utils.plotValue(interSystemProcess.ratio)
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Voltages")] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
+            info["Voltages"] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
                 "\u00A7e" + Utils.plotVolt("", secondaryLoad.voltage)
         }
-        info[I18N.tr("Subsystem Matrix Size")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
+        info[I18N.tr("Subsystem Matrix Size: ")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
         return info
     }
 

--- a/src/main/kotlin/mods/eln/transparentnode/NixieTube.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/NixieTube.kt
@@ -163,9 +163,9 @@ class NixieTubeElement(node: TransparentNode, _descriptor: TransparentNodeDescri
 
     override fun getWaila(): MutableMap<String, String> {
         var info = HashMap<String, String>()
-        info.put("Digit", curDigit.toString())
-        info.put("Blank", curBlank.toString())
-        info.put("Dots", when(curDots) {
+        info.put(tr("Digit"), curDigit.toString())
+        info.put(tr("Blank"), curBlank.toString())
+        info.put(tr("Dots"), when(curDots) {
             1 -> "low"
             2 -> "high"
             3 -> "both"

--- a/src/main/kotlin/mods/eln/transparentnode/NixieTube.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/NixieTube.kt
@@ -163,9 +163,9 @@ class NixieTubeElement(node: TransparentNode, _descriptor: TransparentNodeDescri
 
     override fun getWaila(): MutableMap<String, String> {
         var info = HashMap<String, String>()
-        info.put(tr("Digit"), curDigit.toString())
-        info.put(tr("Blank"), curBlank.toString())
-        info.put(tr("Dots"), when(curDots) {
+        info.put("Digit", curDigit.toString())
+        info.put("Blank", curBlank.toString())
+        info.put("Dots", when(curDots) {
             1 -> "low"
             2 -> "high"
             3 -> "both"

--- a/src/main/kotlin/mods/eln/transparentnode/ThermalHeatExchanger.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/ThermalHeatExchanger.kt
@@ -3,7 +3,7 @@ package mods.eln.transparentnode.themralheatexchanger
 import mods.eln.Eln
 import mods.eln.fluid.ElementSidedFluidHandler
 import mods.eln.fluid.TankData
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
 import mods.eln.misc.Utils
@@ -65,9 +65,9 @@ class ThermalHeatExchangerDescriptor(
 
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list.add(I18N.tr("Generates heat when supplied with ic2:hotcoolant"))
-        list.add(I18N.tr("Ejects out ic2:coolant"))
-        list.add(Utils.plotCelsius(I18N.tr("  Max. temperature: "), thermal.maximumTemperature))
+        list.add(tr("Generates heat when supplied with ic2:hotcoolant"))
+        list.add(tr("Ejects out ic2:coolant"))
+        list.add(Utils.plotCelsius(tr("  Max. temperature: "), thermal.maximumTemperature))
     }
 
     override fun mustHaveFloor() = false
@@ -235,13 +235,13 @@ class ThermalHeatExchangerElement(
     override fun thermoMeterString(side: Direction): String = Utils.plotCelsius("T:", thermalLoad.temperatureCelsius) + " " + Utils.plotPower(joulesPerTick * 20)
 
     override fun getWaila(): Map<String, String> = mutableMapOf(
-        Pair(I18N.tr("Control"), Utils.plotPercent("", electricalControlLoad.normalized)),
-        Pair(I18N.tr("input tank level"), tank.getFluidAmount(INPUT_SIDE).toString()),
-        Pair(I18N.tr("output tank level"), tank.getFluidAmount(OUTPUT_SIDE).toString()),
-        Pair(I18N.tr("input mB/t"), Utils.plotBuckets("", inputMbPerTick / 1000.0)),
-        Pair(I18N.tr("output mB/t"), Utils.plotBuckets("", outputMbPerTick / 1000.0)),
-        Pair(I18N.tr("joules per tick"), joulesPerTick.toString()),
-        Pair(I18N.tr("thermal power"), Utils.plotPower(joulesPerTick * 20))
+        Pair(tr("Control"), Utils.plotPercent("", electricalControlLoad.normalized)),
+        Pair(tr("input tank level"), tank.getFluidAmount(INPUT_SIDE).toString()),
+        Pair(tr("output tank level"), tank.getFluidAmount(OUTPUT_SIDE).toString()),
+        Pair(tr("input mB/t"), Utils.plotBuckets("", inputMbPerTick / 1000.0)),
+        Pair(tr("output mB/t"), Utils.plotBuckets("", outputMbPerTick / 1000.0)),
+        Pair(tr("joules per tick"), joulesPerTick.toString()),
+        Pair(tr("thermal power"), Utils.plotPower(joulesPerTick * 20))
     )
 
     override fun writeToNBT(nbt: NBTTagCompound) {

--- a/src/main/kotlin/mods/eln/transparentnode/VariableDcDc.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/VariableDcDc.kt
@@ -330,10 +330,10 @@ class VariableDcDcElement(transparentNode: TransparentNode, descriptor: Transpar
         val info = HashMap<String, String>()
         info[tr("Ratio")] = Utils.plotValue(interSystemProcess.ratio)
         // It's just not fair not to show the voltages on the VDC/DC. It's so variable...
-        info["Voltages"] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
+        info[tr("Voltages")] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
             "\u00A7e" + Utils.plotVolt("", secondaryLoad.voltage)
-        info["Control Voltage"] = Utils.plotVolt(control.voltage)
-        info[tr("Subsystem Matrix Size: ")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
+        info[tr("Control Voltage")] = Utils.plotVolt(control.voltage)
+        info[tr("Subsystem Matrix Size")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
         return info
     }
 

--- a/src/main/kotlin/mods/eln/transparentnode/VariableDcDc.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/VariableDcDc.kt
@@ -9,7 +9,6 @@ import mods.eln.generic.GenericItemUsingDamageSlot
 import mods.eln.gui.GuiContainerEln
 import mods.eln.gui.GuiHelperContainer
 import mods.eln.gui.ISlotSkin
-import mods.eln.i18n.I18N
 import mods.eln.i18n.I18N.tr
 import mods.eln.item.*
 import mods.eln.misc.*
@@ -80,8 +79,8 @@ class VariableDcDcDescriptor(name: String, objM: Obj3D, coreM: Obj3D, casingM: O
     }
 
     override fun addRealismContext(list: MutableList<String>?): RealisticEnum {
-        list?.add(I18N.tr("This variable DC/DC has unrealistic capacitance effects and can sink/source power that violates Newton's laws"))
-        list?.add(I18N.tr("It is made this way to improve the performance of the simulator in large power networks"))
+        list?.add(tr("This variable DC/DC has unrealistic capacitance effects and can sink/source power that violates Newton's laws"))
+        list?.add(tr("It is made this way to improve the performance of the simulator in large power networks"))
         return RealisticEnum.UNREALISTIC
     }
 

--- a/src/main/kotlin/mods/eln/transparentnode/VariableDcDc.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/VariableDcDc.kt
@@ -330,10 +330,10 @@ class VariableDcDcElement(transparentNode: TransparentNode, descriptor: Transpar
         val info = HashMap<String, String>()
         info[tr("Ratio")] = Utils.plotValue(interSystemProcess.ratio)
         // It's just not fair not to show the voltages on the VDC/DC. It's so variable...
-        info[tr("Voltages")] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
+        info["Voltages"] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
             "\u00A7e" + Utils.plotVolt("", secondaryLoad.voltage)
-        info[tr("Control Voltage")] = Utils.plotVolt(control.voltage)
-        info[tr("Subsystem Matrix Size")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
+        info["Control Voltage"] = Utils.plotVolt(control.voltage)
+        info[tr("Subsystem Matrix Size: ")] = Utils.renderDoubleSubsystemWaila(primaryLoad.subSystem, secondaryLoad.subSystem)
         return info
     }
 

--- a/src/main/kotlin/mods/eln/transparentnode/battery/BatteryDescriptor.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/battery/BatteryDescriptor.kt
@@ -1,7 +1,6 @@
 package mods.eln.transparentnode.battery
 
 import mods.eln.Eln
-import mods.eln.i18n.I18N
 import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
 import mods.eln.misc.Obj3D.Obj3DPart
@@ -127,13 +126,13 @@ class BatteryDescriptor(
 
     override fun addInformation(itemStack: ItemStack, entityPlayer: EntityPlayer?, list: MutableList<String>, par4: Boolean) {
         super.addInformation(itemStack, entityPlayer, list, par4)
-        list.add(Utils.plotVolt(I18N.tr("Nominal voltage: "), electricalU))
-        list.add(Utils.plotPower(I18N.tr("Nominal power: "), electricalStdP))
-        list.add(Utils.plotEnergy(I18N.tr("Energy capacity: "), electricalStdDischargeTime * electricalStdP))
-        list.add(Utils.plotOhm(I18N.tr("Internal resistance: "), electricalRs * 2))
+        list.add(Utils.plotVolt(tr("Nominal voltage: "), electricalU))
+        list.add(Utils.plotPower(tr("Nominal power: "), electricalStdP))
+        list.add(Utils.plotEnergy(tr("Energy capacity: "), electricalStdDischargeTime * electricalStdP))
+        list.add(Utils.plotOhm(tr("Internal resistance: "), electricalRs * 2))
         list.add("")
-        list.add(Utils.plotPercent(I18N.tr("Actual charge: "), getChargeInTag(itemStack)))
-        if (lifeEnable) list.add(Utils.plotPercent(I18N.tr("Life: "), getLifeInTag(itemStack)))
+        list.add(Utils.plotPercent(tr("Actual charge: "), getChargeInTag(itemStack)))
+        if (lifeEnable) list.add(Utils.plotPercent(tr("Life: "), getLifeInTag(itemStack)))
     }
 
     override fun addRealismContext(list: MutableList<String>?): RealisticEnum {
@@ -148,7 +147,7 @@ class BatteryDescriptor(
     }
 
     override fun getName(stack: ItemStack): String {
-        return super.getName(stack) + Utils.plotPercent(I18N.tr(" charged at "), getChargeInTag(stack))
+        return super.getName(stack) + Utils.plotPercent(tr(" charged at "), getChargeInTag(stack))
     }
 
     fun getChargeInTag(stack: ItemStack): Double {

--- a/src/main/kotlin/mods/eln/transparentnode/battery/BatteryElement.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/battery/BatteryElement.kt
@@ -1,7 +1,7 @@
 package mods.eln.transparentnode.battery
 
 import mods.eln.Eln
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
 import mods.eln.misc.Utils
@@ -131,15 +131,15 @@ class BatteryElement(transparentNode: TransparentNode, descriptor: TransparentNo
 
     override fun getWaila(): Map<String, String> {
         val info: MutableMap<String, String> = HashMap()
-        info[I18N.tr("Charge")] = Utils.plotPercent("", batteryProcess.charge)
-        info[I18N.tr("Energy")] = Utils.plotEnergy("", batteryProcess.energy)
-        info[I18N.tr("Life")] = Utils.plotPercent("", batteryProcess.life)
+        info[tr("Charge")] = Utils.plotPercent("", batteryProcess.charge)
+        info[tr("Energy")] = Utils.plotEnergy("", batteryProcess.energy)
+        info[tr("Life")] = Utils.plotPercent("", batteryProcess.life)
         if (Eln.wailaEasyMode) {
-            info[I18N.tr("Voltage")] = Utils.plotVolt("", batteryProcess.u)
-            info[I18N.tr("Current")] = Utils.plotAmpere("", batteryProcess.dischargeCurrent)
-            info[I18N.tr("Temperature")] = Utils.plotCelsius("", thermalLoad.temperatureCelsius)
+            info[tr("Voltage")] = Utils.plotVolt("", batteryProcess.u)
+            info[tr("Current")] = Utils.plotAmpere("", batteryProcess.dischargeCurrent)
+            info[tr("Temperature")] = Utils.plotCelsius("", thermalLoad.temperatureCelsius)
         }
-        info[I18N.tr("Subsystem Matrix Size")] = Utils.renderSubSystemWaila(positiveLoad.subSystem)
+        info[tr("Subsystem Matrix Size")] = Utils.renderSubSystemWaila(positiveLoad.subSystem)
         return info
     }
 

--- a/src/main/kotlin/mods/eln/transparentnode/battery/BatteryGuiDraw.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/battery/BatteryGuiDraw.kt
@@ -5,7 +5,7 @@ import mods.eln.gui.GuiScreenEln
 import mods.eln.gui.GuiVerticalProgressBar
 import mods.eln.gui.HelperStdContainer
 import mods.eln.gui.IGuiObject
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Utils
 
 class BatteryGuiDraw(var render: BatteryRender) : GuiScreenEln() {
@@ -25,7 +25,7 @@ class BatteryGuiDraw(var render: BatteryRender) : GuiScreenEln() {
     override fun preDraw(f: Float, x: Int, y: Int) {
         super.preDraw(f, x, y)
         energyBar!!.setValue((render.energy / (render.descriptor.electricalStdEnergy * render.life)).toFloat())
-        energyBar!!.setComment(0, I18N.tr("Energy: %1$", Utils.plotPercent("", energyBar!!.value).replace(" ", "")))
+        energyBar!!.setComment(0, Utils.plotPercent(tr("Energy: "), energyBar!!.value).replace(" ", ""))
     }
 
     override fun postDraw(f: Float, x: Int, y: Int) {
@@ -36,29 +36,29 @@ class BatteryGuiDraw(var render: BatteryRender) : GuiScreenEln() {
         val energyMiss = render.descriptor.electricalStdEnergy * render.life - render.energy
         when {
             Math.abs(p) < 5 -> {
-                str1 = I18N.tr("No charge")
+                str1 = tr("No charge")
             }
             p > 0 -> {
-                str1 = I18N.tr("Discharge")
+                str1 = tr("Discharge")
                 str2 = Utils.plotTime("", render.energy / p)
             }
             energyMiss > 0 -> {
-                str1 = I18N.tr("Charge")
+                str1 = tr("Charge")
                 str2 = Utils.plotTime("", -energyMiss / p)
             }
             else -> {
-                str1 = I18N.tr("Charged")
+                str1 = tr("Charged")
             }
         }
         val xDelta = 70
         if (render.descriptor.lifeEnable) {
-            drawString(8, 8, I18N.tr("Life:"))
+            drawString(8, 8, tr("Life:"))
             drawString(xDelta, 8, Utils.plotPercent("", render.life.toDouble()))
         }
-        drawString(8, 17, I18N.tr("Energy:"))
+        drawString(8, 17, tr("Energy:"))
         drawString(xDelta, 17,
             Utils.plotValue(render.energy.toDouble(), "J/") + Utils.plotValue(render.descriptor.electricalStdEnergy * render.life, "J"))
-        if (render.power >= 0) drawString(8, 26, I18N.tr("Power out:")) else drawString(8, 26, I18N.tr("Power in:"))
+        if (render.power >= 0) drawString(8, 26, tr("Power out:")) else drawString(8, 26, tr("Power in:"))
         drawString(xDelta, 26, Utils.plotValue(Math.abs(render.power).toDouble(), "W/") + Utils.plotValue(render.descriptor.electricalStdP, "W"))
         drawString(8, 35, str1)
         drawString(xDelta, 35, str2)

--- a/src/main/kotlin/mods/eln/transparentnode/festive/FestiveElement.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/festive/FestiveElement.kt
@@ -1,6 +1,5 @@
 package mods.eln.transparentnode.festive
 
-import mods.eln.i18n.I18N
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
@@ -29,11 +28,11 @@ class FestiveElement(node: TransparentNode, descriptor: TransparentNodeDescripto
     }
 
     override fun thermoMeterString(side: Direction): String {
-        return I18N.tr("Not as warm as it could be")
+        return "Not as warm as it could be"
     }
 
     override fun multiMeterString(side: Direction): String {
-        return I18N.tr("It probably works if you apply ~200v to the xmas wireless channel")
+        return "It probably works if you apply ~200v to the xmas wireless channel"
     }
 
     override fun getElectricalLoad(side: Direction, lrdu: LRDU): ElectricalLoad? {

--- a/src/main/kotlin/mods/eln/transparentnode/festive/FestiveElement.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/festive/FestiveElement.kt
@@ -1,6 +1,6 @@
 package mods.eln.transparentnode.festive
 
-import mods.eln.i18n.I18N
+import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
@@ -29,11 +29,11 @@ class FestiveElement(node: TransparentNode, descriptor: TransparentNodeDescripto
     }
 
     override fun thermoMeterString(side: Direction): String {
-        return I18N.tr("Not as warm as it could be")
+        return tr("Not as warm as it could be")
     }
 
     override fun multiMeterString(side: Direction): String {
-        return I18N.tr("It probably works if you apply ~200v to the xmas wireless channel")
+        return tr("It probably works if you apply ~200v to the xmas wireless channel")
     }
 
     override fun getElectricalLoad(side: Direction, lrdu: LRDU): ElectricalLoad? {

--- a/src/main/kotlin/mods/eln/transparentnode/festive/FestiveElement.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/festive/FestiveElement.kt
@@ -1,5 +1,6 @@
 package mods.eln.transparentnode.festive
 
+import mods.eln.i18n.I18N
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
@@ -28,11 +29,11 @@ class FestiveElement(node: TransparentNode, descriptor: TransparentNodeDescripto
     }
 
     override fun thermoMeterString(side: Direction): String {
-        return "Not as warm as it could be"
+        return I18N.tr("Not as warm as it could be")
     }
 
     override fun multiMeterString(side: Direction): String {
-        return "It probably works if you apply ~200v to the xmas wireless channel"
+        return I18N.tr("It probably works if you apply ~200v to the xmas wireless channel")
     }
 
     override fun getElectricalLoad(side: Direction, lrdu: LRDU): ElectricalLoad? {

--- a/src/main/resources/assets/eln/lang/en_US.lang
+++ b/src/main/resources/assets/eln/lang/en_US.lang
@@ -12,6 +12,7 @@ achievement.open_guide.desc=Open the wiki guide
 800V_Arc_Furnace.name=800V Arc Furnace
 Experimental_Battery.name=Experimental Battery
 Creative_Cable.name=Creative Cable
+2x_Graphite_Rods.name=2x Graphite Rods
 200V_Active_Thermal_Dissipator.name=200V Active Thermal Dissipator
 200V_Battery_Charger.name=200V Battery Charger
 200V_Compressor.name=200V Compressor
@@ -34,6 +35,8 @@ Creative_Cable.name=Creative Cable
 2x3_Rotating_Solar_Panel.name=2x3 Rotating Solar Panel
 2x3_Solar_Panel.name=2x3 Solar Panel
 3.2kV_Tungsten_Heating_Corp.name=3.2kV Tungsten Heating Corp
+3x_Graphite_Rods.name=3x Graphite Rods
+4x_Graphite_Rods.name=4x Graphite Rods
 50V_Battery_Charger.name=50V Battery Charger
 50V_Carbon_Incandescent_Light_Bulb.name=50V Carbon Incandescent Light Bulb
 50V_Compressor.name=50V Compressor
@@ -70,6 +73,8 @@ Analog_Watch.name=Analog Watch
 Analog_vuMeter.name=Analog Gauge
 Analogic_Regulator.name=Analogic Regulator
 Animal_Filter.name=Animal Filter
+Arc_Clay_Ingot.name=Arc Clay Ingot
+Arc_Metal_Ingot.name=Arc Metal Ingot
 Auto_Miner.name=Auto Miner
 Average_Electrical_Drill.name=Average Electrical Drill
 Average_Ferromagnetic_Core.name=Average Ferromagnetic Core
@@ -80,6 +85,8 @@ Blown_Lead_Fuse.name=Blown Lead Fuse
 Blue_Brush.name=Blue Brush
 Brown_Brush.name=Brown Brush
 Capacity_Oriented_Battery.name=Capacity Oriented Battery
+Canister_of_Arc_Water.name=Canister of Arc Water
+Canister_of_Water.name=Canister of Water
 Casing.name=Casing
 Cheap_Chip.name=Cheap Chip
 Cheap_Electrical_Drill.name=Cheap Electrical Drill
@@ -87,12 +94,15 @@ Cheap_Ferromagnetic_Core.name=Cheap Ferromagnetic Core
 Cinnabar_Dust.name=Cinnabar Dust
 Cinnabar_Ore.name=Cinnabar Ore
 Clutch.name=Clutch
+Clutch_Pin.name=Clutch Pin
+Coal_Clutch_Plate.name=Coal Clutch Plate
 Coal_Dust.name=Coal Dust
 Coal_Plate.name=Coal Plate
 Combustion_Chamber.name=Combustion Chamber
 Config_Copy_Tool.name=Config Copy Tool
 Configurable_summing_unit.name=Configurable summing unit
 Copper_Cable.name=Copper Cable
+Copper_Clutch_Plate.name=Copper Clutch Plate
 Copper_Dust.name=Copper Dust
 Copper_Ingot.name=Copper Ingot
 Copper_Ore.name=Copper Ore
@@ -107,6 +117,7 @@ Variable_DC-DC_Converter.name=Variable DC-DC Converter
 D_Flip_Flop_Chip.name=D Flip Flop Chip
 Data_Logger.name=Data Logger
 Data_Logger_Print.name=Data Logger Print
+Diamond_Dust.name=Diamond Dust
 Dielectric.name=Dielectric
 Digital_Display.name=Digital Display
 Digital_Watch.name=Digital Watch
@@ -138,8 +149,10 @@ Fuel_Heat_Furnace.name=Fuel Heat Furnace
 Gas_Turbine.name=Gas Turbine
 Generator.name=Generator
 Shaft_Motor.name=Shaft Motor
+Gold_Clutch_Plate.name=Gold Clutch Plate
 Gold_Dust.name=Gold Dust
 Gold_Plate.name=Gold Plate
+Graphite_Rod.name=Graphite Rod
 Gray_Brush.name=Gray Brush
 Green_Brush.name=Green Brush
 Ground_Cable.name=Ground Cable
@@ -151,9 +164,12 @@ High_Voltage_Relay.name=High Voltage Relay
 High_Voltage_Switch.name=High Voltage Switch
 Hub.name=Hub
 Industrial_Data_Logger.name=Industrial Data Logger
+Inert_Canister.name=Inert Canister
 Iron_Cable.name=Iron Cable
+Iron_Clutch_Plate.name=Iron Clutch Plate
 Iron_Dust.name=Iron Dust
 Iron_Plate.name=Iron Plate
+Irresponsible_Electrical_Drill.name=Irresponsible Electrical Drill
 JK_Flip_Flop_Chip.name=JK Flip Flop Chip
 Joint.name=Joint
 Joint_hub.name=Joint hub
@@ -161,7 +177,9 @@ LED_vuMeter.name=LED vuMeter
 Lamp_Socket_A.name=Lamp Socket A
 Lamp_Socket_B_Projector.name=Lamp Socket B Projector
 Lamp_Supply.name=Lamp Supply
+Lapis_Dust.name=Lapis Dust
 Large_Rheostat.name=Large Rheostat
+Lead_Clutch_Plate.name=Lead Clutch Plate
 Lead_Dust.name=Lead Dust
 Lead_Fuse_for_high_voltage_cables.name=Lead Fuse for high voltage cables
 Lead_Fuse_for_low_voltage_cables.name=Lead Fuse for low voltage cables
@@ -204,8 +222,8 @@ NOT_Chip.name=NOT Chip
 Nixie_Tube.name=Nixie Tube
 Nuclear_Alarm.name=Nuclear Alarm
 OR_Chip.name=OR Chip
-On_OFF_Regulator_10_Percent.name=On/off regulator 10%
-On_OFF_Regulator_1_Percent.name=On/off regulator 1%
+On/OFF_Regulator_10_Percent.name=On/off regulator 10%
+On/OFF_Regulator_1_Percent.name=On/off regulator 1%
 OpAmp.name=OpAmp
 Optimal_Ferromagnetic_Core.name=Optimal Ferromagnetic Core
 Orange_Brush.name=Orange Brush
@@ -280,6 +298,7 @@ Stone_Heat_Furnace.name=Stone Heat Furnace
 Street_Light.name=Streetlight
 Suspended_Lamp_Socket.name=Suspended Lamp Socket
 Suspended_Lamp_Socket_(No_Swing).name=Suspended Lamp Socket (No Swing)
+Synthetic_Diamond.name=Synthetic Diamond
 Tachometer.name=Tachometer
 Temperature_Probe.name=Temperature Probe
 Thermal_Probe.name=Thermal Probe
@@ -292,7 +311,9 @@ Tungsten_Cable.name=Tungsten Cable
 Tungsten_Dust.name=Tungsten Dust
 Tungsten_Ingot.name=Tungsten Ingot
 Tungsten_Ore.name=Tungsten Ore
+Turbo_Electrical_Drill.name=Turbo Electrical Drill
 Tutorial_Sign.name=Tutorial Sign
+unreleasedium.name=unreleasedium
 Very_High_Voltage_Cable.name=Very High Voltage Cable
 Very_High_Voltage_Relay.name=Very High Voltage Relay
 Very_High_Voltage_Switch.name=Very High Voltage Switch
@@ -366,7 +387,7 @@ Cable_loss_factor\:_%1$=Cable loss factor: %1$
 
 # ./src/main/java/mods/eln/item/FuelBurnerDescriptor.kt
 Burn_unit_for_the_gas_heat_furnace.=Burn unit for the gas heat furnace.
-Produced_heat_power\:_=Produced heat power: 
+Produced_heat_power\:_=Produced heat power:
 
 # ./src/main/java/mods/eln/item/HeatingCorpElement.java
 
@@ -400,12 +421,43 @@ Stored_Energy\:_%1$J_(%2$%)=Stored Energy: %1$J (%2$%)
 
 # ./src/main/java/mods/eln/item/regulator/RegulatorSlot.java
 
+# ./src/main/java/mods/eln/mechanical/Clutch.kt
+Prevents_clutches_from_slipping\nagain_after_they_stop.=Prevents clutches from slipping\nagain after they stop.
+
+# ./src/main/java/mods/eln/mechanical/CrankableShaft.kt
+Player_crankable_shaft=Player crankable shaft
+Can_rotate_slowly=Can rotate slowly
+
+# ./src/main/java/mods/eln/mechanical/Generator.kt
+Converts_mechanical_energy_into_electricity,_or_(badly)_vice_versa.=将机械能转换为电能，或反之(低效)。
+Voltage_out\:_%1$=Voltage out: %1$
+Power_out\:_%1$=Power out: %1$
+Rads\:_%1$=Rads: %1$
+
+# ./src/main/java/mods/eln/mechanical/Motor.kt
+Converts_electricity_into_mechanical_energy,_or_(badly)_vice_versa.=Converts electricity into mechanical energy, or (badly) vice versa.
+Voltage_in\:_%1$=Voltage in: %1$
+Power_in\:_%1$=Power in: %1$
+rad_s\:_%1$=rad/s: %1$
+Max_rad_s\:_%1$=Max rad/s: %1$
+
 # ./src/main/java/mods/eln/mechanical/Tachometer.kt
 Rads_s_corresponding\nto_0%_output=Rads/s corresponding\nto 0% output
 Rads_s_corresponding\nto_100%_output=Rads/s corresponding\nto 100% output
 
+# ./src/main/java/mods/eln/mechanical/Turbines.kt
+Converts_%1$_into_mechanical_energy.=Converts %1$ into mechanical energy.
+Nominal_usage_->=Nominal usage ->
+%1$_input\:_%2$_mB_s=%1$ input: %2$ mB/s
+No_valid_fluids_for_this_turbine!=No valid fluids for this turbine!
+Power_out\:_%1$=Power out: %1$
+Power_out\:_%1$-_%2$=Power out: %1$- %2$
+Optimal_rads\:_%1$=Optimal rads: %1$
+Max_rads\:__%1$=Max rads:  %1$
+
 # ./src/main/java/mods/eln/misc/UtilsClient.java
-Hold_shift=Hold shift
+Hold_[shift]_for_details=Hold [shift] for details
+Hold_[ctrl]_for_realism_details=Hold [ctrl] for realism details
 
 # ./src/main/java/mods/eln/misc/Version.java
 mod.name=Electrical Age
@@ -421,6 +473,7 @@ A_voltage-controlled_oscillator_or_VCO_is\nan_electronic_oscillator_whose_oscill
 An_amplifier_increases_the_voltage\nof_an_input_signal_by_a_configurable\ngain_and_outputs_that_voltage.=An amplifier increases the voltage\nof an input signal by a configurable\ngain and outputs that voltage.
 Cut-off_frequency_%1$_Hz=Cut-off frequency %1$ Hz
 Gain=Gain
+Gains=Gains
 Gain_for_input_\u00a713=Gain for input \u00a713
 Gain_for_input_\u00a722=Gain for input \u00a722
 Gain_for_input_\u00a741=Gain for input \u00a741
@@ -467,12 +520,14 @@ Battery_slot=Battery slot
 
 # ./src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerDescriptor.java
 Can_be_used_to_recharge\nelectrical_items_like\:\nFlash_Light,_X-Ray_scanner\nand_Portable_Battery_...=Can be used to recharge\nelectrical items like:\nFlash Light, X-Ray scanner\nand Portable Battery ...
+This_battery_charger_doesn't_take_into_account_battery_chemistry=This battery charger doesn't take into account battery chemistry
 
 # ./src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerElement.java
 Charge_Current=Charge Current
 
 # ./src/main/java/mods/eln/sixnode/diode/DiodeDescriptor.java
 Electrical_current_can_only\nflow_through_the_diode\nfrom_anode_to_cathode=Electrical current can only\nflow through the diode\nfrom anode to cathode
+Works,_with_the_caveat_that_it's_delayed_a_sim_tick=Works, with the caveat that it's delayed a sim tick
 
 # ./src/main/java/mods/eln/sixnode/diode/DiodeElement.java
 Forward_Voltage=Forward Voltage
@@ -509,6 +564,11 @@ Current\:_%1$A=Current: %1$A
 Nominal_Ratings\:=Nominal Ratings:
 Not_adapted_to_transport_power.=Not adapted to transport power.
 Serial_resistance\:_%1$\u2126=Serial resistance: %1$\u2126
+__*_Wire_resistance_is_much_higher_than_normal=  * Wire resistance is much higher than normal
+__*_Wire_resistance_is_not_impacted_by_temperature=  * Wire resistance is not impacted by temperature
+__*_Wire_voltage_current_limits_are_arbitrary_values,_added_as_a_gameplay_mechanic=  * Wire voltage current limits are arbitrary values, added as a gameplay mechanic
+__*_Wire_voltage_limits_are_arbitrary_values,_picked_to_within_reasonable_simulator_error=  * Wire voltage limits are arbitrary values, picked to within reasonable simulator error
+__*_Wire_current_limits_are_arbitrary_values,_added_as_a_gameplay_mechanic=  * Wire current limits are arbitrary values, added as a gameplay mechanic
 
 # ./src/main/java/mods/eln/sixnode/electricalcable/ElectricalCableElement.java
 
@@ -532,6 +592,9 @@ Voltage_[V]=Voltage [V]
 Y-axis_max=Y-axis max
 Y-axis_min=Y-axis min
 
+# ./src/main/java/mods/eln/sixnode/electricaldigitaldisplay/ElectricalDigitalDisplayDescriptor.java
+Displays_signal_value.=Displays signal value.
+
 # ./src/main/java/mods/eln/sixnode/electricalentitysensor/ElectricalEntitySensorDescriptor.java
 Output_voltage_increases\nif_entities_are_moving_around.=Output voltage increases\nif entities are moving around.
 
@@ -543,7 +606,7 @@ Battery_powered_buzzer_\nactivated_in_presence_of_fire.=Battery powered buzzer \
 Output_voltage_increases\nif_a_fire_has_been_detected.=Output voltage increases\nif a fire has been detected.
 
 # ./src/main/java/mods/eln/sixnode/electricalfiredetector/ElectricalFireDetectorElement.java
-Fire_detected\:_=Fire detected: 
+Fire_detected\:_=Fire detected:
 Fire_present=Fire present
 
 # ./src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceDescriptor.java
@@ -615,7 +678,10 @@ Measured_voltage\ncorresponding\nto_100%_output=Measured voltage\ncorresponding\
 
 # ./src/main/java/mods/eln/sixnode/electricalsource/ElectricalSourceDescriptor.java
 Creative_block.=Creative block.
+Provides_an_ideal_current_source\nwithout_energy_or_power_limitation.=Provides an ideal current source\nwithout energy or power limitation.
 Provides_an_ideal_voltage_source\nwithout_energy_or_power_limitation.=Provides an ideal voltage source\nwithout energy or power limitation.
+Acts_as_an_ideal_voltage_source,_with_a_small_inline_resistance=Acts as an ideal voltage source, with a small inline resistance
+Acts_as_an_ideal_current_source,_with_a_small_inline_resistance=Acts as an ideal current source, with a small inline resistance
 
 # ./src/main/java/mods/eln/sixnode/electricalswitch/ElectricalSwitchDescriptor.java
 Can_break_an_electrical_circuit\ninterrupting_the_current.=Can break an electrical circuit\ninterrupting the current.
@@ -632,6 +698,7 @@ Set=Set
 The_time_interval_the\noutput_is_kept_high.=The time interval the\noutput is kept high.
 
 # ./src/main/java/mods/eln/sixnode/electricalvumeter/ElectricalVuMeterDescriptor.java
+Displays_a_color_based_on_the_value_of_a_signal=Displays a color based on the value of a signal
 Displays_the_value_of_a_signal.=Displays the value of a signal.
 
 # ./src/main/java/mods/eln/sixnode/electricalwatch/ElectricalWatchContainer.java
@@ -652,6 +719,13 @@ Storm\:_%1$V=Storm: %1$V
 Maximum_wind_speed_is_%1$m_s=Maximum wind speed is %1$m/s
 Provides_an_electrical_signal\ndependant_on_wind_speed.=Provides an electrical signal\ndependant on wind speed.
 You_can't_place_this_block_on_the_floor_or_the_ceiling=You can't place this block on the floor or the ceiling
+
+# ./src/main/java/mods/eln/sixnode/emergencylamp/EmergencyLampDescriptor.java
+As_long_as_power_is_provided,_the_internal_battery=As long as power is provided, the internal battery
+is_charged_and_the_lamp_is_off._On_a_power_failure,=is charged and the lamp is off. On a power failure,
+the_lamp_turns_on_and_runs_on_batteries.=the lamp turns on and runs on batteries.
+Nominal_voltage\:=Nominal voltage:
+Battery_capacity\:=Battery capacity:
 
 # ./src/main/java/mods/eln/sixnode/energymeter/EnergyMeterElement.java
 Counter=Counter
@@ -679,13 +753,17 @@ value_in_kJ=value in kJ
 # ./src/main/java/mods/eln/sixnode/groundcable/GroundCableDescriptor.java
 Can_be_used_to_set_a_point_of_an\nelectrical_network_to_0V_potential.\nFor_example_to_ground_negative_battery_contacts.=Can be used to set a point of an\nelectrical network to 0V potential.\nFor example to ground negative battery contacts.
 Provides_a_zero_volt_reference.=Provides a zero volt reference.
+Acts_as_a_ground_reference.=Acts as a ground reference.
+Has_a_small_resistance_inline=Has a small resistance inline
 
 # ./src/main/java/mods/eln/sixnode/hub/HubDescriptor.java
 Allows_crossing_cables\non_one_single_block.=Allows crossing cables\non one single block.
+A_bit_contrived,_as_the_wires_could_just_cross_over_each_other._Realism_depends_on_the_wires_used.=A bit contrived, as the wires could just cross over each other. Realism depends on the wires used.
 
 # ./src/main/java/mods/eln/sixnode/lampsocket/LampSocketDescriptor.java
 Angle\:_%1$°_to_%2$°=Angle: %1$° to %2$°
 Spot_range\:_%1$_blocks=Spot range: %1$ blocks
+Wireless_mode_of_lights_intended_to_pretend_wires_are_in_the_walls=Wireless mode of lights intended to pretend wires are in the walls
 
 # ./src/main/java/mods/eln/sixnode/lampsocket/LampSocketElement.java
 Bulb=Bulb
@@ -703,6 +781,9 @@ Electrical_cable_slot\nBase_range_is_32_blocks.\nEach_additional_cable\nincrease
 Capable_of_operating_3_light_channels.=Capable of operating 3 light channels.
 Supplies_power_to_nearby_lamps.=Supplies power to nearby lamps.
 Supports_control_from_a_wireless_signal\nchannel_for_each_lighting_channel.=Supports control from a wireless signal\nchannel for each lighting channel.
+Most_homes_have_a_circuit_breaker_panel_for_lights=Most homes have a circuit breaker panel for lights
+The_wireless_power_aspect_is_pretending_there_are_wires_in_the_walls=The wireless power aspect is pretending there are wires in the walls
+Wireless_control_signals_are_totally_possible=Wireless control signals are totally possible
 
 # ./src/main/java/mods/eln/sixnode/lampsupply/LampSupplyElement.java
 Total_power=Total power
@@ -726,17 +807,32 @@ Station_name=Station name
 Wireless_RX=Wireless RX
 Wireless_TX=Wireless TX
 
+# ./src/main/java/mods/eln/sixnode/PortableNaN.kt
+Voltage\:_Yes=Voltage: Yes
+Current\:_No=Current: No
+Serial_Resistance\:_OK_Ω=Serial Resistance: OK Ω
+A_debugging_feature_that_throws_NaN_(Not_a_Number)_anywhere_it_can_in_the_simulator_to_find_bugs=A debugging feature that throws NaN (Not a Number) anywhere it can in the simulator to find bugs
+
 # ./src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixContainer.java
 (Increases_maximum_voltage)=(Increases maximum voltage)
 
 # ./src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixElement.java
 Capacity=Capacity
 
+# ./src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixDescriptor.java
+Provides_capacitance._Use_with_dielectrics_and_redstone=Provides capacitance. Use with dielectrics and redstone
+It_doesn't_really_behave_well_for_DC=It doesn't really behave well for DC
+
 # ./src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixElement.java
 Inductance=Inductance
 
+# ./src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixDescriptor.java
+Provides_inductance._Use_with_iron_cores_and_bare_copper_cables=Provides inductance. Use with iron cores and bare copper cables
+*_Missing_an_inductive_voltage_spike_on_field_collapse=* Missing an inductive voltage spike on field collapse
+
 # ./src/main/java/mods/eln/sixnode/powersocket/PowerSocketDescriptor.java
 Supplies_any_device\nplugged_in_with_energy.=Supplies any device\nplugged in with energy.
+Homes_have_power_sockets._These_are_not_them.=Homes have power sockets. These are not them.
 
 # ./src/main/java/mods/eln/sixnode/powersocket/PowerSocketGui.java
 Specify_the_device_to_supply_through_this_socket.=Specify the device to supply through this socket.
@@ -747,11 +843,15 @@ Coal_dust_slot=Coal dust slot
 
 # ./src/main/java/mods/eln/sixnode/resistor/ResistorElement.java
 
+# ./src/main/java/mods/eln/sixnode/resistor/ResistorDescriptor.java
+It's_a_resistor=It's a resistor
+
 # ./src/main/java/mods/eln/sixnode/thermalcable/ThermalCableDescriptor.java
-High_parallel_resistance\n_\=>_Low_power_dissipation.=High parallel resistance\n => Low power dissipation.
-Low_serial_resistance\n_\=>_High_conductivity.=Low serial resistance\n => High conductivity.
+High_parallel_resistance\n_⇨_Low_power_dissipation.=High parallel resistance\n ⇨ Low power dissipation.
+Low_serial_resistance\n_⇨_High_conductivity.=Low serial resistance\n ⇨ High conductivity.
 Parallel_resistance\:_%1$K_W=Parallel resistance: %1$K/W
 Serial_resistance\:_%1$K_W=Serial resistance: %1$K/W
+The_thermal_simulator_doesn't_properly_manage_heat=The thermal simulator doesn't properly manage heat
 
 # ./src/main/java/mods/eln/sixnode/thermalcable/ThermalCableElement.java
 Thermic_power=Thermic power
@@ -781,6 +881,18 @@ Set_beacon_name=Set beacon name
 
 # ./src/main/java/mods/eln/sixnode/wirelesssignal/rx/WirelessSignalRxGui.java
 
+# ./src/main/java/mods/eln/sixnode/wirelesssignal/rx/WirelessSignalRxDescriptor.java
+Receive_signal_voltage_on_selected_wireless_signal_channel=Receive signal voltage on selected wireless signal channel
+It_should_require_power_to_receive_and_propogate_the_signal_realistically=It should require power to receive and propogate the signal realistically
+
+# ./src/main/java/mods/eln/sixnode/wirelesssignal/tx/WirelessSignalTxDescriptor.java
+Sends_signal_voltage_on_selected_wireless_signal_channel=Sends signal voltage on selected wireless signal channel
+It_should_require_power_to_transmit_realistically=It should require power to transmit realistically
+
+# ./src/main/java/mods/eln/sixnode/wirelesssignal/repeater/WirelessSignalRepeaterDescriptor.java
+Repeats_all_wireless_signals_in_range=Repeats all wireless signals in range
+It_should_require_power_realistically=It should require power realistically
+
 # ./src/main/java/mods/eln/transparentnode/FuelGenerator.kt
 Fuel_level=Fuel level
 Nominal_power\:_%1$_W=Nominal power: %1$ W
@@ -796,7 +908,7 @@ Furnace_is_off=Furnace is off
 Furnace_is_on=Furnace is on
 Heat_Power\:_%1$=Heat Power: %1$
 Set_point\:_%1$=Set point: %1$
-__Max._temperature\:_=  Max. temperature: 
+__Max._temperature\:_=  Max. temperature:
 
 # ./src/main/java/mods/eln/transparentnode/LargeRheostat.kt
 Control_resistance_with_signal=Control resistance with signal
@@ -804,6 +916,9 @@ Dissapates_~4kW_of_heat_passively=Dissapates ~4kW of heat passively
 Nom._Resistance\:_%1$=Nom. Resistance: %1$
 Power_loss=Power loss
 Set_resistance_with_coal_dust=Set resistance with coal dust
+Has_some_caveats\:=Has some caveats:
+__*_Resistance_is_not_impacted_by_temperature=  * Resistance is not impacted by temperature
+__*_Signal_input_doesn't_require_power=  * Signal input doesn't require power
 
 # ./src/main/java/mods/eln/transparentnode/autominer/AutoMinerContainer.java
 Drill_slot=Drill slot
@@ -827,13 +942,20 @@ Overheating_protection=Overheating protection
 Overvoltage_protection=Overvoltage protection
 
 # ./src/main/java/mods/eln/transparentnode/battery/BatteryDescriptor.java
-Actual_charge\:_=Actual charge: 
-Energy_capacity\:_=Energy capacity: 
-Internal_resistance\:_=Internal resistance: 
-Life\:_=Life: 
-Nominal_power\:_=Nominal power: 
-Nominal_voltage\:_=Nominal voltage: 
+Actual_charge\:_=Actual charge:
+Energy_capacity\:_=Energy capacity:
+Internal_resistance\:_=Internal resistance:
+Life\:_=Life:
+Nominal_power\:_=Nominal power:
+Nominal_voltage\:_=Nominal voltage:
 _charged_at_=charged at
+Battery_could_be_realistic_in_the_future=Battery could be realistic in the future
+__*_Batteries_have_internal_resistance=  * Batteries have internal resistance
+__*_Not_currently_simulating_any_particular_chemistry_of_battery=  * Not currently simulating any particular chemistry of battery
+Batteries_are_based_in_realistic_battery_designs_that_someone_might_implement_realistically\:=Batteries are based in realistic battery designs that someone might implement realistically\:
+__*_Single_use_batteries_emulate_a_voltaic_pile=  * Single use batteries emulate a voltaic pile
+__*_Current_oriented_uses_two_smaller_batteries_in_parallel_to_increase_current_capability=  * Current oriented uses two smaller batteries in parallel to increase current capability
+__*_Voltage_oriented_uses_two_smaller_batteries_in_series_to_increase_voltage=  * Voltage oriented uses two smaller batteries in series to increase voltage
 
 # ./src/main/java/mods/eln/transparentnode/battery/BatteryElement.java
 
@@ -891,6 +1013,10 @@ Cost=Cost
 # ./src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineElement.java
 Power_provided=Power provided
 
+# ./src/main/java/mods/eln/transparentnode/Fabricator.kt
+The_Fabricator_creates_chips\nfrom_silicon_and_copper_plates=The Fabricator creates chips\nfrom silicon and copper plates
+Nominal_Ohms\:_%1$=Nominal Ohms: %1$
+
 # ./src/main/java/mods/eln/transparentnode/heatfurnace/HeatFurnaceContainer.java
 Combustion_chamber_slot=Combustion chamber slot
 Fuel_slot=Fuel slot
@@ -902,6 +1028,11 @@ Set_temperature=Set temperature
 Control_gauge_at_%1$%=Control gauge at %1$%
 Decline_fuel=Decline fuel
 Take_fuel=Take fuel
+
+# ./src/main/java/mods/eln/transparentnode/NixieTube.kt
+Displays_a_single_glowing_digit.=Displays a single glowing digit.
+Signal_input_doesn't_require_power,_and_interfaces_are_tailored_to_gameplay=Signal input doesn't require power, and interfaces are tailored to gameplay
+Nixie_tube_has_been_textured_realistically=Nixie tube has been textured realistically
 
 # ./src/main/java/mods/eln/transparentnode/powercapacitor/PowerCapacitorContainer.java
 (Increases_maximal_voltage)=(Increases maximal voltage)
@@ -954,12 +1085,20 @@ Fan_voltage\:_%1$V=Fan voltage: %1$V
 
 # ./src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveElement.java
 
+# ./src/main/java/mods/eln/transparentnode/ThermalHeatExchanger.kt
+Generates_heat_when_supplied_with_ic2\:hotcoolant=Generates heat when supplied with ic2:hotcoolant
+Ejects_out_ic2\:coolant=Ejects out ic2:coolant
+
 # ./src/main/java/mods/eln/transparentnode/transformer/TransformerContainer.java
 Casing_slot=Casing slot
 
 # ./src/main/java/mods/eln/transparentnode/transformer/TransformerDescriptor.java
 The_voltage_ratio_is_proportional\nto_the_cable_stacks_count_ratio.=The voltage ratio is proportional\nto the cable stacks count ratio.
 Transforms_an_input_voltage_to\nan_output_voltage.=Transforms an input voltage to\nan output voltage.
+The_output_voltage_is_controlled\nfrom_a_signal_input=The output voltage is controlled\nfrom a signal input
+This_variable_DC_DC_has_unrealistic_capacitance_effects_and_can_sink_source_power_that_violates_Newton's_laws=This variable DC DC has unrealistic capacitance effects and can sink source power that violates Newton's laws
+It_is_made_this_way_to_improve_the_performance_of_the_simulator_in_large_power_networks=It is made this way to improve the performance of the simulator in large power networks
+This_DC_DC_has_unrealistic_capacitance_effects_and_can_sink_source_power_that_violates_Newton's_laws=This DC DC has unrealistic capacitance effects and can sink source power that violates Newton's laws
 
 # ./src/main/java/mods/eln/transparentnode/transformer/TransformerElement.java
 Core_factor=Core factor
@@ -1074,6 +1213,7 @@ Is_off=Is off
 Is_on=Is on
 Life=Life
 Max._temperature\:_%1$°C=Max. temperature: %1$°C
+miaou=miaou
 Min._temperature\:_%1$°C=Min. temperature: %1$°C
 Measured_value\ncorresponding\nto_0%_output=Measured value\ncorresponding\nto 0% output
 Measured_value\ncorresponding\nto_100%_output=Measured value\ncorresponding\nto 100% output
@@ -1100,6 +1240,7 @@ Powered_by_Lamp_Supply=Powered by Lamp Supply
 Powered_by_cable=Powered by cable
 Produced_power=Produced power
 Range\:_%1$_blocks=Range: %1$ blocks
+Really_useless=Really useless
 Redstone_slot=Redstone slot
 Redstone_value=Redstone value
 Regulator_slot=Regulator slot
@@ -1121,6 +1262,7 @@ Toggle=Toggle
 Toggle_switch=Toggle switch
 Toggles_the_output_each_time\nan_emitter's_value_rises.\nUseful_to_allow_multiple_buttons\nto_control_the_same_light.=Toggles the output each time\nan emitter's value rises.\nUseful to allow multiple buttons\nto control the same light.
 Used_to_cool_down_turbines.=Used to cool down turbines.
+useless=useless
 Uses_the_biggest\nvalue_on_the_channel.=Uses the biggest\nvalue on the channel.
 Uses_the_smallest\nvalue_on_the_channel.=Uses the smallest\nvalue on the channel.
 Validate=Validate
@@ -1130,7 +1272,7 @@ Voltage_drop=Voltage drop
 Voltages=Voltages
 Yes=Yes
 You_can't_place_this_block_at_this_side=You can't place this block at this side
-_O\:_= O: 
+_O\:_= O:
 
 # FIXME
 Grid_DC-DC_Converter.name=Grid Transformer
@@ -1174,3 +1316,42 @@ Type_E_Socket.name=Type E Socket
 Type_J_Socket.name=Type J Socket
 Conduit.name=Conduit Cable
 tile.eln.Conduit.name=Conduit Block
+Subsystem_Matrix_Size=Subsystem Matrix Size
+Charging...=Charging...
+Batteries_empty=Batteries empty
+Fully_charged=Fully charged
+Simple=Simple
+Slots=Slots
+Inputs=Inputs
+Min=Min
+Max=Max
+Speed=Speed
+Speeds=Speeds
+Energies=Energies
+Clutching=Clutching
+Fuel_usage=Fuel usage
+Process_State=Process State
+Can_Process=Can Process
+Not_as_warm_as_it_could_be=Not as warm as it could be
+It_probably_works_if_you_apply_~200v_to_the_xmas_wireless_channel=It probably works if you apply ~200v to the xmas wireless channel
+Control=Control
+input_tank_level=input tank level
+output_tank_level=output tank level
+input_mB_t=input mB/t
+output_mB_t=output mB/t
+joules_per_tick=joules per tick
+thermal_power=thermal power
+Left=Left
+Right=Right
+Transfer=Transfer
+Drive=Drive
+Signal=Signal
+Closed?=Closed?
+Digit=Digit
+Blank=Blank
+Dots=Dots
+No_wireless_signal_in_area!=No wireless signal in area!
+_Strength= Strength
+_Value= Value
+Control_Voltage=Control Voltage
+Operation=Operation

--- a/src/main/resources/assets/eln/lang/en_US.lang
+++ b/src/main/resources/assets/eln/lang/en_US.lang
@@ -12,7 +12,6 @@ achievement.open_guide.desc=Open the wiki guide
 800V_Arc_Furnace.name=800V Arc Furnace
 Experimental_Battery.name=Experimental Battery
 Creative_Cable.name=Creative Cable
-2x_Graphite_Rods.name=2x Graphite Rods
 200V_Active_Thermal_Dissipator.name=200V Active Thermal Dissipator
 200V_Battery_Charger.name=200V Battery Charger
 200V_Compressor.name=200V Compressor
@@ -35,8 +34,6 @@ Creative_Cable.name=Creative Cable
 2x3_Rotating_Solar_Panel.name=2x3 Rotating Solar Panel
 2x3_Solar_Panel.name=2x3 Solar Panel
 3.2kV_Tungsten_Heating_Corp.name=3.2kV Tungsten Heating Corp
-3x_Graphite_Rods.name=3x Graphite Rods
-4x_Graphite_Rods.name=4x Graphite Rods
 50V_Battery_Charger.name=50V Battery Charger
 50V_Carbon_Incandescent_Light_Bulb.name=50V Carbon Incandescent Light Bulb
 50V_Compressor.name=50V Compressor
@@ -73,8 +70,6 @@ Analog_Watch.name=Analog Watch
 Analog_vuMeter.name=Analog Gauge
 Analogic_Regulator.name=Analogic Regulator
 Animal_Filter.name=Animal Filter
-Arc_Clay_Ingot.name=Arc Clay Ingot
-Arc_Metal_Ingot.name=Arc Metal Ingot
 Auto_Miner.name=Auto Miner
 Average_Electrical_Drill.name=Average Electrical Drill
 Average_Ferromagnetic_Core.name=Average Ferromagnetic Core
@@ -85,8 +80,6 @@ Blown_Lead_Fuse.name=Blown Lead Fuse
 Blue_Brush.name=Blue Brush
 Brown_Brush.name=Brown Brush
 Capacity_Oriented_Battery.name=Capacity Oriented Battery
-Canister_of_Arc_Water.name=Canister of Arc Water
-Canister_of_Water.name=Canister of Water
 Casing.name=Casing
 Cheap_Chip.name=Cheap Chip
 Cheap_Electrical_Drill.name=Cheap Electrical Drill
@@ -94,15 +87,12 @@ Cheap_Ferromagnetic_Core.name=Cheap Ferromagnetic Core
 Cinnabar_Dust.name=Cinnabar Dust
 Cinnabar_Ore.name=Cinnabar Ore
 Clutch.name=Clutch
-Clutch_Pin.name=Clutch Pin
-Coal_Clutch_Plate.name=Coal Clutch Plate
 Coal_Dust.name=Coal Dust
 Coal_Plate.name=Coal Plate
 Combustion_Chamber.name=Combustion Chamber
 Config_Copy_Tool.name=Config Copy Tool
 Configurable_summing_unit.name=Configurable summing unit
 Copper_Cable.name=Copper Cable
-Copper_Clutch_Plate.name=Copper Clutch Plate
 Copper_Dust.name=Copper Dust
 Copper_Ingot.name=Copper Ingot
 Copper_Ore.name=Copper Ore
@@ -117,7 +107,6 @@ Variable_DC-DC_Converter.name=Variable DC-DC Converter
 D_Flip_Flop_Chip.name=D Flip Flop Chip
 Data_Logger.name=Data Logger
 Data_Logger_Print.name=Data Logger Print
-Diamond_Dust.name=Diamond Dust
 Dielectric.name=Dielectric
 Digital_Display.name=Digital Display
 Digital_Watch.name=Digital Watch
@@ -149,10 +138,8 @@ Fuel_Heat_Furnace.name=Fuel Heat Furnace
 Gas_Turbine.name=Gas Turbine
 Generator.name=Generator
 Shaft_Motor.name=Shaft Motor
-Gold_Clutch_Plate.name=Gold Clutch Plate
 Gold_Dust.name=Gold Dust
 Gold_Plate.name=Gold Plate
-Graphite_Rod.name=Graphite Rod
 Gray_Brush.name=Gray Brush
 Green_Brush.name=Green Brush
 Ground_Cable.name=Ground Cable
@@ -164,12 +151,9 @@ High_Voltage_Relay.name=High Voltage Relay
 High_Voltage_Switch.name=High Voltage Switch
 Hub.name=Hub
 Industrial_Data_Logger.name=Industrial Data Logger
-Inert_Canister.name=Inert Canister
 Iron_Cable.name=Iron Cable
-Iron_Clutch_Plate.name=Iron Clutch Plate
 Iron_Dust.name=Iron Dust
 Iron_Plate.name=Iron Plate
-Irresponsible_Electrical_Drill.name=Irresponsible Electrical Drill
 JK_Flip_Flop_Chip.name=JK Flip Flop Chip
 Joint.name=Joint
 Joint_hub.name=Joint hub
@@ -177,9 +161,7 @@ LED_vuMeter.name=LED vuMeter
 Lamp_Socket_A.name=Lamp Socket A
 Lamp_Socket_B_Projector.name=Lamp Socket B Projector
 Lamp_Supply.name=Lamp Supply
-Lapis_Dust.name=Lapis Dust
 Large_Rheostat.name=Large Rheostat
-Lead_Clutch_Plate.name=Lead Clutch Plate
 Lead_Dust.name=Lead Dust
 Lead_Fuse_for_high_voltage_cables.name=Lead Fuse for high voltage cables
 Lead_Fuse_for_low_voltage_cables.name=Lead Fuse for low voltage cables
@@ -222,8 +204,8 @@ NOT_Chip.name=NOT Chip
 Nixie_Tube.name=Nixie Tube
 Nuclear_Alarm.name=Nuclear Alarm
 OR_Chip.name=OR Chip
-On/OFF_Regulator_10_Percent.name=On/off regulator 10%
-On/OFF_Regulator_1_Percent.name=On/off regulator 1%
+On_OFF_Regulator_10_Percent.name=On/off regulator 10%
+On_OFF_Regulator_1_Percent.name=On/off regulator 1%
 OpAmp.name=OpAmp
 Optimal_Ferromagnetic_Core.name=Optimal Ferromagnetic Core
 Orange_Brush.name=Orange Brush
@@ -298,7 +280,6 @@ Stone_Heat_Furnace.name=Stone Heat Furnace
 Street_Light.name=Streetlight
 Suspended_Lamp_Socket.name=Suspended Lamp Socket
 Suspended_Lamp_Socket_(No_Swing).name=Suspended Lamp Socket (No Swing)
-Synthetic_Diamond.name=Synthetic Diamond
 Tachometer.name=Tachometer
 Temperature_Probe.name=Temperature Probe
 Thermal_Probe.name=Thermal Probe
@@ -311,9 +292,7 @@ Tungsten_Cable.name=Tungsten Cable
 Tungsten_Dust.name=Tungsten Dust
 Tungsten_Ingot.name=Tungsten Ingot
 Tungsten_Ore.name=Tungsten Ore
-Turbo_Electrical_Drill.name=Turbo Electrical Drill
 Tutorial_Sign.name=Tutorial Sign
-unreleasedium.name=unreleasedium
 Very_High_Voltage_Cable.name=Very High Voltage Cable
 Very_High_Voltage_Relay.name=Very High Voltage Relay
 Very_High_Voltage_Switch.name=Very High Voltage Switch
@@ -387,7 +366,7 @@ Cable_loss_factor\:_%1$=Cable loss factor: %1$
 
 # ./src/main/java/mods/eln/item/FuelBurnerDescriptor.kt
 Burn_unit_for_the_gas_heat_furnace.=Burn unit for the gas heat furnace.
-Produced_heat_power\:_=Produced heat power:
+Produced_heat_power\:_=Produced heat power: 
 
 # ./src/main/java/mods/eln/item/HeatingCorpElement.java
 
@@ -421,43 +400,12 @@ Stored_Energy\:_%1$J_(%2$%)=Stored Energy: %1$J (%2$%)
 
 # ./src/main/java/mods/eln/item/regulator/RegulatorSlot.java
 
-# ./src/main/java/mods/eln/mechanical/Clutch.kt
-Prevents_clutches_from_slipping\nagain_after_they_stop.=Prevents clutches from slipping\nagain after they stop.
-
-# ./src/main/java/mods/eln/mechanical/CrankableShaft.kt
-Player_crankable_shaft=Player crankable shaft
-Can_rotate_slowly=Can rotate slowly
-
-# ./src/main/java/mods/eln/mechanical/Generator.kt
-Converts_mechanical_energy_into_electricity,_or_(badly)_vice_versa.=将机械能转换为电能，或反之(低效)。
-Voltage_out\:_%1$=Voltage out: %1$
-Power_out\:_%1$=Power out: %1$
-Rads\:_%1$=Rads: %1$
-
-# ./src/main/java/mods/eln/mechanical/Motor.kt
-Converts_electricity_into_mechanical_energy,_or_(badly)_vice_versa.=Converts electricity into mechanical energy, or (badly) vice versa.
-Voltage_in\:_%1$=Voltage in: %1$
-Power_in\:_%1$=Power in: %1$
-rad_s\:_%1$=rad/s: %1$
-Max_rad_s\:_%1$=Max rad/s: %1$
-
 # ./src/main/java/mods/eln/mechanical/Tachometer.kt
 Rads_s_corresponding\nto_0%_output=Rads/s corresponding\nto 0% output
 Rads_s_corresponding\nto_100%_output=Rads/s corresponding\nto 100% output
 
-# ./src/main/java/mods/eln/mechanical/Turbines.kt
-Converts_%1$_into_mechanical_energy.=Converts %1$ into mechanical energy.
-Nominal_usage_->=Nominal usage ->
-%1$_input\:_%2$_mB_s=%1$ input: %2$ mB/s
-No_valid_fluids_for_this_turbine!=No valid fluids for this turbine!
-Power_out\:_%1$=Power out: %1$
-Power_out\:_%1$-_%2$=Power out: %1$- %2$
-Optimal_rads\:_%1$=Optimal rads: %1$
-Max_rads\:__%1$=Max rads:  %1$
-
 # ./src/main/java/mods/eln/misc/UtilsClient.java
-Hold_[shift]_for_details=Hold [shift] for details
-Hold_[ctrl]_for_realism_details=Hold [ctrl] for realism details
+Hold_shift=Hold shift
 
 # ./src/main/java/mods/eln/misc/Version.java
 mod.name=Electrical Age
@@ -473,7 +421,6 @@ A_voltage-controlled_oscillator_or_VCO_is\nan_electronic_oscillator_whose_oscill
 An_amplifier_increases_the_voltage\nof_an_input_signal_by_a_configurable\ngain_and_outputs_that_voltage.=An amplifier increases the voltage\nof an input signal by a configurable\ngain and outputs that voltage.
 Cut-off_frequency_%1$_Hz=Cut-off frequency %1$ Hz
 Gain=Gain
-Gains=Gains
 Gain_for_input_\u00a713=Gain for input \u00a713
 Gain_for_input_\u00a722=Gain for input \u00a722
 Gain_for_input_\u00a741=Gain for input \u00a741
@@ -520,14 +467,12 @@ Battery_slot=Battery slot
 
 # ./src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerDescriptor.java
 Can_be_used_to_recharge\nelectrical_items_like\:\nFlash_Light,_X-Ray_scanner\nand_Portable_Battery_...=Can be used to recharge\nelectrical items like:\nFlash Light, X-Ray scanner\nand Portable Battery ...
-This_battery_charger_doesn't_take_into_account_battery_chemistry=This battery charger doesn't take into account battery chemistry
 
 # ./src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerElement.java
 Charge_Current=Charge Current
 
 # ./src/main/java/mods/eln/sixnode/diode/DiodeDescriptor.java
 Electrical_current_can_only\nflow_through_the_diode\nfrom_anode_to_cathode=Electrical current can only\nflow through the diode\nfrom anode to cathode
-Works,_with_the_caveat_that_it's_delayed_a_sim_tick=Works, with the caveat that it's delayed a sim tick
 
 # ./src/main/java/mods/eln/sixnode/diode/DiodeElement.java
 Forward_Voltage=Forward Voltage
@@ -564,11 +509,6 @@ Current\:_%1$A=Current: %1$A
 Nominal_Ratings\:=Nominal Ratings:
 Not_adapted_to_transport_power.=Not adapted to transport power.
 Serial_resistance\:_%1$\u2126=Serial resistance: %1$\u2126
-__*_Wire_resistance_is_much_higher_than_normal=  * Wire resistance is much higher than normal
-__*_Wire_resistance_is_not_impacted_by_temperature=  * Wire resistance is not impacted by temperature
-__*_Wire_voltage_current_limits_are_arbitrary_values,_added_as_a_gameplay_mechanic=  * Wire voltage current limits are arbitrary values, added as a gameplay mechanic
-__*_Wire_voltage_limits_are_arbitrary_values,_picked_to_within_reasonable_simulator_error=  * Wire voltage limits are arbitrary values, picked to within reasonable simulator error
-__*_Wire_current_limits_are_arbitrary_values,_added_as_a_gameplay_mechanic=  * Wire current limits are arbitrary values, added as a gameplay mechanic
 
 # ./src/main/java/mods/eln/sixnode/electricalcable/ElectricalCableElement.java
 
@@ -592,9 +532,6 @@ Voltage_[V]=Voltage [V]
 Y-axis_max=Y-axis max
 Y-axis_min=Y-axis min
 
-# ./src/main/java/mods/eln/sixnode/electricaldigitaldisplay/ElectricalDigitalDisplayDescriptor.java
-Displays_signal_value.=Displays signal value.
-
 # ./src/main/java/mods/eln/sixnode/electricalentitysensor/ElectricalEntitySensorDescriptor.java
 Output_voltage_increases\nif_entities_are_moving_around.=Output voltage increases\nif entities are moving around.
 
@@ -606,7 +543,7 @@ Battery_powered_buzzer_\nactivated_in_presence_of_fire.=Battery powered buzzer \
 Output_voltage_increases\nif_a_fire_has_been_detected.=Output voltage increases\nif a fire has been detected.
 
 # ./src/main/java/mods/eln/sixnode/electricalfiredetector/ElectricalFireDetectorElement.java
-Fire_detected\:_=Fire detected:
+Fire_detected\:_=Fire detected: 
 Fire_present=Fire present
 
 # ./src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceDescriptor.java
@@ -678,10 +615,7 @@ Measured_voltage\ncorresponding\nto_100%_output=Measured voltage\ncorresponding\
 
 # ./src/main/java/mods/eln/sixnode/electricalsource/ElectricalSourceDescriptor.java
 Creative_block.=Creative block.
-Provides_an_ideal_current_source\nwithout_energy_or_power_limitation.=Provides an ideal current source\nwithout energy or power limitation.
 Provides_an_ideal_voltage_source\nwithout_energy_or_power_limitation.=Provides an ideal voltage source\nwithout energy or power limitation.
-Acts_as_an_ideal_voltage_source,_with_a_small_inline_resistance=Acts as an ideal voltage source, with a small inline resistance
-Acts_as_an_ideal_current_source,_with_a_small_inline_resistance=Acts as an ideal current source, with a small inline resistance
 
 # ./src/main/java/mods/eln/sixnode/electricalswitch/ElectricalSwitchDescriptor.java
 Can_break_an_electrical_circuit\ninterrupting_the_current.=Can break an electrical circuit\ninterrupting the current.
@@ -698,7 +632,6 @@ Set=Set
 The_time_interval_the\noutput_is_kept_high.=The time interval the\noutput is kept high.
 
 # ./src/main/java/mods/eln/sixnode/electricalvumeter/ElectricalVuMeterDescriptor.java
-Displays_a_color_based_on_the_value_of_a_signal=Displays a color based on the value of a signal
 Displays_the_value_of_a_signal.=Displays the value of a signal.
 
 # ./src/main/java/mods/eln/sixnode/electricalwatch/ElectricalWatchContainer.java
@@ -719,13 +652,6 @@ Storm\:_%1$V=Storm: %1$V
 Maximum_wind_speed_is_%1$m_s=Maximum wind speed is %1$m/s
 Provides_an_electrical_signal\ndependant_on_wind_speed.=Provides an electrical signal\ndependant on wind speed.
 You_can't_place_this_block_on_the_floor_or_the_ceiling=You can't place this block on the floor or the ceiling
-
-# ./src/main/java/mods/eln/sixnode/emergencylamp/EmergencyLampDescriptor.java
-As_long_as_power_is_provided,_the_internal_battery=As long as power is provided, the internal battery
-is_charged_and_the_lamp_is_off._On_a_power_failure,=is charged and the lamp is off. On a power failure,
-the_lamp_turns_on_and_runs_on_batteries.=the lamp turns on and runs on batteries.
-Nominal_voltage\:=Nominal voltage:
-Battery_capacity\:=Battery capacity:
 
 # ./src/main/java/mods/eln/sixnode/energymeter/EnergyMeterElement.java
 Counter=Counter
@@ -753,17 +679,13 @@ value_in_kJ=value in kJ
 # ./src/main/java/mods/eln/sixnode/groundcable/GroundCableDescriptor.java
 Can_be_used_to_set_a_point_of_an\nelectrical_network_to_0V_potential.\nFor_example_to_ground_negative_battery_contacts.=Can be used to set a point of an\nelectrical network to 0V potential.\nFor example to ground negative battery contacts.
 Provides_a_zero_volt_reference.=Provides a zero volt reference.
-Acts_as_a_ground_reference.=Acts as a ground reference.
-Has_a_small_resistance_inline=Has a small resistance inline
 
 # ./src/main/java/mods/eln/sixnode/hub/HubDescriptor.java
 Allows_crossing_cables\non_one_single_block.=Allows crossing cables\non one single block.
-A_bit_contrived,_as_the_wires_could_just_cross_over_each_other._Realism_depends_on_the_wires_used.=A bit contrived, as the wires could just cross over each other. Realism depends on the wires used.
 
 # ./src/main/java/mods/eln/sixnode/lampsocket/LampSocketDescriptor.java
 Angle\:_%1$°_to_%2$°=Angle: %1$° to %2$°
 Spot_range\:_%1$_blocks=Spot range: %1$ blocks
-Wireless_mode_of_lights_intended_to_pretend_wires_are_in_the_walls=Wireless mode of lights intended to pretend wires are in the walls
 
 # ./src/main/java/mods/eln/sixnode/lampsocket/LampSocketElement.java
 Bulb=Bulb
@@ -781,9 +703,6 @@ Electrical_cable_slot\nBase_range_is_32_blocks.\nEach_additional_cable\nincrease
 Capable_of_operating_3_light_channels.=Capable of operating 3 light channels.
 Supplies_power_to_nearby_lamps.=Supplies power to nearby lamps.
 Supports_control_from_a_wireless_signal\nchannel_for_each_lighting_channel.=Supports control from a wireless signal\nchannel for each lighting channel.
-Most_homes_have_a_circuit_breaker_panel_for_lights=Most homes have a circuit breaker panel for lights
-The_wireless_power_aspect_is_pretending_there_are_wires_in_the_walls=The wireless power aspect is pretending there are wires in the walls
-Wireless_control_signals_are_totally_possible=Wireless control signals are totally possible
 
 # ./src/main/java/mods/eln/sixnode/lampsupply/LampSupplyElement.java
 Total_power=Total power
@@ -807,32 +726,17 @@ Station_name=Station name
 Wireless_RX=Wireless RX
 Wireless_TX=Wireless TX
 
-# ./src/main/java/mods/eln/sixnode/PortableNaN.kt
-Voltage\:_Yes=Voltage: Yes
-Current\:_No=Current: No
-Serial_Resistance\:_OK_Ω=Serial Resistance: OK Ω
-A_debugging_feature_that_throws_NaN_(Not_a_Number)_anywhere_it_can_in_the_simulator_to_find_bugs=A debugging feature that throws NaN (Not a Number) anywhere it can in the simulator to find bugs
-
 # ./src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixContainer.java
 (Increases_maximum_voltage)=(Increases maximum voltage)
 
 # ./src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixElement.java
 Capacity=Capacity
 
-# ./src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixDescriptor.java
-Provides_capacitance._Use_with_dielectrics_and_redstone=Provides capacitance. Use with dielectrics and redstone
-It_doesn't_really_behave_well_for_DC=It doesn't really behave well for DC
-
 # ./src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixElement.java
 Inductance=Inductance
 
-# ./src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixDescriptor.java
-Provides_inductance._Use_with_iron_cores_and_bare_copper_cables=Provides inductance. Use with iron cores and bare copper cables
-*_Missing_an_inductive_voltage_spike_on_field_collapse=* Missing an inductive voltage spike on field collapse
-
 # ./src/main/java/mods/eln/sixnode/powersocket/PowerSocketDescriptor.java
 Supplies_any_device\nplugged_in_with_energy.=Supplies any device\nplugged in with energy.
-Homes_have_power_sockets._These_are_not_them.=Homes have power sockets. These are not them.
 
 # ./src/main/java/mods/eln/sixnode/powersocket/PowerSocketGui.java
 Specify_the_device_to_supply_through_this_socket.=Specify the device to supply through this socket.
@@ -843,15 +747,11 @@ Coal_dust_slot=Coal dust slot
 
 # ./src/main/java/mods/eln/sixnode/resistor/ResistorElement.java
 
-# ./src/main/java/mods/eln/sixnode/resistor/ResistorDescriptor.java
-It's_a_resistor=It's a resistor
-
 # ./src/main/java/mods/eln/sixnode/thermalcable/ThermalCableDescriptor.java
-High_parallel_resistance\n_⇨_Low_power_dissipation.=High parallel resistance\n ⇨ Low power dissipation.
-Low_serial_resistance\n_⇨_High_conductivity.=Low serial resistance\n ⇨ High conductivity.
+High_parallel_resistance\n_\=>_Low_power_dissipation.=High parallel resistance\n => Low power dissipation.
+Low_serial_resistance\n_\=>_High_conductivity.=Low serial resistance\n => High conductivity.
 Parallel_resistance\:_%1$K_W=Parallel resistance: %1$K/W
 Serial_resistance\:_%1$K_W=Serial resistance: %1$K/W
-The_thermal_simulator_doesn't_properly_manage_heat=The thermal simulator doesn't properly manage heat
 
 # ./src/main/java/mods/eln/sixnode/thermalcable/ThermalCableElement.java
 Thermic_power=Thermic power
@@ -881,18 +781,6 @@ Set_beacon_name=Set beacon name
 
 # ./src/main/java/mods/eln/sixnode/wirelesssignal/rx/WirelessSignalRxGui.java
 
-# ./src/main/java/mods/eln/sixnode/wirelesssignal/rx/WirelessSignalRxDescriptor.java
-Receive_signal_voltage_on_selected_wireless_signal_channel=Receive signal voltage on selected wireless signal channel
-It_should_require_power_to_receive_and_propogate_the_signal_realistically=It should require power to receive and propogate the signal realistically
-
-# ./src/main/java/mods/eln/sixnode/wirelesssignal/tx/WirelessSignalTxDescriptor.java
-Sends_signal_voltage_on_selected_wireless_signal_channel=Sends signal voltage on selected wireless signal channel
-It_should_require_power_to_transmit_realistically=It should require power to transmit realistically
-
-# ./src/main/java/mods/eln/sixnode/wirelesssignal/repeater/WirelessSignalRepeaterDescriptor.java
-Repeats_all_wireless_signals_in_range=Repeats all wireless signals in range
-It_should_require_power_realistically=It should require power realistically
-
 # ./src/main/java/mods/eln/transparentnode/FuelGenerator.kt
 Fuel_level=Fuel level
 Nominal_power\:_%1$_W=Nominal power: %1$ W
@@ -908,7 +796,7 @@ Furnace_is_off=Furnace is off
 Furnace_is_on=Furnace is on
 Heat_Power\:_%1$=Heat Power: %1$
 Set_point\:_%1$=Set point: %1$
-__Max._temperature\:_=  Max. temperature:
+__Max._temperature\:_=  Max. temperature: 
 
 # ./src/main/java/mods/eln/transparentnode/LargeRheostat.kt
 Control_resistance_with_signal=Control resistance with signal
@@ -916,9 +804,6 @@ Dissapates_~4kW_of_heat_passively=Dissapates ~4kW of heat passively
 Nom._Resistance\:_%1$=Nom. Resistance: %1$
 Power_loss=Power loss
 Set_resistance_with_coal_dust=Set resistance with coal dust
-Has_some_caveats\:=Has some caveats:
-__*_Resistance_is_not_impacted_by_temperature=  * Resistance is not impacted by temperature
-__*_Signal_input_doesn't_require_power=  * Signal input doesn't require power
 
 # ./src/main/java/mods/eln/transparentnode/autominer/AutoMinerContainer.java
 Drill_slot=Drill slot
@@ -942,20 +827,13 @@ Overheating_protection=Overheating protection
 Overvoltage_protection=Overvoltage protection
 
 # ./src/main/java/mods/eln/transparentnode/battery/BatteryDescriptor.java
-Actual_charge\:_=Actual charge:
-Energy_capacity\:_=Energy capacity:
-Internal_resistance\:_=Internal resistance:
-Life\:_=Life:
-Nominal_power\:_=Nominal power:
-Nominal_voltage\:_=Nominal voltage:
+Actual_charge\:_=Actual charge: 
+Energy_capacity\:_=Energy capacity: 
+Internal_resistance\:_=Internal resistance: 
+Life\:_=Life: 
+Nominal_power\:_=Nominal power: 
+Nominal_voltage\:_=Nominal voltage: 
 _charged_at_=charged at
-Battery_could_be_realistic_in_the_future=Battery could be realistic in the future
-__*_Batteries_have_internal_resistance=  * Batteries have internal resistance
-__*_Not_currently_simulating_any_particular_chemistry_of_battery=  * Not currently simulating any particular chemistry of battery
-Batteries_are_based_in_realistic_battery_designs_that_someone_might_implement_realistically\:=Batteries are based in realistic battery designs that someone might implement realistically\:
-__*_Single_use_batteries_emulate_a_voltaic_pile=  * Single use batteries emulate a voltaic pile
-__*_Current_oriented_uses_two_smaller_batteries_in_parallel_to_increase_current_capability=  * Current oriented uses two smaller batteries in parallel to increase current capability
-__*_Voltage_oriented_uses_two_smaller_batteries_in_series_to_increase_voltage=  * Voltage oriented uses two smaller batteries in series to increase voltage
 
 # ./src/main/java/mods/eln/transparentnode/battery/BatteryElement.java
 
@@ -1013,10 +891,6 @@ Cost=Cost
 # ./src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineElement.java
 Power_provided=Power provided
 
-# ./src/main/java/mods/eln/transparentnode/Fabricator.kt
-The_Fabricator_creates_chips\nfrom_silicon_and_copper_plates=The Fabricator creates chips\nfrom silicon and copper plates
-Nominal_Ohms\:_%1$=Nominal Ohms: %1$
-
 # ./src/main/java/mods/eln/transparentnode/heatfurnace/HeatFurnaceContainer.java
 Combustion_chamber_slot=Combustion chamber slot
 Fuel_slot=Fuel slot
@@ -1028,11 +902,6 @@ Set_temperature=Set temperature
 Control_gauge_at_%1$%=Control gauge at %1$%
 Decline_fuel=Decline fuel
 Take_fuel=Take fuel
-
-# ./src/main/java/mods/eln/transparentnode/NixieTube.kt
-Displays_a_single_glowing_digit.=Displays a single glowing digit.
-Signal_input_doesn't_require_power,_and_interfaces_are_tailored_to_gameplay=Signal input doesn't require power, and interfaces are tailored to gameplay
-Nixie_tube_has_been_textured_realistically=Nixie tube has been textured realistically
 
 # ./src/main/java/mods/eln/transparentnode/powercapacitor/PowerCapacitorContainer.java
 (Increases_maximal_voltage)=(Increases maximal voltage)
@@ -1085,20 +954,12 @@ Fan_voltage\:_%1$V=Fan voltage: %1$V
 
 # ./src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveElement.java
 
-# ./src/main/java/mods/eln/transparentnode/ThermalHeatExchanger.kt
-Generates_heat_when_supplied_with_ic2\:hotcoolant=Generates heat when supplied with ic2:hotcoolant
-Ejects_out_ic2\:coolant=Ejects out ic2:coolant
-
 # ./src/main/java/mods/eln/transparentnode/transformer/TransformerContainer.java
 Casing_slot=Casing slot
 
 # ./src/main/java/mods/eln/transparentnode/transformer/TransformerDescriptor.java
 The_voltage_ratio_is_proportional\nto_the_cable_stacks_count_ratio.=The voltage ratio is proportional\nto the cable stacks count ratio.
 Transforms_an_input_voltage_to\nan_output_voltage.=Transforms an input voltage to\nan output voltage.
-The_output_voltage_is_controlled\nfrom_a_signal_input=The output voltage is controlled\nfrom a signal input
-This_variable_DC_DC_has_unrealistic_capacitance_effects_and_can_sink_source_power_that_violates_Newton's_laws=This variable DC DC has unrealistic capacitance effects and can sink source power that violates Newton's laws
-It_is_made_this_way_to_improve_the_performance_of_the_simulator_in_large_power_networks=It is made this way to improve the performance of the simulator in large power networks
-This_DC_DC_has_unrealistic_capacitance_effects_and_can_sink_source_power_that_violates_Newton's_laws=This DC DC has unrealistic capacitance effects and can sink source power that violates Newton's laws
 
 # ./src/main/java/mods/eln/transparentnode/transformer/TransformerElement.java
 Core_factor=Core factor
@@ -1213,7 +1074,6 @@ Is_off=Is off
 Is_on=Is on
 Life=Life
 Max._temperature\:_%1$°C=Max. temperature: %1$°C
-miaou=miaou
 Min._temperature\:_%1$°C=Min. temperature: %1$°C
 Measured_value\ncorresponding\nto_0%_output=Measured value\ncorresponding\nto 0% output
 Measured_value\ncorresponding\nto_100%_output=Measured value\ncorresponding\nto 100% output
@@ -1240,7 +1100,6 @@ Powered_by_Lamp_Supply=Powered by Lamp Supply
 Powered_by_cable=Powered by cable
 Produced_power=Produced power
 Range\:_%1$_blocks=Range: %1$ blocks
-Really_useless=Really useless
 Redstone_slot=Redstone slot
 Redstone_value=Redstone value
 Regulator_slot=Regulator slot
@@ -1262,7 +1121,6 @@ Toggle=Toggle
 Toggle_switch=Toggle switch
 Toggles_the_output_each_time\nan_emitter's_value_rises.\nUseful_to_allow_multiple_buttons\nto_control_the_same_light.=Toggles the output each time\nan emitter's value rises.\nUseful to allow multiple buttons\nto control the same light.
 Used_to_cool_down_turbines.=Used to cool down turbines.
-useless=useless
 Uses_the_biggest\nvalue_on_the_channel.=Uses the biggest\nvalue on the channel.
 Uses_the_smallest\nvalue_on_the_channel.=Uses the smallest\nvalue on the channel.
 Validate=Validate
@@ -1272,7 +1130,7 @@ Voltage_drop=Voltage drop
 Voltages=Voltages
 Yes=Yes
 You_can't_place_this_block_at_this_side=You can't place this block at this side
-_O\:_= O:
+_O\:_= O: 
 
 # FIXME
 Grid_DC-DC_Converter.name=Grid Transformer
@@ -1316,42 +1174,3 @@ Type_E_Socket.name=Type E Socket
 Type_J_Socket.name=Type J Socket
 Conduit.name=Conduit Cable
 tile.eln.Conduit.name=Conduit Block
-Subsystem_Matrix_Size=Subsystem Matrix Size
-Charging...=Charging...
-Batteries_empty=Batteries empty
-Fully_charged=Fully charged
-Simple=Simple
-Slots=Slots
-Inputs=Inputs
-Min=Min
-Max=Max
-Speed=Speed
-Speeds=Speeds
-Energies=Energies
-Clutching=Clutching
-Fuel_usage=Fuel usage
-Process_State=Process State
-Can_Process=Can Process
-Not_as_warm_as_it_could_be=Not as warm as it could be
-It_probably_works_if_you_apply_~200v_to_the_xmas_wireless_channel=It probably works if you apply ~200v to the xmas wireless channel
-Control=Control
-input_tank_level=input tank level
-output_tank_level=output tank level
-input_mB_t=input mB/t
-output_mB_t=output mB/t
-joules_per_tick=joules per tick
-thermal_power=thermal power
-Left=Left
-Right=Right
-Transfer=Transfer
-Drive=Drive
-Signal=Signal
-Closed?=Closed?
-Digit=Digit
-Blank=Blank
-Dots=Dots
-No_wireless_signal_in_area!=No wireless signal in area!
-_Strength= Strength
-_Value= Value
-Control_Voltage=Control Voltage
-Operation=Operation

--- a/src/main/resources/assets/eln/lang/en_US.lang
+++ b/src/main/resources/assets/eln/lang/en_US.lang
@@ -423,6 +423,8 @@ Stored_Energy\:_%1$J_(%2$%)=Stored Energy: %1$J (%2$%)
 
 # ./src/main/java/mods/eln/mechanical/Clutch.kt
 Prevents_clutches_from_slipping\nagain_after_they_stop.=Prevents clutches from slipping\nagain after they stop.
+Clutch_Plate=Clutch Plate
+Clutch_Pin=Clutch Pin
 
 # ./src/main/java/mods/eln/mechanical/CrankableShaft.kt
 Player_crankable_shaft=Player crankable shaft
@@ -430,16 +432,15 @@ Can_rotate_slowly=Can rotate slowly
 
 # ./src/main/java/mods/eln/mechanical/Generator.kt
 Converts_mechanical_energy_into_electricity,_or_(badly)_vice_versa.=将机械能转换为电能，或反之(低效)。
-Voltage_out\:_%1$=Voltage out: %1$
-Power_out\:_%1$=Power out: %1$
-Rads\:_%1$=Rads: %1$
+__Voltage_out\:_=Voltage out:
+__Rads\:_%1$=  Rads: %1$
 
 # ./src/main/java/mods/eln/mechanical/Motor.kt
 Converts_electricity_into_mechanical_energy,_or_(badly)_vice_versa.=Converts electricity into mechanical energy, or (badly) vice versa.
-Voltage_in\:_%1$=Voltage in: %1$
-Power_in\:_%1$=Power in: %1$
-rad_s\:_%1$=rad/s: %1$
-Max_rad_s\:_%1$=Max rad/s: %1$
+__Voltage_in\:_=  Voltage in:
+__Power_in\:_=  Power in:
+__rad_s\:_=  rad/s:
+Max_rad_s\:_=Max rad/s:
 
 # ./src/main/java/mods/eln/mechanical/Tachometer.kt
 Rads_s_corresponding\nto_0%_output=Rads/s corresponding\nto 0% output
@@ -450,10 +451,10 @@ Converts_%1$_into_mechanical_energy.=Converts %1$ into mechanical energy.
 Nominal_usage_->=Nominal usage ->
 %1$_input\:_%2$_mB_s=%1$ input: %2$ mB/s
 No_valid_fluids_for_this_turbine!=No valid fluids for this turbine!
-Power_out\:_%1$=Power out: %1$
+__Power_out\:_=Power out:
 Power_out\:_%1$-_%2$=Power out: %1$- %2$
-Optimal_rads\:_%1$=Optimal rads: %1$
-Max_rads\:__%1$=Max rads:  %1$
+__Optimal_rads\:_=Optimal rads:
+Max_rads\:__=Max rads:
 
 # ./src/main/java/mods/eln/misc/UtilsClient.java
 Hold_[shift]_for_details=Hold [shift] for details
@@ -563,7 +564,7 @@ Cable_is_adapted_to_conduct\nelectrical_signals.=Cable is adapted to conduct\nel
 Current\:_%1$A=Current: %1$A
 Nominal_Ratings\:=Nominal Ratings:
 Not_adapted_to_transport_power.=Not adapted to transport power.
-Serial_resistance\:_%1$\u2126=Serial resistance: %1$\u2126
+Serial_resistance\:_%1$Ω=Serial resistance: %1$Ω
 __*_Wire_resistance_is_much_higher_than_normal=  * Wire resistance is much higher than normal
 __*_Wire_resistance_is_not_impacted_by_temperature=  * Wire resistance is not impacted by temperature
 __*_Wire_voltage_current_limits_are_arbitrary_values,_added_as_a_gameplay_mechanic=  * Wire voltage current limits are arbitrary values, added as a gameplay mechanic
@@ -767,6 +768,7 @@ Wireless_mode_of_lights_intended_to_pretend_wires_are_in_the_walls=Wireless mode
 
 # ./src/main/java/mods/eln/sixnode/lampsocket/LampSocketElement.java
 Bulb=Bulb
+Life_Left\:_=Life Left:
 
 # ./src/main/java/mods/eln/sixnode/lampsocket/LampSocketGuiDraw.java
 Cable_slot_empty=Cable slot empty
@@ -847,8 +849,8 @@ Coal_dust_slot=Coal dust slot
 It's_a_resistor=It's a resistor
 
 # ./src/main/java/mods/eln/sixnode/thermalcable/ThermalCableDescriptor.java
-High_parallel_resistance\n_⇨_Low_power_dissipation.=High parallel resistance\n ⇨ Low power dissipation.
-Low_serial_resistance\n_⇨_High_conductivity.=Low serial resistance\n ⇨ High conductivity.
+High_parallel_resistance\n_->_Low_power_dissipation.=High parallel resistance\n -> Low power dissipation.
+Low_serial_resistance\n_->_High_conductivity.=Low serial resistance\n -> High conductivity.
 Parallel_resistance\:_%1$K_W=Parallel resistance: %1$K/W
 Serial_resistance\:_%1$K_W=Serial resistance: %1$K/W
 The_thermal_simulator_doesn't_properly_manage_heat=The thermal simulator doesn't properly manage heat
@@ -900,14 +902,14 @@ Nominal_voltage\:_%1$_V=Nominal voltage: %1$ V
 Produces_electricity_using_gasoline.=Produces electricity using gasoline.
 
 # ./src/main/java/mods/eln/transparentnode/FuelHeatFurnace.kt
-Actual\:_%1$=Actual: %1$
+Actual\:_=Actual:
 Analog_regulator_slot=Analog regulator slot
-Control_value_at_%1$=Control value at %1$
+Control_value_at_=Control value at
 Fuel_burner_slot=Fuel burner slot
 Furnace_is_off=Furnace is off
 Furnace_is_on=Furnace is on
-Heat_Power\:_%1$=Heat Power: %1$
-Set_point\:_%1$=Set point: %1$
+Heat_Power\:_=Heat Power:
+Set_point\:_=Set point:
 __Max._temperature\:_=  Max. temperature:
 
 # ./src/main/java/mods/eln/transparentnode/LargeRheostat.kt
@@ -963,7 +965,7 @@ __*_Voltage_oriented_uses_two_smaller_batteries_in_series_to_increase_voltage=  
 Charged=Charged
 Discharge=Discharge
 Energy\:=Energy:
-Energy\:_%1$=Energy: %1$
+Energy\:_=Energy:
 Life\:=Life:
 No_charge=No charge
 Power_in\:=Power in:
@@ -1208,7 +1210,7 @@ Inductance\:_%1$H=Inductance: %1$H
 Input=Input
 Input_voltage=Input voltage
 Internal_control=Internal control
-Internal_resistance\:_%1$\u2126=Internal resistance: %1$\u2126
+Internal_resistance\:_%1$Ω=Internal resistance: %1$Ω
 Is_off=Is off
 Is_on=Is on
 Life=Life
@@ -1246,7 +1248,7 @@ Redstone_value=Redstone value
 Regulator_slot=Regulator slot
 Reset=Reset
 Resistance=Resistance
-Resistance\:_%1$\u2126=Resistance: %1$\u2126
+Resistance\:_%1$Ω=Resistance: %1$Ω
 Signal_Voltage=Signal Voltage
 Smallest=Smallest
 Specify_the_channel=Specify the channel

--- a/src/main/resources/assets/eln/lang/zh_CN.lang
+++ b/src/main/resources/assets/eln/lang/zh_CN.lang
@@ -423,8 +423,6 @@ Stored_Energy\:_%1$J_(%2$%)=储存的能量: %1$J (%2$%)
 
 # ./src/main/java/mods/eln/mechanical/Clutch.kt
 Prevents_clutches_from_slipping\nagain_after_they_stop.=防止离合器停止后打滑。
-Clutch_Plate=槽(离合器片)
-Clutch_Pin=槽(离合器销)
 
 # ./src/main/java/mods/eln/mechanical/CrankableShaft.kt
 Player_crankable_shaft=手动曲轴
@@ -1287,7 +1285,7 @@ Utility_Pole_w/DC-DC_Converter.name=T1电线杆(变压器)
 Portable_NaN.name=便携式NaN(开发项目)
 Old_800V_Arc_Furnace.name=电弧炉(800V,10kW)
 Christmas_Tree.name=圣诞树
-Holiday_Candle.name=节日蜡烛
+Holiday_Candle.name=假日蜡烛
 String_Lights.name=一串灯
 Radial_Motor.name=发动机(燃气,64mB/s)
 Thermal_Heat_Exchanger.name=热交换器
@@ -1333,7 +1331,7 @@ Energies=动能
 Clutching=制动力信号
 Fuel_usage=燃料消耗速度
 Process_State=加工进度
-Can_Process=工作中
+Can_Process=可以工作
 Not_as_warm_as_it_could_be=没有达到预期的温暖程度
 It_probably_works_if_you_apply_~200v_to_the_xmas_wireless_channel=如果你在"xmas"无线照明频道中输入200V，它可能会工作
 Control=控制

--- a/src/main/resources/assets/eln/lang/zh_CN.lang
+++ b/src/main/resources/assets/eln/lang/zh_CN.lang
@@ -423,6 +423,8 @@ Stored_Energy\:_%1$J_(%2$%)=储存的能量: %1$J (%2$%)
 
 # ./src/main/java/mods/eln/mechanical/Clutch.kt
 Prevents_clutches_from_slipping\nagain_after_they_stop.=防止离合器停止后打滑。
+Clutch_Plate=槽(离合器片)
+Clutch_Pin=槽(离合器销)
 
 # ./src/main/java/mods/eln/mechanical/CrankableShaft.kt
 Player_crankable_shaft=手动曲轴
@@ -1285,7 +1287,7 @@ Utility_Pole_w/DC-DC_Converter.name=T1电线杆(变压器)
 Portable_NaN.name=便携式NaN(开发项目)
 Old_800V_Arc_Furnace.name=电弧炉(800V,10kW)
 Christmas_Tree.name=圣诞树
-Holiday_Candle.name=假日蜡烛
+Holiday_Candle.name=节日蜡烛
 String_Lights.name=一串灯
 Radial_Motor.name=发动机(燃气,64mB/s)
 Thermal_Heat_Exchanger.name=热交换器
@@ -1331,7 +1333,7 @@ Energies=动能
 Clutching=制动力信号
 Fuel_usage=燃料消耗速度
 Process_State=加工进度
-Can_Process=可以工作
+Can_Process=工作中
 Not_as_warm_as_it_could_be=没有达到预期的温暖程度
 It_probably_works_if_you_apply_~200v_to_the_xmas_wireless_channel=如果你在"xmas"无线照明频道中输入200V，它可能会工作
 Control=控制

--- a/src/main/resources/assets/eln/lang/zh_CN.lang
+++ b/src/main/resources/assets/eln/lang/zh_CN.lang
@@ -1,155 +1,212 @@
 #<ELN_LANGFILE_V1_1>
 
 # ./src/main/java/mods/eln/Achievements.java
-Electrical_Age_[WIP]=电力时代Electrical Age\n(translate by KLsz and polish by aneBlack)
+Electrical_Age_[WIP]=电力时代Electrical Age\n(translate by KLsz and polish by aneBlack,later polished by Eternal130)
 achievement.craft_50v_macerator=初入粉碎之法
-achievement.craft_50v_macerator.desc=50V的粉碎工艺！
+achievement.craft_50v_macerator.desc=合成一个粉碎机(50v)
 achievement.open_guide=学会内置Wiki
 achievement.open_guide.desc=内置Wiki的能量,超乎你想象
 
 # ./src/main/java/mods/eln/Eln.java
 10A_Diode.name=二极管(10A)
-200V_Active_Thermal_Dissipator.name=散热器(T\:200W+1.2kW,200°C;E\:200V,60W)
+800V_Arc_Furnace.name=电弧炉(800V,10kW)
+Experimental_Battery.name=实验电池
+Creative_Cable.name=创造超导体导线
+2x_Graphite_Rods.name=2联碳棒
+200V_Active_Thermal_Dissipator.name=散热器(主动,冷却功率:200W+1.2kW,最高温度:130°C,风扇参数:200V,60W)
 200V_Battery_Charger.name=电池充电器(200V,1kW)
-200V_Compressor.name=压缩机(200V)
+200V_Compressor.name=压缩机(200V,2.00kW)
 200V_Condensator.name=电容(200V)
-200V_Copper_Heating_Corp.name=铜电热丝(200V,600W)
+200V_Copper_Heating_Corp.name=加热器(铜,200V,600W)
 200V_Economic_Light_Bulb.name=节能灯泡(200V,15W)
+200V_Emergency_Lamp.name=应急灯(200V)
 200V_Farming_Lamp.name=暖箱灯泡(200V,120W)
-200V_Fuel_Generator.name=200V Fuel Generator
+200V_Fuel_Generator.name=发电机(轻油,200V,6kW)
 200V_Incandescent_Light_Bulb.name=白炽灯泡(200V,30W)
-200V_Iron_Heating_Corp.name=铁电热丝(200V,900W)
-200V_LED_Bulb.name=200V LED Bulb
-200V_Macerator.name=粉碎机(200V,400W)
-200V_Magnetizer.name=磁化器(200V,400W)
-200V_Plate_Machine.name=冷轧机(200V,400W)
-200V_Power_Socket.name=能源接口(200V)
-200V_Tungsten_Heating_Corp.name=钨电热丝(200V,1.2kW)
-200V_Turbine.name=发电机(温差,200V,500W,Δ350°C)
+200V_Iron_Heating_Corp.name=加热器(铁,200V,900W)
+200V_LED_Bulb.name=LED灯泡(200V,15W)
+200V_Macerator.name=粉碎机(200V,2.00kW)
+200V_Magnetizer.name=磁化机(200V,2.00kW)
+200V_Plate_Machine.name=冷轧机(200V,2.00kW)
+200V_Power_Socket.name=插座(200V)
+200V_Tungsten_Heating_Corp.name=加热器(钨,200V,1.2kW)
+200V_Turbine.name=发电机(温差,200V,2.00kW,Δ350°C)
 25A_Diode.name=二极管(25A)
+2x3_Rotating_Solar_Panel.name=2x3自适应太阳能板
+2x3_Solar_Panel.name=2x3太阳能板
+3.2kV_Tungsten_Heating_Corp.name=加热器(钨,3.2kV,12.0kW)
+3x_Graphite_Rods.name=3联碳棒
+4x_Graphite_Rods.name=4联碳棒
 50V_Battery_Charger.name=电池充电器(50V,400W)
 50V_Carbon_Incandescent_Light_Bulb.name=碳丝灯泡(50V,25W)
-50V_Compressor.name=压缩机(50V)
+50V_Compressor.name=压缩机(50V,200W)
 50V_Condensator.name=电容(50V)
-50V_Copper_Heating_Corp.name=铜电热丝(50V,250W)
+50V_Copper_Heating_Corp.name=加热器(铜,50V,250W)
 50V_Economic_Light_Bulb.name=节能灯泡(50V,15W)
 50V_Egg_Incubator.name=鸡蛋孵化器(50V)
+50V_Emergency_Lamp.name=应急灯(50V)
 50V_Farming_Lamp.name=暖箱灯泡(50V,120W)
-50V_Fuel_Generator.name=50V Fuel Generator
+50V_Fuel_Generator.name=发电机(轻油,50V,1.2kW)
 50V_Incandescent_Light_Bulb.name=白炽灯泡(50V,30W)
-50V_Iron_Heating_Corp.name=铁电热丝(50V,375W)
-50V_LED_Bulb.name=50V LED Bulb
+50V_Iron_Heating_Corp.name=加热器(铁,50V,375W)
+50V_LED_Bulb.name=LED灯泡(50V,15W)
 50V_Macerator.name=粉碎机(50V,200W)
 50V_Magnetizer.name=磁化机(50V,200W)
 50V_Plate_Machine.name=冷轧机(50V,200W)
-50V_Power_Socket.name=能源接口(50V)
-50V_Tungsten_Heating_Corp.name=钨电热丝(50V,500W)
+50V_Power_Socket.name=插座(50V)
+50V_Tungsten_Heating_Corp.name=加热器(钨,50V,500W)
 50V_Turbine.name=发电机(温差,50V,300W,Δ250°C)
-800V_Defence_Turret.name=防御塔(800V,min-50W,max-1kW)
-AND_Chip.name=AND Chip
+800V_Defence_Turret.name=防御塔(800V,最低100W,最高10kW)
+800V_Tungsten_Heating_Corp.name=加热器(钨,800V,4.81kW)
+AND_Chip.name=数字集成电路(与)
 Advanced_Chip.name=芯片(高级)
 Advanced_Electrical_Motor.name=电机(高级)
-Advanced_Energy_Meter.name=电能表(高级)
+Advanced_Energy_Meter.name=电表(高级)
 Advanced_Machine_Block.name=机器方块(高级)
 Advanced_Magnet.name=磁铁(高级)
 AllMeter.name=通用表
 Alloy_Dust.name=钨钢合金粉
 Alloy_Ingot.name=钨钢合金锭
 Alloy_Plate.name=钨钢合金板
+Amplifier.name=模拟集成电路(功率放大器)
 Analog_Watch.name=模拟时钟
-Analog_vuMeter.name=模拟电压表(信号)
-Analogic_Regulator.name=模拟温控组件
+Analog_vuMeter.name=信号计(模拟)
+Analogic_Regulator.name=温控组件(敏感度:模拟)
 Animal_Filter.name=动物筛选组件
+Arc_Clay_Ingot.name=铝锭
+Arc_Metal_Ingot.name=钢锭
 Auto_Miner.name=自动挖矿机(800V)
-Average_Electrical_Drill.name=电钻(1kW,5")
-Average_Ferromagnetic_Core.name=磁能核心(4.0)
+Average_Electrical_Drill.name=钻头(1kW,5")
+Average_Ferromagnetic_Core.name=铁磁芯(50.0)
 Basic_Magnet.name=磁铁(基础)
+Big_Fuel_Burner.name=大型燃料燃烧器
 Black_Brush.name=刷子(黑)
+Blown_Lead_Fuse.name=铅保险丝
 Blue_Brush.name=刷子(蓝)
 Brown_Brush.name=刷子(棕)
-Capacity_Oriented_Battery.name=电源(容量更大,12V,125W,240kJ)
+Capacity_Oriented_Battery.name=电池(容量更大,12.5V,125W,480KJ)
+Canister_of_Arc_Water.name=惰性炭罐(电弧液)
+Canister_of_Water.name=惰性炭罐(水)
+Casing.name=变压器罩
 Cheap_Chip.name=芯片(基础)
-Cheap_Electrical_Drill.name=电钻(500W,8")
-Cheap_Ferromagnetic_Core.name=磁能核心(10.0)
+Cheap_Electrical_Drill.name=钻头(500W,8")
+Cheap_Ferromagnetic_Core.name=劣质铁磁芯(100.0)
 Cinnabar_Dust.name=朱砂粉
 Cinnabar_Ore.name=朱砂矿石
-Coal_Dust.name=煤粉
-Coal_Plate.name=煤板
-Combustion_Chamber.name=炉膛组件
+Clutch.name=离合器
+Clutch_Pin.name=离合器销
+Coal_Clutch_Plate.name=碳离合器片
+Coal_Dust.name=碳粉
+Coal_Plate.name=碳板
+Combustion_Chamber.name=燃烧室
+Config_Copy_Tool.name=配置复制工具
+Configurable_summing_unit.name=模拟集成电路(可配置求和单元)
 Copper_Cable.name=导线(铜)
+Copper_Clutch_Plate.name=铜离合器片
 Copper_Dust.name=铜粉
 Copper_Ingot.name=铜锭
 Copper_Ore.name=铜矿
 Copper_Plate.name=铜板
-Copper_Thermal_Cable.name=导热管(铜,1k°C)
-Cost_Oriented_Battery.name=电源(更廉价,50V,250W,60KJ)
-Current_Oriented_Battery.name=电源(电流更大,50V,1000W,40KJ)
+Copper_Thermal_Cable.name=热管(铜,980°C)
+Cost_Oriented_Battery.name=电池(更廉价,50V,250W,120KJ)
+Current_Oriented_Battery.name=电池(电流更大,50V,1.0kW,80KJ)
 Cyan_Brush.name=刷子(青)
-D_Flip_Flop_Chip.name=D Flip Flop Chip
+Legacy_DC-DC_Converter.name=直流-直流 变压器(传统)
+DC-DC_Converter.name=直流-直流 变压器
+Variable_DC-DC_Converter.name=直流-直流 变压器(可调)
+D_Flip_Flop_Chip.name=数字集成电路(边缘D触发器)
 Data_Logger.name=示波器(台式,信号)
 Data_Logger_Print.name=示波器(打印,信号)
+Diamond_Dust.name=钻石粉
 Dielectric.name=绝缘体
+Digital_Display.name=信号显示器
 Digital_Watch.name=数字时钟
 Electrical_Anemometer_Sensor.name=传感器(风力)
 Electrical_Breaker.name=断路器
-Electrical_Daylight_Sensor.name=感应器(阳光)
-Electrical_Entity_Sensor.name=感应器(实体)
-Electrical_Fire_Detector.name=电气火花传感器
+Electrical_Daylight_Sensor.name=传感器(阳光)
+Electrical_Entity_Sensor.name=传感器(实体)
+Electrical_Fire_Buzzer.name=蜂鸣器(火警)
+Electrical_Fire_Detector.name=传感器(火警)
 Electrical_Furnace.name=电炉
-Electrical_Light_Sensor.name=感应器(光)
+Electrical_Fuse_Holder.name=保险盒
+Electrical_Light_Sensor.name=传感器(光)
 Electrical_Motor.name=电机
-Electrical_Probe.name=电力传感器
-Electrical_Probe_Chip.name=芯片(电力传感器)
-Electrical_Source.name=电源
+Electrical_Probe.name=探测器(电气)
+Electrical_Probe_Chip.name=芯片(电气探测器)
+Electrical_Source.name=电压源
 Electrical_Timer.name=断路延时器
 Electrical_Weather_Sensor.name=传感器(天气)
-Electrical_age_wrench,\nCan_be_used_to_turn\nsmall_wall_blocks=扳手用来翻转一些小方块
-Energy_Meter.name=电能表
-Experimental_Transporter.name=传送机
-Fast_Electrical_Drill.name=电钻(2kW,3")
+Electrical_age_wrench,\nCan_be_used_to_turn\nsmall_wall_blocks=扳手用来旋转一些小设备或打开设置界面
+Energy_Meter.name=电表
+Experimental_Transporter.name=传送机(实验性)
+Fast_Electrical_Drill.name=钻头(2kW,3")
 Ferrite_Ingot.name=铁氧体锭
+Fixed_Shaft.name=固定轴
 Flat_Lamp_Socket.name=灯座(扁平)
 Fluorescent_Lamp_Socket.name=灯座(荧光)
-Generator.name=Generator
+Flywheel.name=飞轮
+Fuel_Heat_Furnace.name=燃油加热炉
+Gas_Turbine.name=发动机(燃气,4mB/s)
+Generator.name=发电机(动能,3.2kV,4.0kW)
+Shaft_Motor.name=发动机(电力,3.2kV,1.2kW)
+Gold_Clutch_Plate.name=金离合器片
 Gold_Dust.name=金粉
 Gold_Plate.name=金板
+Graphite_Rod.name=碳棒
 Gray_Brush.name=刷子(灰)
 Green_Brush.name=刷子(绿)
 Ground_Cable.name=导线(接地)
-High_Power_Receiver_Antenna.name=天线(接收)(800V,2kW)
-High_Power_Transmitter_Antenna.name=天线(发射)(800V,2kW,300m)
+High_Current_Cable.name=导线(100A,12.0MW)
+High_Power_Receiver_Antenna.name=天线(接收,800V,2kW)
+High_Power_Transmitter_Antenna.name=天线(发射,800V,2kW,300m)
 High_Voltage_Cable.name=导线(800V,5kW)
 High_Voltage_Relay.name=继电器(800V)
 High_Voltage_Switch.name=开关(800V)
 Hub.name=集线器
 Industrial_Data_Logger.name=示波器(工业,信号)
+Inert_Canister.name=惰性炭罐
 Iron_Cable.name=导线(铁)
+Iron_Clutch_Plate.name=铁离合器片
 Iron_Dust.name=铁粉
 Iron_Plate.name=铁板
-JK_Flip_Flop_Chip.name=JK Flip Flop Chip
-LED_vuMeter.name=LED指示灯
+Irresponsible_Electrical_Drill.name=钻头(200kW,0.1")
+JK_Flip_Flop_Chip.name=数字集成电路(JK触发器)
+Joint.name=转轴
+Joint_hub.name=万向节轮毂
+LED_vuMeter.name=信号计(LED)
 Lamp_Socket_A.name=灯座(圆盘式)
 Lamp_Socket_B_Projector.name=灯座(圆盘式,高级)
 Lamp_Supply.name=无线照明控制盒
-Large_Rheostat.name=Large Rheostat
+Lapis_Dust.name=青金石粉
+Large_Rheostat.name=变阻器(大型)
+Lead_Clutch_Plate.name=铅离合器片
 Lead_Dust.name=铅粉
+Lead_Fuse_for_high_voltage_cables.name=铅保险丝(高压)
+Lead_Fuse_for_low_voltage_cables.name=铅保险丝(低压)
+Lead_Fuse_for_medium_voltage_cables.name=铅保险丝(中压)
+Lead_Fuse_for_very_high_voltage_cables.name=铅保险丝(超高压)
 Lead_Ingot.name=铅锭
 Lead_Ore.name=铅矿石
 Lead_Plate.name=铅板
-Life_Oriented_Battery.name=电源(生命更长,50V,250W,60KJ)
+Life_Oriented_Battery.name=电池(寿命更长,50V,250W,120KJ)
 Light_Blue_Brush.name=刷子(浅蓝)
 Lime_Brush.name=刷子(黄绿)
 Long_Suspended_Lamp_Socket.name=灯座(吊挂,长)
-Low_Power_Receiver_Antenna.name=天线(接收)(50V,250W)
-Low_Power_Transmitter_Antenna.name=天线(发射)(50V,250W,200m)
+Long_Suspended_Lamp_Socket_(No_Swing).name=灯座(吊挂,长,无摆动)
+Low_Current_Cable.name=导线(5A,600kW)
+Low_Power_Receiver_Antenna.name=天线(接收,50V,250W)
+Low_Power_Transmitter_Antenna.name=天线(发射,50V,250W,200m)
 Low_Voltage_Cable.name=导线(50V,1kW)
 Low_Voltage_Relay.name=继电器(50V)
 Low_Voltage_Switch.name=开关(50V)
+Lowpass_filter.name=模拟集成电路(低通滤波器)
 Machine_Block.name=机器方块
-Machine_Booster.name=增压器
+Machine_Booster.name=增压升级
 Magenta_Brush.name=刷子(品红)
-Medium_Power_Receiver_Antenna.name=天线(接收)(200V,1kW)
-Medium_Power_Transmitter_Antenna.name=天线(发射)(200V,1kW,250m)
+Medium_Current_Cable.name=导线(20A,2.40MW)
+Medium_Fuel_Burner.name=中型燃料燃烧器
+Medium_Power_Receiver_Antenna.name=天线(接收,200V,1kW)
+Medium_Power_Transmitter_Antenna.name=天线(发射,200V,1kW,250m)
 Medium_Voltage_Cable.name=导线(200V,2kW)
 Medium_Voltage_Relay.name=继电器(200V)
 Medium_Voltage_Switch.name=开关(200V)
@@ -159,27 +216,30 @@ Modbus_RTU.name=Modbus RTU通讯协议
 Modern_Data_Logger.name=示波器(薄屏,信号)
 Monster_Filter.name=怪物筛选组件
 MultiMeter.name=万用表
-NAND_Chip.name=NAND Chip
-NOR_Chip.name=NOR Chip
-NOT_Chip.name=NOT Chip
-Nuclear_Alarm.name=警报(核)
-OR_Chip.name=OR Chip
-On_OFF_Regulator_10_Percent.name=开/关温控10%
-On_OFF_Regulator_1_Percent.name=开/关温控1%
-Optimal_Ferromagnetic_Core.name=磁能核心(1.0)
+NAND_Chip.name=数字集成电路(与非)
+NOR_Chip.name=数字集成电路(或非)
+NOT_Chip.name=数字集成电路(非)
+Nixie_Tube.name=辉光管
+Nuclear_Alarm.name=警报器(声音:核打击)
+OR_Chip.name=数字集成电路(或)
+On/OFF_Regulator_10_Percent.name=温控组件(敏感度:10%)
+On/OFF_Regulator_1_Percent.name=温控组件(敏感度:1%)
+OpAmp.name=模拟集成电路(运算放大器)
+Optimal_Ferromagnetic_Core.name=优质铁磁芯(1.0)
 Orange_Brush.name=刷子(橙)
 Ore_Scanner.name=矿物扫描仪
-Oscillator_Chip.name=Oscillator Chip
+Oscillator_Chip.name=数字集成电路(振荡器)
 Overheating_Protection.name=保护装置(过热)
 Overvoltage_Protection.name=保护装置(过压)
-PAL_Chip.name=PAL Chip
+PAL_Chip.name=数字集成电路(PAL)
+PID_Regulator.name=模拟集成电路(PID调节器)
 Pink_Brush.name=刷子(粉)
 Player_Filter.name=玩家筛选组件
-Portable_Battery.name=移动电池
-Portable_Battery_Pack.name=移动电池包
-Portable_Condensator.name=移动电容
-Portable_Condensator_Pack.name=移动电容包
-Portable_Electrical_Axe.name=电斧
+Portable_Battery.name=便携电池
+Portable_Battery_Pack.name=便携电池包
+Portable_Condensator.name=移便携电容
+Portable_Condensator_Pack.name=便携电容包
+Portable_Electrical_Axe.name=电锯
 Portable_Electrical_Mining_Drill.name=电钻
 Power_Capacitor.name=电容
 Power_Inductor.name=电感
@@ -188,14 +248,17 @@ Power_capacitor.name=电容
 Power_inductor.name=电感
 Purple_Brush.name=刷子(紫)
 Red_Brush.name=刷子(红)
-Redstone-to-Voltage_Converter.name=转换器(红石→电)
+Redstone-to-Voltage_Converter.name=红石-电压转换器
 Rheostat.name=变阻器
 Robust_Lamp_Socket.name=灯座(小)
 Rubber.name=橡胶
-Schmitt_Trigger_Chip.name=Schmitt Trigger Chip
+Sample_and_hold.name=模拟集成电路(采样保持)
+Scanner.name=扫描仪
+Schmitt_Trigger_Chip.name=数字集成电路(施密特触发器)
 Sconce_Lamp_Socket.name=灯座(壁挂)
 Signal_20H_inductor.name=电感(20H)(信号)
-Signal_Antenna.name=天线(信号)
+Signal_Antenna.name=信号天线
+Signal_Bus_Cable.name=信号总线电缆
 Signal_Button.name=按钮(信号)
 Signal_Cable.name=导线(信号)
 Signal_Diode.name=二极管(信号)
@@ -203,199 +266,317 @@ Signal_Processor.name=信号处理器
 Signal_Relay.name=继电器(信号)
 Signal_Source.name=信号源
 Signal_Switch.name=开关(信号)
-Signal_Switch_with_LED.name=开关(信号)(LED)
+Signal_Switch_with_LED.name=开关(信号,LED)
 Signal_Trimmer.name=信号发生器
 Silicon_Dust.name=硅粉
 Silicon_Ingot.name=硅锭
 Silicon_Plate.name=硅板
-Silver_Brush.name=刷子(银)
+Silver_Brush.name=刷子(淡灰)
 Simple_Lamp_Socket.name=灯座(普通)
-Single-use_Battery.name=电源(一次性,50V,500W,120kJ)
-Small_200V_Copper_Heating_Corp.name=加热核心(铜,200V,小)
-Small_200V_Iron_Heating_Corp.name=加热核心(铁,200V,小)
-Small_200V_Tungsten_Heating_Corp.name=加热核心(钨,200V,小)
-Small_50V_Carbon_Incandescent_Light_Bulb.name=小型碳丝灯泡(50V)
-Small_50V_Copper_Heating_Corp.name=加热核心(铜,50V,小)
-Small_50V_Economic_Light_Bulb.name=小型节能灯泡(50V)
-Small_50V_Incandescent_Light_Bulb.name=小型白炽灯泡(50V)
-Small_50V_Iron_Heating_Corp.name=加热核心(铁,50V,小)
-Small_50V_Tungsten_Heating_Corp.name=加热核心(钨,50V,小)
-Small_Active_Thermal_Dissipator.name=散热器(T\:200W+800W,150°C;E\:50V,50W)
+Single-use_Battery.name=电池(一次性,50V,500W,60KJ)
+Small_200V_Copper_Heating_Corp.name=加热器(铜,200V,400W)
+Small_200V_Iron_Heating_Corp.name=加热器(铁,200V,600W)
+Small_200V_Tungsten_Heating_Corp.name=加热器(钨,200V,800W)
+Small_3.2kV_Tungsten_Heating_Corp.name=加热器(钨,3.2kV,4.0kW)
+Small_50V_Carbon_Incandescent_Light_Bulb.name=碳丝灯泡(50V,15W)
+Small_50V_Copper_Heating_Corp.name=加热器(铜,50V,150W)
+Small_50V_Economic_Light_Bulb.name=节能灯泡(50V,10W)
+Small_50V_Incandescent_Light_Bulb.name=白炽灯泡(50V,20W)
+Small_50V_Iron_Heating_Corp.name=加热器(铁,50V,180W)
+Small_50V_Tungsten_Heating_Corp.name=加热器(钨,50V,240W)
+Small_800V_Tungsten_Heating_Corp.name=加热器(钨,800V,3.60kW)
+Small_Active_Thermal_Dissipator.name=散热器(主动,冷却功率:200W+800W,最高温度:130°C,风扇参数:50V,50W)
 Small_Flashlight.name=手电筒
-Small_Passive_Thermal_Dissipator.name=散热器(250W,220°C)
-Small_Rotating_Solar_Panel.name=太阳能电池板(追踪,14.8V,65W)
-Small_Solar_Panel.name=太阳能电板(14.8V,65W)
+Small_Fuel_Burner.name=小型燃料燃烧器
+Small_Passive_Thermal_Dissipator.name=散热器(被动,冷却功率:250W,最高温度:200°C)
+Small_Rotating_Solar_Panel.name=太阳能板(追踪,14.8V,65W)
+Small_Solar_Panel.name=太阳能板(14.8V,65W)
 Solar_Tracker.name=太阳追踪组件
-Standard_Alarm.name=警报(基础)
-Steam_Turbine.name=Steam Turbine
-Stone_Heat_Furnace.name=燃烧器(800°C,1kW)
+Standard_Alarm.name=警报器(声音:标准)
+Steam_Turbine.name=发动机(蒸汽,7200mB/s)
+Stone_Heat_Furnace.name=石制加热炉(780°C,4.00kW)
 Street_Light.name=灯座(路灯)
 Suspended_Lamp_Socket.name=灯座(吊挂)
-Temperature_Probe.name=温度传感器
-Thermal_Probe.name=热能传感器
-Thermal_Probe_Chip.name=芯片(热能传感器)
+Suspended_Lamp_Socket_(No_Swing).name=灯座(吊挂,无摆动)
+Synthetic_Diamond.name=人造金刚石
+Tachometer.name=转速计
+Temperature_Probe.name=探测器(温度)
+Thermal_Probe.name=探测器(热量)
+Thermal_Probe_Chip.name=芯片(热能探测器)
 Thermistor.name=热敏电阻
-ThermoMeter.name=温度计
-Transformer.name=变压器
+Thermometer.name=温度计
 Tree_Resin.name=树脂
 Tree_Resin_Collector.name=树脂收集器
 Tungsten_Cable.name=导线(钨)
 Tungsten_Dust.name=钨粉
 Tungsten_Ingot.name=钨锭
 Tungsten_Ore.name=钨矿石
+Turbo_Electrical_Drill.name=钻头(10kW,1")
 Tutorial_Sign.name=指示标志
-Very_High_Voltage_Cable.name=导线(3200V)
+unreleasedium.name=铀(未释放)
+Very_High_Voltage_Cable.name=导线(3200V,15kW)
 Very_High_Voltage_Relay.name=继电器(3200V)
 Very_High_Voltage_Switch.name=开关(3200V)
-Voltage-to-Redstone_Converter.name=转换器(电→红石)
-Voltage_Oriented_Battery.name=电源(电压更大,200V,250W)
-Voltage_Probe.name=电压传感器
+Voltage-to-Redstone_Converter.name=电压-红石转换器
+Voltage_Oriented_Battery.name=电池(电压更大,200V,250W,120KJ)
+Voltage_Probe.name=探测器(电压)
+Voltage_controlled_amplifier.name=模拟集成电路(压控放大器)
+Voltage_controlled_sawtooth_oscillator.name=模拟集成电路(压控振荡器,锯齿)
+Voltage_controlled_sine_oscillator.name=模拟集成电路(压控振荡器,正弦)
 Water_Turbine.name=发电机(水力,50V,30W)
 Weak_50V_Battery_Charger.name=电池充电器(50V,200W)
 White_Brush.name=刷子(白)
 Wind_Turbine.name=发电机(风力,59V,160W)
 Wireless_Analyser.name=监测仪(无线)
 Wireless_Button.name=按钮(无线)
-Wireless_Signal_Receiver.name=信号接收器(无线)
-Wireless_Signal_Repeater.name=信号加强器(无线)
-Wireless_Signal_Transmitter.name=信号发射器(无线)
+Wireless_Signal_Receiver.name=无线信号接收器
+Wireless_Signal_Repeater.name=无线信号中继器
+Wireless_Signal_Transmitter.name=无线信号发射器
 Wireless_Switch.name=开关(无线)
 Wrench.name=扳手
 X-Ray_Scanner.name=扫描仪
-XNOR_Chip.name=XNOR Chip
-XOR_Chip.name=XOR Chip
+XNOR_Chip.name=数字集成电路(同或)
+XOR_Chip.name=数字集成电路(异或)
 Yellow_Brush.name=刷子(黄)
 entity.EAReplicator.name=复制机
-item.Copper Axe.name\=铜镐
-item.Copper Axe.name\=铜镐
-item.Copper Axe.name\=铜镐
-item.Copper Axe.name\=铜镐
-item.Copper Axe.name\=铜镐
-item.Copper Axe.name\=铜镐
-item.Copper Axe.name\=铜镐
-item.Copper Axe.name\=铜镐
-item.Copper Axe.name\=铜镐
-item.E-Coal Boots.name\=EC鞋
-item.E-Coal Boots.name\=EC鞋
-item.E-Coal Boots.name\=EC鞋
-item.E-Coal Boots.name\=EC鞋
+item.Copper Axe.name=铜斧
+item.Copper Boots.name=铜靴
+item.Copper Chestplate.name=铜胸甲
+item.Copper Helmet.name=铜头盔
+item.Copper Hoe.name=铜锄
+item.Copper Leggings.name=铜护腿
+item.Copper Pickaxe.name=铜镐
+item.Copper Shovel.name=铜铲
+item.Copper Sword.name=铜剑
+item.E-Coal Boots.name=电力碳纤维靴子
+item.E-Coal Chestplate.name=电力碳纤维胸甲
+item.E-Coal Helmet.name=电力碳纤维头盔
+item.E-Coal Leggings.name=电力碳纤维护腿
 itemGroup.Eln=电力时代
-mod.meta.desc=你的基地,因使用电力产生红热的光芒\!
+mod.meta.desc=你的基地,因使用电力产生红热的光芒\!!
+tile.arc_clay_block.name=铝块
+tile.arc_metal_block.name=钢块
 tile.eln.ElnProbe.name=电力时代电脑传感器
-tile.eln.EnergyConverterElnToOtherHVUBlock.name=电力时代能源(800V)转至其他能源
-tile.eln.EnergyConverterElnToOtherLVUBlock.name=电力时代能源(50V)转至其他能源
-tile.eln.EnergyConverterElnToOtherMVUBlock.name=电力时代能源(200V)转至其他能源
+tile.eln.EnergyConverter.name=能量转换器
+tile.hot_water.name=热水
+fluid.hot_water=热水
+item.hot_water_bucket.name=热水桶
+tile.cold_water.name=冷水
+fluid.cold_water=冷水
+item.cold_water_bucket.name=冷水桶
 
 # ./src/main/java/mods/eln/i18n/I18N.java
 You_have_%1$_lives_left=你还剩%1$条生命
 
-# ./src/main/java/mods/eln/item/BrushDescriptor.java
+# ./src/main/java/mods/eln/item/BrushDescriptor.kt
 Brush_is_dry=刷子干了
 Can_paint_%1$_blocks=可以继续漆%1$个方块
 
+# ./src/main/java/mods/eln/item/CaseItemDescriptor.kt
+Can_be_used_to_encase_EA_items_that_support_it=可以用来封装变压器
+
 # ./src/main/java/mods/eln/item/CombustionChamber.java
-Upgrade_for_the_Stone_Heat_Furnace.=你的发电机升级啦~
+Upgrade_for_the_Stone_Heat_Furnace.=升级石头加热炉。
 
 # ./src/main/java/mods/eln/item/ElectricalDrillDescriptor.java
-Energy_per_operation\:_%1$J=启动需要能量\:%1$J
-Time_per_operation\:_%1$s=启动所需时间\:%1$s
+Energy_per_operation\:_%1$J=每次操作需要能量: %1$J
+Time_per_operation\:_%1$h=每次操作需要时间: %1$s
 
 # ./src/main/java/mods/eln/item/FerromagneticCoreDescriptor.java
-Cable_loss_factor\:_%1$=导线损耗系数\:%1$
+Cable_loss_factor\:_%1$=导线损耗系数: %1$
+
+# ./src/main/java/mods/eln/item/FuelBurnerDescriptor.kt
+Burn_unit_for_the_gas_heat_furnace.=燃油加热炉的燃烧装置。
+Produced_heat_power\:_=产热功率:
 
 # ./src/main/java/mods/eln/item/HeatingCorpElement.java
 
 # ./src/main/java/mods/eln/item/LampDescriptor.java
 Bad=差
-Condition\:=条件\:
-End_of_life=生命就此终结
+Condition\:=状态:
+End_of_life=即将损坏
 Good=好
 New=新
-Nominal_lifetime\:_%1$h=理论寿命\:%1$h
-Technology\:_%1$=科技\:%1$
+Nominal_lifetime\:_%1$h=额定寿命: %1$h
+Technology\:_%1$=技术: %1$
 Used=旧
 
 # ./src/main/java/mods/eln/item/LampSlot.java
-Lamp_slot=槽(灯)
+Lamp_slot=槽(灯泡)
 
 # ./src/main/java/mods/eln/item/OverHeatingProtectionDescriptor.java
-Useful_to_prevent_overheating\nof_Batteries=有效防止电源过热
+Useful_to_prevent_overheating\nof_Batteries=有效防止电池过热
 
 # ./src/main/java/mods/eln/item/OverVoltageProtectionDescriptor.java
-Useful_to_prevent_over-voltage\nof_Batteries=有效防止电源过压
+Useful_to_prevent_over-voltage\nof_Batteries=有效防止电池过压
 
 # ./src/main/java/mods/eln/item/SolarTrackerDescriptor.java
-Solar_panel_upgrade=太阳能电板升级
+Solar_panel_upgrade=太阳能板升级
 
-# ./src/main/java/mods/eln/item/electricalitem/BatteryItem.java
+# ./src/main/java/mods/eln/item/electricalitem/ElectricalArmor.java
 
 # ./src/main/java/mods/eln/item/electricalitem/ElectricalLampItem.java
-Off=关
-On=开
-State\:=状态\:
-Stored_Energy\:_%1$J_(%2$%)=储存的能量\:%1$J(%2$%)
+State\:=状态:
+Stored_Energy\:_%1$J_(%2$%)=储存的能量: %1$J (%2$%)
 
 # ./src/main/java/mods/eln/item/regulator/RegulatorSlot.java
 
+# ./src/main/java/mods/eln/mechanical/Clutch.kt
+Prevents_clutches_from_slipping\nagain_after_they_stop.=防止离合器停止后打滑。
+
+# ./src/main/java/mods/eln/mechanical/CrankableShaft.kt
+Player_crankable_shaft=手动曲轴
+Can_rotate_slowly=右键慢速转动
+
+# ./src/main/java/mods/eln/mechanical/Generator.kt
+Converts_mechanical_energy_into_electricity,_or_(badly)_vice_versa.=将机械能转换为电能，或反之(低效)。
+Voltage_out\:_%1$=输出电压:
+Power_out\:_%1$=输出功率: %1$
+Rads\:_%1$=最佳转速: %1$
+
+# ./src/main/java/mods/eln/mechanical/Motor.kt
+Converts_electricity_into_mechanical_energy,_or_(badly)_vice_versa.=将电能转换为机械能，或反之(低效)。
+Voltage_in\:_%1$=输入电压: %1$
+Power_in\:_%1$=输入功率: %1$
+rad_s\:_%1$=最佳转速: %1$
+Max_rad_s\:_%1$=最大转速: %1$
+
+# ./src/main/java/mods/eln/mechanical/Tachometer.kt
+Rads_s_corresponding\nto_0%_output=对应 0% 输出的Rads/s(转速)
+Rads_s_corresponding\nto_100%_output=对应 100% 输出的Rads/s(转速)
+
+# ./src/main/java/mods/eln/mechanical/Turbines.kt
+Converts_%1$_into_mechanical_energy.=消耗%1$产生机械能
+Nominal_usage_->=额定参数:
+%1$_input\:_%2$_mB_s=%1$输入: %2$ mB/s
+No_valid_fluids_for_this_turbine!=没有有效的流体用于这个发动机!
+Power_out\:_%1$=输出功率: %1$
+Power_out\:_%1$-_%2$=输出功率: %1$- %2$
+Optimal_rads\:_%1$=最佳转速: %1$
+Max_rads\:__%1$=最大转速:  %1$
+
 # ./src/main/java/mods/eln/misc/UtilsClient.java
-Hold_shift=请戳Shift
+Hold_[shift]_for_details=按住 [shift] 查看细节
+Hold_[ctrl]_for_realism_details=按住 [ctrl] 查看拟真细节
 
 # ./src/main/java/mods/eln/misc/Version.java
 mod.name=电力时代
 
-# ./src/main/java/mods/eln/node/six/SixNodeDescriptor.java
+# ./src/main/java/mods/eln/node/transparent/TransparentNodeDescriptor.java
 
 # ./src/main/java/mods/eln/simplenode/energyconverter/EnergyConverterElnToOtherGui.java
-Input_power_is_limited_to_%1$W=输入功率限制\:%1$W
+Input_power_is_limited_to_%1$W=输入功率限制 %1$W
+
+# ./src/main/java/mods/eln/sixnode/AnalogChips.kt
+A_voltage-controlled_amplifier_(VCA)\nis_an_electronic_amplifier_that_varies\nits_gain_depending_on_the_control_voltage.=压控放大器(Voltage Controlled Amplifier，VCA)\n是一种根据控制电压来调节增益的信号放大器。
+A_voltage-controlled_oscillator_or_VCO_is\nan_electronic_oscillator_whose_oscillation\nfrequency_is_controlled_by_a_voltage_input.=压控振荡器(Voltage-Controlled Oscillator，VCO)\n是一种振荡电路，其振荡频率由输入电压控制。
+An_amplifier_increases_the_voltage\nof_an_input_signal_by_a_configurable\ngain_and_outputs_that_voltage.=放大器通过可配置的增益增加输入信号的电压并输出该电压。
+Cut-off_frequency_%1$_Hz=截止频率%1$ Hz
+Gain=增益
+Gains=增益
+Gain_for_input_\u00a713=输入增益 \u00a713
+Gain_for_input_\u00a722=输入增益 \u00a722
+Gain_for_input_\u00a741=输入增益 \u00a741
+Lowpass_filter_-_Passes_signals_with_a\nfrequency_lower_than_a_certain_cutoff_frequency\nand_attenuates_signals_with_frequencies_higher\nthan_the_cutoff_frequency.=低通滤波器 \n- 传递低于特定截止频率的信号，\n并衰减高于截止频率的信号。
+Operational_Amplifier_-_DC_coupled\nhigh-gain_voltage_amplifier_with\ndifferential_input._Can_be_used_to\ncompare_voltages_or_as_configurable_amplifier.=运算放大器 \n- 直流耦合高增益电压放大器，具有差分输入。\n可以用于比较电压或作为可配置的放大器。
+Params=参数
+Proportional–integral–derivative_controller._A_PID\ncontroller_continuously_calculates_an_error_value_as\nthe_difference_between_a_desired_setpoint_and_a_measured\nprocess_variable_and_applies_a_correction_based_on\nproportional,_integral,_and_derivative_terms.=比例积分微分控制器(Proportional-Integral-Derivative Controller，PID控制器)。\nPID控制器持续计算误差值，\n即期望设定值与测量的过程变量之间的差异，\n并基于比例、积分和微分项进行校正。
+Samples_the_voltage_of_a_varying_analog_signal_when\nthe_clock_input_changes_from_0_to_1_and_holds_its\noutput_voltage_at_a_constant_level_until_next_clock_pulse.\nYou_can_see_it_as_an_analog_D-Flipflop.=当时钟输入从0变为1时，\n对变化的模拟信号进行采样，\n并将其输出电压保持在恒定水平，直到下一个时钟脉冲。\n可以将其视为模拟D触发器。
+The_summing_unit_outputs_the_sum_of\nthe_three_weighted_inputs.The\ngain_for_each_input_can_be_configured.=求和单元输出三个加权输入的和。\n可以配置每个输入的增益。
+
+# ./src/main/java/mods/eln/sixnode/ElectricalFuse.kt
+Protects_electrical_components.\nFuse_melts_if_current_exceeds_the\nfuse_limit=保护电气元件。如果电流超过保险丝的限制，保险丝会熔断。
+
+# ./src/main/java/mods/eln/sixnode/EmergencyLamp.kt
 
 # ./src/main/java/mods/eln/sixnode/LogicGate.kt
-_O\:_= O\:
+A_Programmable_Array_Logic_(PAL)_is_a_programmable\nlogic_device_semiconductors_used_to__implement_any_logic\nfunction_in_only_one_digital_circuit._The_function_is\nstateless,_which_means_that_no_intermediate_state_is_saved.=可编程阵列逻辑(PAL)是一种可编程的逻辑器件半导体，\n用于在一个数字电路中实现任何逻辑功能。\n该功能是无状态的，意味着没有保存中间状态。
+If_the_input_J_is_1_(high)_and_K_is_0_(low)\nduring_a_clock_pulse,_the_output_becomes_1_(high).\nIf_J_is_0_(low)_and_K_is_1_(high)_during_the_pulse,\nthe_output_becomes_0_(low)._If_both_inputs_are_0_(low)\nduring_the_clock_pulse,_the_state_is_maintained._If_both\ninputs_are_1_(high)_the_input_is_toggled_if_a_rising_edge\nwas_detected_at_the_clock_input.=如果在时钟脉冲期间输入J为1(高电平)，K为0(低电平)，\n输出变为1(高电平)。\n如果在脉冲期间J为0(低电平)，K为1(高电平)，\n输出变为0(低电平)。\n如果在时钟脉冲期间两个输入都为0(低电平)，\n状态保持不变。\n如果两个输入都为1(高电平)，\n当在时钟输入检测到上升沿时，输入会切换。
+If_the_input_voltage_is_lower_than_10V,_the\noutput_is_0_(low),_if_the_output_is_bigger_or\nequal_to_30V,_the_output_will_be_1_(high)._For\nall_voltages_in_between,_the_output_does_not_change.=如果输入电压低于10V，则输出为0(低电平)；\n如果输出大于或等于30V，则输出为1(高电平)；\n对于介于两者之间的所有电压，输出不变。
+Implements_an_exclusive_or.\nAn_output_of_1_(high)_results_if_one_or\nall_three_inputs_to_the_gate_are_1_(high).=实现逻辑:异或。\n如果集成电路的三个输入中奇数个输入为1(高电平)，\n则输出为1(高电平)。
+Implements_logical_conjunction.\nA_1_(high)_output_results_only_if_all_of\nthe_three_inputs_to_the_AND_gate_are_1_(high).=实现逻辑:与。\n只有当集成电路的三个输入全部为1(高电平)时，\n才会输出1(高电平)。
+Implements_logical_disjunction.\nA_1_(high)_output_results_if_at_least\none_input_to_the_gate_is_1_(high).=实现逻辑:或。\n如果集成电路的至少一个输入为1(高电平)，\n则输出为1(高电平)。
+Inverts_the_input_signal.\nOutputs_a_voltage_representing_the\nopposite_logic-level_to_its_input.=实现逻辑:非。\n输出与输入相反逻辑电平。
+Its_output_is_complement_(inverted)\nto_that_of_the_AND_gate.=实现逻辑:与非。\n输出与与门相反逻辑电平。
+Its_output_is_complement_(inverted)\nto_that_of_the_OR_gate.=实现逻辑:或非。\n输出与或门相反逻辑电平。
+Its_output_is_complement_(inverted)\nto_that_of_the_XOR_gate.=实现逻辑:同或。\n输出与异或门相反逻辑电平。
+Outputs_a_rectangular_signal_which's_frequency\ndepends_to_the_input_voltage._The_higher_the\ninput_voltage_-_the_higher_the_frequency.=输出方波信号，\n其频率取决于输入电压，\n输入电压越高频率越高。
+The_D_flip-flop_captures_the_value\nof_the_D-input_at_a_rising_edge\nportion_of_the_clock_cycle.=边缘D触发器在时钟周期的上升沿将输出更改为输入值。
+UNDEF=未定义
+
+# ./src/main/java/mods/eln/sixnode/Scanner.kt
+-_For_inventories,_outputs_either_total_fill_or_fraction_of_slots_with_any_items.=- 对于物品容器，输出可以是总填充量百分比，或者是有物品的格子比例。
+-_For_tanks,_outputs_fill_percentage.=- 对于液体容器，输出填充百分比。
+Otherwise_behaves_as_a_vanilla_comparator.=或者作为普通比较器。
+Right-click_to_change_mode.=右键改变模式。
+Scans_blocks_to_produce_signals.=扫描方块以产生信号。
 
 # ./src/main/java/mods/eln/sixnode/TreeResinCollector/TreeResinCollectorDescriptor.java
-Produces_Tree_Resin_over\ntime_when_put_on_a_tree.=放在树上即可生产树脂
-This_block_can_only_be_placed_on_the_side_of_a_tree!=这只能在一棵树的侧面防止啊
+Produces_Tree_Resin_over\ntime_when_put_on_a_tree.=放在树上即可生产树脂。
+This_block_can_only_be_placed_on_the_side_of_a_tree!=只能在树的侧面放置！
 
 # ./src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerContainer.java
 Battery_slot=槽(电池)
 
 # ./src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerDescriptor.java
-Can_be_used_to_recharge\nelectrical_items_like\:\nFlash_Light,_X-Ray_scanner\nand_Portable_Battery_...=可以用来给电力时代的东西充电\n例如移动电池,手电筒,扫描仪
+Can_be_used_to_recharge\nelectrical_items_like\:\nFlash_Light,_X-Ray_scanner\nand_Portable_Battery_...=可以用来给电力时代的东西充电\n例如便携电池，手电筒，扫描仪 ...
+This_battery_charger_doesn't_take_into_account_battery_chemistry=这个电池充电器不考虑电池的化学成分
 
-# ./src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerGui.java
+# ./src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerElement.java
+Charge_Current=充电电流
 
 # ./src/main/java/mods/eln/sixnode/diode/DiodeDescriptor.java
-Electrical_current_can_only\nflow_through_the_diode\nfrom_anode_to_cathode=电流只能从二极管的一端流到另一端
+Electrical_current_can_only\nflow_through_the_diode\nfrom_anode_to_cathode=电流只能从二极管的阳极流向阴极。
+Works,_with_the_caveat_that_it's_delayed_a_sim_tick=有效，但需要注意的是，它会延迟一个模拟时钟周期。
+
+# ./src/main/java/mods/eln/sixnode/diode/DiodeElement.java
+Forward_Voltage=正向电压
 
 # ./src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmDescriptor.java
-=
-Emits_an_acoustic_alarm_if\nthe_input_signal_is_high=当输入信号高的时候\n发出巨大的警报声
+Emits_an_acoustic_alarm_if\nthe_input_signal_is_high=当输入高电平信号时\n发出巨大的警报声
+
+# ./src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmElement.java
+Engaged=激活中
+Input_Voltage=输入电压
 
 # ./src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmGui.java
-Sound_is_muted=声音已静音
-Sound_is_not_muted=声音已开启
+Sound_is_muted=声音:关
+Sound_is_not_muted=声音:开
 
 # ./src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerContainer.java
 
 # ./src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerDescriptor.java
-Protects_electrical_components\nOpens_contact_if\:\n__-_Voltage_exceeds_a_certain_level\n-_Current_exceeds_the_cable_limit=保护电路\n如果电压过大或电流过载都会打开
+Protects_electrical_components\nOpens_contact_if\:\n__-_Voltage_exceeds_a_certain_level\n__-_Current_exceeds_the_cable_limit=保护电气元件，当满足以下条件之一时断开:\n - 电压超过一定水平 \n- 电流超过电缆的限制。
+
+# ./src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerElement.java
+Contact=触点
 
 # ./src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerGui.java
-Maximum_voltage_before_cutting_off=切断前最大电压
-Minimum_voltage_before_cutting_off=切断前最小电压
-Switch_is_off=开关关闭
-Switch_is_on=开关打开
+Maximum_voltage_before_cutting_off=Maximum voltage before cutting off
+Minimum_voltage_before_cutting_off=Minimum voltage before cutting off
+Switch_is_off=开关已断开
+Switch_is_on=开关已合上
 
 # ./src/main/java/mods/eln/sixnode/electricalcable/ElectricalCableDescriptor.java
-A_signal_is_electrical_information\nwhich_must_be_between_0V_and_%1$V=信号用来传递电气信息\n必须要在0V和%1$V之间
+A_signal_is_electrical_information\nwhich_must_be_between_0V_and_%1$=信号用于传输电子信号\n必须在 0V 到 %1$之间
 Cable_is_adapted_to_conduct\nelectrical_signals.=该电缆适用于传输电子信号
-Current\:_%1$A=电流\:%1$A
-Not_adapted_to_transport_power.=没有适配到传送功率
-Save_usage\:=保存用法\:
-Serial_resistance\:_%1$Ω=串联电阻\:%1$Ω
+Current\:_%1$A=电流: %1$A
+Nominal_Ratings\:=额定参数:
+Not_adapted_to_transport_power.=没有适配到传送功率.
+Serial_resistance\:_%1$Ω=串联电阻: %1$Ω
+__*_Wire_resistance_is_much_higher_than_normal=  * 导线电阻远高于正常值
+__*_Wire_resistance_is_not_impacted_by_temperature=  * 导线电阻不受温度影响
+__*_Wire_voltage_current_limits_are_arbitrary_values,_added_as_a_gameplay_mechanic=  * 导线无电压/电流限制，作为游戏机制添加
+__*_Wire_voltage_limits_are_arbitrary_values,_picked_to_within_reasonable_simulator_error=  * 导线无电压限制，选择合理的模拟器误差
+__*_Wire_current_limits_are_arbitrary_values,_added_as_a_gameplay_mechanic=  * 导线无电流限制，作为游戏机制添加
+
+# ./src/main/java/mods/eln/sixnode/electricalcable/ElectricalCableElement.java
 
 # ./src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerDescriptor.java
-It_can_store_up_to_256_points.=它最多可以储存256个单位
-Measures_the_voltage_of_an\nelectrical_signal_and_plots\nthe_data_in_real_time.=测量电子信号的实时电压
+It_can_store_up_to_256_points.=最多可以储存256个点.
+Measures_the_voltage_of_an\nelectrical_signal_and_plots\nthe_data_in_real_time.=测量电信号的电压并实时绘制数据。
+
+# ./src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerElement.java
 
 # ./src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerGui.java
 Back_to_display=回到显示
@@ -411,32 +592,46 @@ Voltage_[V]=电压(V)
 Y-axis_max=Y轴最大值
 Y-axis_min=Y轴最小值
 
-# ./src/main/java/mods/eln/sixnode/electricalentitysensor/ElectricalEntitySensorContainer.java
+# ./src/main/java/mods/eln/sixnode/electricaldigitaldisplay/ElectricalDigitalDisplayDescriptor.java
+Displays_signal_value.=显示信号值。
 
 # ./src/main/java/mods/eln/sixnode/electricalentitysensor/ElectricalEntitySensorDescriptor.java
 Output_voltage_increases\nif_entities_are_moving_around.=如果有生物在周围移动那么增大输出电压
 
+# ./src/main/java/mods/eln/sixnode/electricalentitysensor/ElectricalEntitySensorElement.java
+Entity_present=存在实体
+
 # ./src/main/java/mods/eln/sixnode/electricalfiredetector/ElectricalFireDetectorDescriptor.java
+Battery_powered_buzzer_\nactivated_in_presence_of_fire.=电池供电的蜂鸣器在发生火灾时启动
 Output_voltage_increases\nif_a_fire_has_been_detected.=如果周围有火那么增大输出电压
+
+# ./src/main/java/mods/eln/sixnode/electricalfiredetector/ElectricalFireDetectorElement.java
+Fire_detected\:_=火灾探测:
+Fire_present=发生火灾
 
 # ./src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceDescriptor.java
 Provides_configurable_signal\nvoltage.=提供可调整的信号电压
 
 # ./src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceGui.java
-Output_at_%1$%=输出\:%1$%
+Output_at_%1$%=输出: %1$%
 
 # ./src/main/java/mods/eln/sixnode/electricallightsensor/ElectricalLightSensorDescriptor.java
 0V_at_night,_%1$V_at_noon.=夜间0V,午时%1$V
 Provides_an_electrical_voltage\nin_the_presence_of_light.=接受到光的时候提供电压
 Provides_an_electrical_voltage\nwhich_is_proportional_to\nthe_intensity_of_daylight.=接收到日光的时候提供电压\n电压与日光强度成正比
 
-# ./src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathContainer.java
+# ./src/main/java/mods/eln/sixnode/electricallightsensor/ElectricalLightSensorElement.java
+Light_level=光照等级
 
 # ./src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathDescriptor.java
-Applicable_boolean_operators\:=适用于布尔(boolean)算子\:
-Applicable_functions\:=适用于\:
-Applicable_mathematical_operators\:=适用于数学算子
+Applicable_boolean_operators\:=适用于布尔(boolean)算子:
+Applicable_functions\:=适用于:
+Applicable_mathematical_operators\:=适用于数学算子:
 Calculates_an_output_signal_from\n3_inputs_(A,_B,_C)_using_an_equation.=用3个输入(A,B,C)值\n进行函数计算\n然后输出信号
+
+# ./src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathElement.java
+Equation=方程式
+Input_voltages=输入电压
 
 # ./src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathGui.java
 %1$_Redstone(s)_required=需要%1$个红石粉
@@ -449,112 +644,162 @@ Waiting_for_completion...=请稍后...
 # ./src/main/java/mods/eln/sixnode/electricalredstoneinput/ElectricalRedstoneInputDescriptor.java
 Converts_Redstone_signal\nto_an_electrical_voltage.=把红石信号转换为电压
 
+# ./src/main/java/mods/eln/sixnode/electricalredstoneinput/ElectricalRedstoneInputElement.java
+
 # ./src/main/java/mods/eln/sixnode/electricalredstoneoutput/ElectricalRedstoneOutputDescriptor.java
 Converts_electrical_voltage\ninto_a_Redstone_signal.=把电压转换为红石信号
 
+# ./src/main/java/mods/eln/sixnode/electricalredstoneoutput/ElectricalRedstoneOutputElement.java
+
 # ./src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayDescriptor.java
-A_relay_is_an_electrical\ncontact_that_conducts_electric\ncurrent_or_not,_depending\nthe_actual_input_signal_voltage.=继电器是根据信号电压的有无\n控制电路闭合断开的仪器
+A_relay_is_an_electrical\ncontact_that_conducts\ncurrent_when_a_signal\nvoltage_is_applied.=继电器是根据信号电压的有无\n控制电路闭合断开的仪器
+The_relay's_input_behaves\nlike_a_Schmitt_Trigger.=继电器的输入行为类似于施密特触发器
+
+# ./src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayElement.java
+Default_position=Default position
 
 # ./src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayGui.java
-Normally_closed=默认关闭
+Normally_closed=默认合上
 Normally_open=默认打开
+
+# ./src/main/java/mods/eln/sixnode/electricalsensor/ElectricalSensorDescriptor.java
+Can_measure_Voltage_Power_Current=可以测量电压/功率/电流
+Measures_electrical_values_on_cables.=测量导线的电气值
+Measures_voltage_on_cables.=测量导线上的电压
+
+# ./src/main/java/mods/eln/sixnode/electricalsensor/ElectricalSensorElement.java
+Measured_current=实测电流
+Measured_power=实测功率
+Measured_voltage=实测电压
+
+# ./src/main/java/mods/eln/sixnode/electricalsensor/ElectricalSensorGui.java
+Measured_voltage\ncorresponding\nto_0%_output=对应于0%输出的测量电压
+Measured_voltage\ncorresponding\nto_100%_output=对应于100%输出的测量电压
 
 # ./src/main/java/mods/eln/sixnode/electricalsource/ElectricalSourceDescriptor.java
 Creative_block.=创造方块
-Provides_an_ideal_voltage_source\nwithout_energy_or_power_limitation.=无限制的永久能源(创造专用)
-
-# ./src/main/java/mods/eln/sixnode/electricalsource/ElectricalSourceGui.java
-Output_voltage=输出电压
+Provides_an_ideal_current_source\nwithout_energy_or_power_limitation.=无功率/能量限制的理想电流源
+Provides_an_ideal_voltage_source\nwithout_energy_or_power_limitation.=无功率/能量限制的理想电压源
+Acts_as_an_ideal_voltage_source,_with_a_small_inline_resistance=作为理想电压源，内阻很小
+Acts_as_an_ideal_current_source,_with_a_small_inline_resistance=作为理想电流源，内阻很小
 
 # ./src/main/java/mods/eln/sixnode/electricalswitch/ElectricalSwitchDescriptor.java
-Can_break_an_electrical_circuit\ninterrupting_the_current.=能破坏导线以中断电流
+Can_break_an_electrical_circuit\ninterrupting_the_current.=能切断导线以中断电流
 
 # ./src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutDescriptor.java
-Upon_application_of_a_high_signal,\nthe_timer_maintains_the_output_high_for\na_configurable_interval._Can_be_re-triggered.=当应用于高强度信号时\n定时器一定输出间隔后会输出高强度信号。\n可以循环进行
+Upon_application_of_a_high_signal,\nthe_timer_maintains_the_output_high_for\na_configurable_interval._Can_be_re-triggered.=当提供高电平信号时\n断路延时器在接下来可配置时间间隔内会输出高电平信号。\n可以重复触发
+
+# ./src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutElement.java
+Output=输出
+Remaining=剩余
 
 # ./src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutGui.java
-Set=设置
-The_time_interval_the\noutput_is_kept_high.=保持高输出间隔
+Set=激活
+The_time_interval_the\noutput_is_kept_high.=高电平输出时间
 
 # ./src/main/java/mods/eln/sixnode/electricalvumeter/ElectricalVuMeterDescriptor.java
+Displays_a_color_based_on_the_value_of_a_signal=基于信号值显示颜色
 Displays_the_value_of_a_signal.=显示信号的值
 
 # ./src/main/java/mods/eln/sixnode/electricalwatch/ElectricalWatchContainer.java
-Portable_battery_slot=槽(移动电池)
+
+# ./src/main/java/mods/eln/sixnode/electricalwatch/ElectricalWatchDescriptor.java
+Requires_batteries_for_operation.=需要电池进行工作
+Tells_the_time.=告诉你时间
+
+# ./src/main/java/mods/eln/sixnode/electricalwatch/ElectricalWatchElement.java
 
 # ./src/main/java/mods/eln/sixnode/electricalweathersensor/ElectricalWeatherSensorDescriptor.java
-Clear\:_%1$V=晴朗\:%1$V
+Clear\:_%1$V=晴朗: %1$V
 Provides_an_electrical_signal\ndepending_the_actual_weather.=提供信号,强度由天气决定
-Rain\:_%1$V=阴雨\:%1$V
-Storm\:_%1$V=雷暴\:%1$V
+Rain\:_%1$V=阴雨: %1$V
+Storm\:_%1$V=雷暴: %1$V
 
 # ./src/main/java/mods/eln/sixnode/electricalwindsensor/ElectricalWindSensorDescriptor.java
 Maximum_wind_speed_is_%1$m_s=最高风速%1$m/s
 Provides_an_electrical_signal\ndependant_on_wind_speed.=提供信号,强度由风速决定
-You_can't_place_this_block_on_the_floor_or_the_ceiling=You can't place this block on the floor or the ceiling
+You_can't_place_this_block_on_the_floor_or_the_ceiling=你不能将这个方块放置于天花板底部和地板上
 
-# ./src/main/java/mods/eln/sixnode/electricasensor/ElectricalSensorDescriptor.java
-Can_measure_Voltage_Power_Current=可以测量电压/功率/电流
-Measures_electrical_values_on_cables.=测量电缆的电气值
-Measures_voltage_on_cables.=测量导线上的电压
+# ./src/main/java/mods/eln/sixnode/emergencylamp/EmergencyLampDescriptor.java
+As_long_as_power_is_provided,_the_internal_battery=通电时,内部电池
+is_charged_and_the_lamp_is_off._On_a_power_failure,=充电,灯泡关闭.断电时,
+the_lamp_turns_on_and_runs_on_batteries.=灯泡打开并使用电池供电.
+Nominal_voltage\:=额定电压:
+Battery_capacity\:=电池容量:
 
-# ./src/main/java/mods/eln/sixnode/electricasensor/ElectricalSensorGui.java
-Current=电流
-Measured_voltage\ncorresponding\nto_0%_output=测量电压\n对应\n0%输出
-Measured_voltage\ncorresponding\nto_100%_output=测量电压\n对应\n0%输出
-Voltage=电压
+# ./src/main/java/mods/eln/sixnode/energymeter/EnergyMeterElement.java
+Counter=计量
+Energy_left=剩余能量
+Mode=模式
+Prepay=预付款
 
 # ./src/main/java/mods/eln/sixnode/energymeter/EnergyMeterGui.java
 Change_password=修改密码
-Counter_Mode=计数模式
-Counts_the_energy_conducted_from\n\u00a74red\u00a7f_to_\u00a71blue\u00a7f.=计算从\\u00a74red\\u00a7f到\\u00a71blue\\u00a7f的能量
-Energy_counter\:_%1$J=能量计算\:%1$J
-Enter_new_energy=输入新能源
+Counter_Mode=计量模式
+Counts_the_energy_conducted_from\n\u00a74red\u00a7f_to_\u00a71blue\u00a7f.=计量从\n\u00a74red\u00a7f到\u00a71blue\u00a7f通过的电量
+Energy_counter\:_%1$J=能量计算: %1$J
+Enter_new_energy=输入新的能量
 Enter_password=输入密码
 Prepay_Mode=预付费模式
 Reset_time_counter=重置计时器
-Set_energy_counter=设置计时器
-Time_counter\:=计时器\:
-Try_password=测试密码
-You_can_set_an_initial\namount_of_available_energy.\nWhen_the_counter_arrives_at_0\nthe_contact_will_be_opened.=你可以设置一个初始的可用能量。\n当计时器到达0时，电路联通。
-is_off=关闭了
-is_on=打开着
+Set_energy_counter=设置计数器
+Time_counter\:=计时器:
+Try_password=尝试密码
+You_can_set_an_initial\namount_of_available_energy.\nWhen_the_counter_arrives_at_0\nthe_contact_will_be_opened.=你可以设置一个初始的可用电量。\n当计数器到达0时,电路断开。
+is_off=电路断开
+is_on=电路连通
 value_in_kJ=单位是kJ
 
 # ./src/main/java/mods/eln/sixnode/groundcable/GroundCableDescriptor.java
-Can_be_used_to_set_a_point_of_an\nelectrical_network_to_0V_potential.\nFor_example_to_ground_negative_battery_contacts.=可以用来设置0V的点位\n例如电池负极
-Provides_a_zero_volt_reference.=提供0V电路供参考
+Can_be_used_to_set_a_point_of_an\nelectrical_network_to_0V_potential.\nFor_example_to_ground_negative_battery_contacts.=可用于将电网中的某一点设为0V电位，例如将电池负极接地。
+Provides_a_zero_volt_reference.=提供0V参考点
+Acts_as_a_ground_reference.=作为接地点供参考
+Has_a_small_resistance_inline=内阻很小
 
 # ./src/main/java/mods/eln/sixnode/hub/HubDescriptor.java
 Allows_crossing_cables\non_one_single_block.=允许导线在一个方块上面交叉
+A_bit_contrived,_as_the_wires_could_just_cross_over_each_other._Realism_depends_on_the_wires_used.=有点牵强，因为导线可以互相交叉。真实性取决于使用的导线。
 
 # ./src/main/java/mods/eln/sixnode/lampsocket/LampSocketDescriptor.java
-Angle\:_%1$°_to_%2$°=角度\:%1$°到%2$°
-Spot_range\:_%1$_blocks=污染范围\:%1$个方块
+Angle\:_%1$°_to_%2$°=角度: %1$° 到 %2$°
+Spot_range\:_%1$_blocks=光照范围: %1$个方块
+Wireless_mode_of_lights_intended_to_pretend_wires_are_in_the_walls=用于假装电线在墙里的无线模式
+
+# ./src/main/java/mods/eln/sixnode/lampsocket/LampSocketElement.java
+Bulb=灯泡
 
 # ./src/main/java/mods/eln/sixnode/lampsocket/LampSocketGuiDraw.java
-%1$_is_not_in_range!=%1$不在范围内
-Cable_slot_empty=槽(导线)
-Orientation\:_%1$°=方向\:%1$°
+Cable_slot_empty=导线槽没有导线
+Orientation\:_%1$°=方向: %1$°
 Parallel=并联
-Powered_by_Lamp_Supply=由无线照明控制盒供电
-Powered_by_cable=导线供电
 Serial=串联
-Specify_the_supply_channel=指定供应通道
 
 # ./src/main/java/mods/eln/sixnode/lampsupply/LampSupplyContainer.java
-Electrical_cable_slot\nBase_range_is_32_blocks.\nEach_additional_cable\nincreases_range_by_one.=电力导线槽\n基本范围为32格\n每加入一条电线\n增加一格的范围
+Electrical_cable_slot\nBase_range_is_32_blocks.\nEach_additional_cable\nincreases_range_by_one.=导线槽\n初始范围为32格\n每加入一条导线\n增加一格的范围
 
 # ./src/main/java/mods/eln/sixnode/lampsupply/LampSupplyDescriptor.java
-Supplies_all_lamps_on_the_channel.=给接入该通道的每个电灯供电
+Capable_of_operating_3_light_channels.=可以控制3个照明频道
+Supplies_power_to_nearby_lamps.=向周围的灯提供能量
+Supports_control_from_a_wireless_signal\nchannel_for_each_lighting_channel.=可以通过无线信号频道对每个照明频道进行控制
+Most_homes_have_a_circuit_breaker_panel_for_lights=大多数家庭都有一个用于照明的断路器面板。
+The_wireless_power_aspect_is_pretending_there_are_wires_in_the_walls=无线照明控制盒是假装墙里有电线。
+Wireless_control_signals_are_totally_possible=无线控制信号是完全有可能的。
+
+# ./src/main/java/mods/eln/sixnode/lampsupply/LampSupplyElement.java
+Total_power=总功率
 
 # ./src/main/java/mods/eln/sixnode/lampsupply/LampSupplyGui.java
-Power_channel_name=供电通道名称
-Wireless_channel_name=无限通道名称
+Power_channel_name=供电频道名称
+Wireless_channel_name=无线信号频道名称
+
+# ./src/main/java/mods/eln/sixnode/modbusrtu/ModbusRtuElement.java
+Modbus_TCP=Modbus TCP通讯协议
+Modbus_Unit_ID=Modbus独立ID
+Modbus_is_disabled,_enable_it_in_Eln.cfg=Modbus被停用,从Eln.cfg中启用
 
 # ./src/main/java/mods/eln/sixnode/modbusrtu/ModbusRtuGui.java
 Add=增加
-Channel_name=通道名称
+Channel_name=频道名称
 Modbus_ID=Modbus网关
 Modbus_RTU=Modbus RTU通讯协议
 Station_ID=站点ID
@@ -562,60 +807,118 @@ Station_name=站点名称
 Wireless_RX=无线接收
 Wireless_TX=无线发送
 
+# ./src/main/java/mods/eln/sixnode/PortableNaN.kt
+Voltage\:_Yes=电压: 是
+Current\:_No=电流: 否
+Serial_Resistance\:_OK_Ω=串联电阻: OK Ω
+A_debugging_feature_that_throws_NaN_(Not_a_Number)_anywhere_it_can_in_the_simulator_to_find_bugs=一个调试功能，可以在模拟器中的任何位置抛出NaN（不是数字）来查找错误
+
 # ./src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixContainer.java
 (Increases_maximum_voltage)=(增大最大电压)
 
-# ./src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixGui.java
+# ./src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixElement.java
+Capacity=电容
 
-# ./src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixContainer.java
+# ./src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixDescriptor.java
+Provides_capacitance._Use_with_dielectrics_and_redstone=提供电容,需要绝缘体和红石
+It_doesn't_really_behave_well_for_DC=它不适合直流电
 
-# ./src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixGui.java
+# ./src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixElement.java
+Inductance=电感
+
+# ./src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixDescriptor.java
+Provides_inductance._Use_with_iron_cores_and_bare_copper_cables=提供电感,需要铁磁芯和铜导线
+*_Missing_an_inductive_voltage_spike_on_field_collapse=*磁场崩溃时缺少感应电压尖峰
 
 # ./src/main/java/mods/eln/sixnode/powersocket/PowerSocketDescriptor.java
-Supplies_any_device\nplugged_in_with_energy.=给任何接入的设备提供能量
+Supplies_any_device\nplugged_in_with_energy.=给任何接入的设备提供能量。
+Homes_have_power_sockets._These_are_not_them.=这些不是家庭的电源插座。
 
 # ./src/main/java/mods/eln/sixnode/powersocket/PowerSocketGui.java
-Specify_the_device_to_supply_through_this_socket.=提供给指定的已连接的某设备
+Specify_the_device_to_supply_through_this_socket.=指定要通过此插座供电的设备。
 
 # ./src/main/java/mods/eln/sixnode/resistor/ResistorContainer.java
 (Sets_resistance)=(设置电阻)
 Coal_dust_slot=槽(煤粉)
 
+# ./src/main/java/mods/eln/sixnode/resistor/ResistorElement.java
+
+# ./src/main/java/mods/eln/sixnode/resistor/ResistorDescriptor.java
+It's_a_resistor=这是一个电阻
+
 # ./src/main/java/mods/eln/sixnode/thermalcable/ThermalCableDescriptor.java
-High_parallel_resistance\n_\=>_Low_power_dissipation.=并联大阻抗的电阻\n以获得低功耗
-Low_serial_resistance\n_\=>_High_conductivity.=并联小阻抗的电阻\n以获得高功耗
-Parallel_resistance\:_%1$K_W=并联\:%1$K/W
-Serial_resistance\:_%1$K_W=串联\:%1$K/W
+High_parallel_resistance\n_⇨_Low_power_dissipation.=高并联热阻\n ⇨ 低热损
+Low_serial_resistance\n_⇨_High_conductivity.=低串联热阻\n ⇨ 高热导.
+Parallel_resistance\:_%1$K_W=并联热阻: %1$K/W
+Serial_resistance\:_%1$K_W=串联热阻: %1$K/W
+The_thermal_simulator_doesn't_properly_manage_heat=热量模拟器无法正确管理热量
+
+# ./src/main/java/mods/eln/sixnode/thermalcable/ThermalCableElement.java
+Thermic_power=热功率
 
 # ./src/main/java/mods/eln/sixnode/thermalsensor/ThermalSensorContainer.java
-Cable_slot=槽(导线)
+Cable_slot=槽(热管)
 
 # ./src/main/java/mods/eln/sixnode/thermalsensor/ThermalSensorDescriptor.java
-Can_measure\:=可以测量\:
-Measures_temperature_of_cables.=测量导线的温度
-Measures_thermal_values_on_cables.=测量导线的温度
-__Temperature_Power_conducted=热/电传导
+Can_measure\:=可以测量:
+Measures_temperature_of_cables.=测量导线的温度.
+Measures_thermal_values_on_cables.=测量热管的热力属性.
+__Temperature_Power_conducted=温度/热功率
+
+# ./src/main/java/mods/eln/sixnode/thermalsensor/ThermalSensorElement.java
+Measured_temperature=实测温度
+Measured_thermal_power=实测热功率
 
 # ./src/main/java/mods/eln/sixnode/thermalsensor/ThermalSensorGui.java
-Measured_temperature\ncorresponding\nto_0%_output=测量温度\n对应\n0%输出
-Measured_temperature\ncorresponding\nto_100%_output=测量温度\n对应\n0%输出
-Temperature=温度
+Measured_temperature\ncorresponding\nto_0%_output=对应于0%输出的测量温度
+Measured_temperature\ncorresponding\nto_100%_output=对应于100%输出的测量温度
 
 # ./src/main/java/mods/eln/sixnode/tutorialsign/TutorialSignElement.java
-No_text_associated_to_this_beacon=没有关联到这个信标的文本
+No_text_associated_to_this_beacon=没有关联到这个标志的文本
 
 # ./src/main/java/mods/eln/sixnode/tutorialsign/TutorialSignGui.java
-Set_beacon_name=设置信标名称
+Set_beacon_name=设置标志名称
 
 # ./src/main/java/mods/eln/sixnode/wirelesssignal/rx/WirelessSignalRxGui.java
 
+# ./src/main/java/mods/eln/sixnode/wirelesssignal/rx/WirelessSignalRxDescriptor.java
+Receive_signal_voltage_on_selected_wireless_signal_channel=接收选定无线信号频道的信号电压
+It_should_require_power_to_receive_and_propogate_the_signal_realistically=它应该需要供电以接收和传播信号，以实现真实性
+
+# ./src/main/java/mods/eln/sixnode/wirelesssignal/tx/WirelessSignalTxDescriptor.java
+Sends_signal_voltage_on_selected_wireless_signal_channel=在选定无线信号频道上发送信号电压
+It_should_require_power_to_transmit_realistically=它应该需要供电以实现真实性
+
+# ./src/main/java/mods/eln/sixnode/wirelesssignal/repeater/WirelessSignalRepeaterDescriptor.java
+Repeats_all_wireless_signals_in_range=重复范围内的所有无线信号
+It_should_require_power_realistically=它应该需要供电以实现真实性
+
 # ./src/main/java/mods/eln/transparentnode/FuelGenerator.kt
-Nominal_power\:_%1$_W=Nominal power\: %1$ W
-Nominal_voltage\:_%1$_V=Nominal voltage\: %1$ V
-Produces_electricity_using_fuel.=用燃料来发电
+Fuel_level=燃油含量
+Nominal_power\:_%1$_W=额定功率: %1$W
+Nominal_voltage\:_%1$_V=额定电压: %1$ V
+Produces_electricity_using_gasoline.=燃烧轻油发电
+
+# ./src/main/java/mods/eln/transparentnode/FuelHeatFurnace.kt
+Actual\:_%1$=实际温度: %1$
+Analog_regulator_slot=槽(温控组件)
+Control_value_at_%1$=控制值 %1$
+Fuel_burner_slot=槽(燃料燃烧器)
+Furnace_is_off=加热炉已停止
+Furnace_is_on=加热炉正在工作
+Heat_Power\:_%1$=加热功率: %1$
+Set_point\:_%1$=设定温度: %1$
+__Max._temperature\:_=  最大温度:
 
 # ./src/main/java/mods/eln/transparentnode/LargeRheostat.kt
-Nom._Resistance\:_%1$=Nom. Resistance\: %1$
+Control_resistance_with_signal=用信号控制电阻
+Dissapates_~4kW_of_heat_passively=提供4000W的被动散热
+Nom._Resistance\:_%1$=当前电阻: %1$
+Power_loss=功率损耗
+Set_resistance_with_coal_dust=用煤粉增加电阻
+Has_some_caveats\:=注意事项:
+__*_Resistance_is_not_impacted_by_temperature=  * 电阻不受温度影响
+__*_Signal_input_doesn't_require_power=  * 信号输入不需要电源
 
 # ./src/main/java/mods/eln/transparentnode/autominer/AutoMinerContainer.java
 Drill_slot=槽(钻头)
@@ -623,207 +926,432 @@ Mining_pipe_slot=槽(挖矿管道)
 Ore_scanner_slot=槽(矿物扫描仪)
 
 # ./src/main/java/mods/eln/transparentnode/autominer/AutoMinerDescriptor.java
-Excavates_on_a_small_radius.\nExtracts_ore_on_a_bigger_radius\:\n10_blocks_radius_after_10_blocks_depth.=小搜索范围挖掘\n挖了10格深后以10个方块为半径挖掘
+Excavates_on_a_small_radius.\nExtracts_ore_on_a_bigger_radius\:\n10_blocks_radius_after_10_blocks_depth.=小范围全部挖掘\n大范围挖掘矿石:10格深度后10格半径
+
+# ./src/main/java/mods/eln/transparentnode/autominer/AutoMinerElement.java
+Depth=深度
+Silk_touch=精准
 
 # ./src/main/java/mods/eln/transparentnode/autominer/AutoMinerGuiDraw.java
 Chest_missing_on_the\nback_of_the_auto_miner!=自动挖矿机背部没有检测到箱子耶
-Halves_speed,_triples_power_draw=Halves speed, triples power draw
-Silk_Touch_Off=Silk Touch Off
-Silk_Touch_On=Silk Touch On
-Silk_touch=Silk touch
+Halves_speed,_triples_power_draw=挖掘速度减半，三倍功率消耗
+Silk_Touch=精准
 
 # ./src/main/java/mods/eln/transparentnode/battery/BatteryContainer.java
 Overheating_protection=保护装置(过热)
-Overvoltage_protection=当压力过大时提供保护
+Overvoltage_protection=保护装置(过压)
 
 # ./src/main/java/mods/eln/transparentnode/battery/BatteryDescriptor.java
-Actual_charge\:_%1$%=实际电量\:%1$%
-Energy_capacity\:_%1$J=能量容量\:%1$J
-_charged_at_%1$%=剩余电量\:%1$%
+Actual_charge\:_=实际电量:
+Energy_capacity\:_=能量容量:
+Internal_resistance\:_=内阻:
+Life\:_=寿命:
+Nominal_power\:_=额定功率:
+Nominal_voltage\:_=额定电压:
+_charged_at_=剩余电量
+Battery_could_be_realistic_in_the_future=电池在未来会更真实
+__*_Batteries_have_internal_resistance=  * 电池有内阻
+__*_Not_currently_simulating_any_particular_chemistry_of_battery=  * 目前没有模拟任何特定的电池化学反应
+Batteries_are_based_in_realistic_battery_designs_that_someone_might_implement_realistically\:=电池基于现实的电池设计(可能有某些人在游戏中实现):
+__*_Single_use_batteries_emulate_a_voltaic_pile=  * 一次性电池模拟伏打堆
+__*_Current_oriented_uses_two_smaller_batteries_in_parallel_to_increase_current_capability=  * 大电流电池使用两个较小的电池并联以增加输出电流
+__*_Voltage_oriented_uses_two_smaller_batteries_in_series_to_increase_voltage=  * 大电压电池使用两个较小的电池串联以增加输出电压
+
+# ./src/main/java/mods/eln/transparentnode/battery/BatteryElement.java
 
 # ./src/main/java/mods/eln/transparentnode/battery/BatteryGuiDraw.java
-Charge=充电
 Charged=充满了
-Discharge=放点
-Energy\:=能量\:
-Energy\:_%1$=能量\:%1$
-Life\:=寿命\:
+Discharge=放电
+Energy\:=电量:
+Energy\:_%1$=电量: %1$
+Life\:=寿命:
 No_charge=没有充电
-Power_in\:=输入能量\:
-Power_out\:=输出能量
+Power_in\:=充电功率:
+Power_out\:=放电功率:
 
 # ./src/main/java/mods/eln/transparentnode/eggincubator/EggIncubatorContainer.java
-Egg_slot=槽(蛋)
+Egg_slot=槽(鸡蛋)
+
+# ./src/main/java/mods/eln/transparentnode/eggincubator/EggIncubatorElement.java
+Has_egg=有蛋
 
 # ./src/main/java/mods/eln/transparentnode/electricalantennarx/ElectricalAntennaRxDescriptor.java
-Wireless_energy_receiver.=能源无线接收
+Wireless_energy_receiver.=无线接收能量
+
+# ./src/main/java/mods/eln/transparentnode/electricalantennarx/ElectricalAntennaRxElement.java
+Effective_power=有效功率
+Power_received=接收功率
+Receiving=接收
 
 # ./src/main/java/mods/eln/transparentnode/electricalantennatx/ElectricalAntennaTxDescriptor.java
-Efficiency\:_%1$%_up_to_%2$%=效率\:%1$%至%2$%
-Wireless_energy_transmitter.=能源无线发送
+Efficiency\:_%1$%_up_to_%2$%=效率: %1$%至%2$%
+Wireless_energy_transmitter.=无线发送能量
+
+# ./src/main/java/mods/eln/transparentnode/electricalantennatx/ElectricalAntennaTxElement.java
+Efficiency=效率
+Transmitting=传输
 
 # ./src/main/java/mods/eln/transparentnode/electricalfurnace/ElectricalFurnaceContainer.java
-Heating_corp_slot=槽(加热核心)
+Heating_corp_slot=槽(加热器)
 
 # ./src/main/java/mods/eln/transparentnode/electricalfurnace/ElectricalFurnaceDescriptor.java
 Similar_to_a_vanilla_furnace,\nbut_heats_with_electricity.=跟一个正常的熔炉一样,只是用电驱动
 
+# ./src/main/java/mods/eln/transparentnode/electricalfurnace/ElectricalFurnaceElement.java
+Heating_element=加热器
+
 # ./src/main/java/mods/eln/transparentnode/electricalfurnace/ElectricalFurnaceGuiDraw.java
-Auto_shutdown=自动关闭
-Manual_shutdown=手动关闭
-Set_point\:_%1$°C=设置温度\:%1$°C
+Auto_shutdown=自动启停
+Manual_shutdown=手动启停
+Set_point\:_%1$°C=设置温度: %1$°C
+
+# ./src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineContainer.java
 
 # ./src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineDescriptor.java
-Cost=价格
+Cost=消耗
+
+# ./src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineElement.java
+Power_provided=供应功率
+
+# ./src/main/java/mods/eln/transparentnode/Fabricator.kt
+The_Fabricator_creates_chips\nfrom_silicon_and_copper_plates=制造机使用铜板和硅晶圆制造芯片
+Nominal_Ohms\:_%1$=额定电阻: %1$
 
 # ./src/main/java/mods/eln/transparentnode/heatfurnace/HeatFurnaceContainer.java
 Combustion_chamber_slot=槽(燃烧室)
 Fuel_slot=槽(燃料)
 
-# ./src/main/java/mods/eln/transparentnode/heatfurnace/HeatFurnaceDescriptor.java
-Generates_heat_when_supplied_with_fuel.=提供燃料的时候产生热
+# ./src/main/java/mods/eln/transparentnode/heatfurnace/HeatFurnaceElement.java
+Set_temperature=设定温度
 
 # ./src/main/java/mods/eln/transparentnode/heatfurnace/HeatFurnaceGuiDraw.java
-Control_gauge_at_%1$%=操作规范\:%1$%
-Decline_fuel=减少燃料
-External_control=手动控制
-Internal_control=自动控制
-Take_fuel=取走燃料
+Control_gauge_at_%1$%=Control gauge at %1$%
+Decline_fuel=待机中
+Take_fuel=运行中
+
+# ./src/main/java/mods/eln/transparentnode/NixieTube.kt
+Displays_a_single_glowing_digit.=显示一个发光的数字
+Signal_input_doesn't_require_power,_and_interfaces_are_tailored_to_gameplay=信号输入不需要能量，接口根据游戏情况量身定制
+Nixie_tube_has_been_textured_realistically=辉光管具有拟真材质
 
 # ./src/main/java/mods/eln/transparentnode/powercapacitor/PowerCapacitorContainer.java
-(Increases_maximal_voltage)=(增大最大电压)
+(Increases_maximal_voltage)=(Increases maximal voltage)
+
+# ./src/main/java/mods/eln/transparentnode/powercapacitor/PowerCapacitorGui.java
+
+# ./src/main/java/mods/eln/transparentnode/powerinductor/PowerInductorContainer.java
+
+# ./src/main/java/mods/eln/transparentnode/powerinductor/PowerInductorGui.java
 
 # ./src/main/java/mods/eln/transparentnode/solarpanel/SolarPanelContainer.java
-Solar_tracker_slot=槽(太阳能跟踪器)
+Solar_tracker_slot=槽(太阳追踪组件)
 
 # ./src/main/java/mods/eln/transparentnode/solarpanel/SolarPanelDescriptor.java
-Can_be_geared_towards_the_sun.=可以使太阳能板直指太阳以获得更多的能源
-Max._power\:_%1$W=最大功率\:%1$W
-Max._voltage\:_%1$V=最大电压\:%1$V
-Produces_power_from_solar_radiation.=从太阳辐射获取能量
+Can_be_geared_towards_the_sun.=可以使太阳能板直指太阳以接收更多能量
+Max._power\:_%1$W=最大功率: %1$W
+Max._voltage\:_%1$V=最大电压: %1$V
+Produces_power_from_solar_radiation.=从太阳辐射中获取能量
+
+# ./src/main/java/mods/eln/transparentnode/solarpanel/SolarPanelElement.java
+Panel_angle=太阳能板角度(与法线夹角)
+Producing_energy=发电中
+Sun_angle=太阳角度(与法线夹角)
 
 # ./src/main/java/mods/eln/transparentnode/solarpanel/SolarPannelGuiDraw.java
 It_is_night=晚上了
-Solar_panel_angle\:_%1$°=太阳能电板角度\:%1$°
-Sun_angle\:_%1$°=太阳角度\:%1$°
+Solar_panel_angle\:_%1$°=太阳能板角度(与法线夹角): %1$°
+Sun_angle\:_%1$°=太阳角度(与法线夹角): %1$°
+
+# ./src/main/java/mods/eln/transparentnode/teleporter/TeleporterDescriptor.java
+It's_experimental!=这是实验性的！
+
+# ./src/main/java/mods/eln/transparentnode/teleporter/TeleporterElement.java
+Destination=目的地
+Distance=距离
+Required_energy=所需能量
 
 # ./src/main/java/mods/eln/transparentnode/teleporter/TeleporterGui.java
-Destination_transporter=传送至目的地
-Power_consumption\:=消耗功率\:
-Power_consumption\:_%1$W=使用功率\:%1$W
-Required_energy\:_%1$J=需要功率\:%1$J
-Start=开始
+Destination_transporter=目的传送机名称
+Power_consumption\:=消耗功率:
+Power_consumption\:_%1$W=使用功率: %1$W
+Required_energy\:_%1$J=需要能量: %1$J
+Start=开始传送
 Transporter_name=传送机名称
 
 # ./src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveDescriptor.java
-Fan_cooling_power\:_%1$W=风冷功率\:%1$W
-Fan_power_consumption\:_%1$W=风扇功率\:%1$W
-Fan_voltage\:_%1$V=风扇电压\:%1$V
+Fan_cooling_power\:_%1$W=风冷功率: %1$W
+Fan_power_consumption\:_%1$W=风扇功率: %1$W
+Fan_voltage\:_%1$V=风扇电压: %1$V
+
+# ./src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveElement.java
+
+# ./src/main/java/mods/eln/transparentnode/ThermalHeatExchanger.kt
+Generates_heat_when_supplied_with_ic2\:hotcoolant=提取ic2热冷却液的热量
+Ejects_out_ic2\:coolant=排出ic2冷却液
+
+# ./src/main/java/mods/eln/transparentnode/transformer/TransformerContainer.java
+Casing_slot=槽(变压器罩)
 
 # ./src/main/java/mods/eln/transparentnode/transformer/TransformerDescriptor.java
-The_voltage_ratio_is_proportional\nto_the_cable_stacks_count_ratio.=电压与导线的数目成正比
+The_voltage_ratio_is_proportional\nto_the_cable_stacks_count_ratio.=电压比与铜导线数目比成正比
 Transforms_an_input_voltage_to\nan_output_voltage.=将输入电压转换为输出电压
+The_output_voltage_is_controlled\nfrom_a_signal_input=输出电压由输入信号控制
+This_variable_DC_DC_has_unrealistic_capacitance_effects_and_can_sink_source_power_that_violates_Newton's_laws=这种可变 直流-直流 变压器具有不切实际的电容效应，可能会消耗/产生违反牛顿定律的功率
+It_is_made_this_way_to_improve_the_performance_of_the_simulator_in_large_power_networks=这样做是为了提高大型电网中模拟器的性能
+This_DC_DC_has_unrealistic_capacitance_effects_and_can_sink_source_power_that_violates_Newton's_laws=这种 直流-直流 变压器具有不切实际的电容效应，可能会消耗/产生违反牛顿定律的功率
+
+# ./src/main/java/mods/eln/transparentnode/transformer/TransformerElement.java
+Core_factor=核心要素
+Isolated=隔离
+Ratio=转换比
 
 # ./src/main/java/mods/eln/transparentnode/turbine/TurbineDescriptor.java
 Generates_electricity_using_heat.=用热能来发电
-Temperature_difference\:_%1$°C=温度差\:%1$°C
+Temperature_difference\:_%1$°C=温差: %1$°C
+
+# ./src/main/java/mods/eln/transparentnode/turbine/TurbineElement.java
+Nominal=额定
+
+# ./src/main/java/mods/eln/transparentnode/turret/TurretContainer.java
 
 # ./src/main/java/mods/eln/transparentnode/turret/TurretDescriptor.java
-CAUTION\:_Cables_can_get_quite_hot!=警告\:导线过热
-Laser_charge_power\:_%1$W...%2$kW=激光充电功率\:%1$W...%2$kW
-Scans_for_entities_and_shoots_if_the\nentity_matches_the_configurable_filter_criteria.=范围内如果找到的实体与过滤器一致\n那么开始攻击该实体直至实体从范围内移除
-Standby_power\:_%1$W=备用功率\:%1$W
+CAUTION\:_Cables_can_get_quite_hot!=警告:小心导线过热
+Laser_charge_power\:_%1$W...%2$kW=激光充电功率: %1$W...%2$kW
+Scans_for_entities_and_shoots_if_the\nentity_matches_the_configurable_filter_criteria.=范围内如果找到的实体与过滤器一致\n那么开始攻击该实体直至实体从范围内消失
+Standby_power\:_%1$W=待机功率: %1$W
+
+# ./src/main/java/mods/eln/transparentnode/turret/TurretElement.java
+??=??
+Charge_level=功率
+Shoot_=攻击
+Shoot_everything=攻击所有
+Shoot_nothing=不攻击
+Target=目标
+animals=动物
+monsters=怪物
+players=玩家
 
 # ./src/main/java/mods/eln/transparentnode/turret/TurretGui.java
-Attack\:=攻击\:
-Do_not_attack\:=不攻击\:
-Recharge_power\:=放电功率
+Attack\:=攻击:
+Do_not_attack\:=不攻击:
+Recharge_power\:=放电功率:
 
 # ./src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineDescriptor.java
 Generates_energy_using_water_stream.=用流动水来发电
-No_place_for_water_turbine!=没有足够的空间供水力发电机工作
+No_place_for_water_turbine!=没有足够的空间放置水力发电机
+
+# ./src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineElement.java
 
 # ./src/main/java/mods/eln/transparentnode/windturbine/WindTurbineDescriptor.java
-Front\:_%1$=前面\:%1$
+Front\:_%1$=前: %1$ 格
 Generates_energy_from_wind.=用风来发电
-Left_Right\:_%1$=左/右\:%1$
-Up_Down\:_%1$=上/下\:%1$
-Wind_area\:=风区
+Left_Right\:_%1$=左右: %1$ 格
+Up_Down\:_%1$=上下: %1$ 格
+Wind_area\:=风区:
 
 # ./src/main/java/mods/eln/wiki/Data.java
-Energy=功率
-Light=亮度
+Light=照明
 Machine=机器
-Ore=kuang'shi
+Ore=矿石
 Portable=便携式
-Resource=源
+Resource=材料
 Signal=信号
 Thermal=热能
 Upgrade=升级
-Utilities=公用
+Utilities=实用
 Wiring=布线
 
 # ./src/main/java/mods/eln/wiki/Default.java
-Previous=过去的
+Previous=后退
 
 # ./src/main/java/mods/eln/wiki/ItemDefault.java
-Can_be_used_to_craft\:=可以用来合成\:
-Cannot_be_crafted!=不能合成而得\!
-Cost_%1$J=消耗能量\:%1$J
-Created_by\:=制作原料\:
-Is_not_a_crafting_material!=不能合成其他物品\!
-Recipe\:=合成表\:
+Can_be_used_to_craft\:=可以作为合成材料:
+Cannot_be_crafted!=无法通过合成获得!
+Cost_%1$J=消耗能量 %1$J
+Created_by\:=生产于:
+Is_not_a_crafting_material!=不能合成其他物品!
+Recipe\:=合成表:
 
 # Appearing in multiple source files
-(Increases_capacity)=(增大容量)
+%1$_is_not_in_range!=%1$ 不在范围内!
+(Increases_capacity)=(增大电容)
 (Increases_inductance)=(增大电感)
-Actual\:_%1$°C=实际温度\:%1$°C
-Biggest=最大的
-Booster_slot=槽(增压器)
-Can_create\:=可以合成\:
-Capacity\:_%1$F=容量\:%1$F
-Charge_power\:_%1$W=充电功率\:%1$W
+Acts_like_a\npush_button.=就像一个按钮
+Acts_like_a\ntoggle_switch.=就像一个拉杆
+Actual\:_%1$°C=实际温度: %1$°C
+Battery_level=电池电量
+Biggest=或
+Booster_slot=槽(增压升级)
+Can_create\:=可以用于生产:
+Capacity\:_%1$F=电容: %1$F
+Channel=频道
+Charge=电量
+Charge_power=充电功率
+Charge_power\:_%1$W=充电功率: %1$W
+Closed=合上
 Connected=已连接
-Cooling_power\:_%1$W=冷却功率\:%1$W
+Cooling_power\:_%1$W=冷却功率: %1$W
 Copper_cable_slot=槽(铜导线)
+Current=电流
 Dielectric_slot=槽(绝缘体)
-Discharge_power\:_%1$W=输出功率\:%1$W
-Electrical_cable_slot=槽(电力导线)
-Entity_filter_slot=槽(生物过滤器)
-Ferromagnetic_core_slot=槽(磁能核心)
+Discharge_power\:_%1$W=放电功率: %1$W
+Electrical_cable_slot=槽(导线)
+Energy=能量
+Entity_filter_slot=槽(生物筛选组件)
+External_control=外部控制中
+Ferromagnetic_core_slot=槽(铁磁芯)
+Generated_power=发电功率
+Generates_heat_when_supplied_with_fuel.=燃烧燃油产热
+Generating=发电中
 Has_a_signal_output.=有一个信号输出
-Inductance\:_%1$H=电感\:%1$H
-Internal_resistance\:_%1$Ω=内阻\:%1$Ω
-Is_off=关
-Is_on=开
-Max._temperature\:_%1$°C=最高温度\:%1$°C
-Measured_value\ncorresponding\nto_0%_output=测量zhi\n对应\n0%输出
-Measured_value\ncorresponding\nto_100%_output=测量zhi\n对应\n0%输出
-Nominal\:=理论\:
-Nominal_power\:_%1$W=理论功率\:%1$W
-Nominal_usage\:=理论使用\:
-Nominal_voltage\:_%1$V=理论电压\:%1$V
+Inductance\:_%1$H=电感: %1$H
+Input=输入
+Input_voltage=输入电压
+Internal_control=内部控制中
+Internal_resistance\:_%1$Ω=内阻: %1$Ω
+Is_off=待机中
+Is_on=工作中
+Life=寿命
+Max._temperature\:_%1$°C=最高温度: %1$°C
+miaou=喵呜~
+Min._temperature\:_%1$°C=最低温度: %1$°C
+Measured_value\ncorresponding\nto_0%_output=对应于0%输出的测量值
+Measured_value\ncorresponding\nto_100%_output=对应于100%输出的测量值
+No=否
+Nominal\:=额定参数:
+Nominal_power\:_%1$W=额定功率: %1$W
+Nominal_usage\:=额定参数:
+Nominal_voltage\:_%1$V=额定电压: %1$V
+None=无
 Not_connected=未连接
 Not_enough_space_for_this_block=没有足够空间放置这个方块
+OFF=关
+ON=开
+Off=关
+On=开
+Open=打开
+Output_voltage=输出电压
+Portable_battery_slot=槽(便携电池)
+Position=触点
 Power=功率
-Power\:_%1$W=功率\:%1$W
-Range\:_%1$_blocks=范围\:%1$个方块
+Power\:_%1$W=功率: %1$W
+Power_consumption=消耗功率
+Powered_by_Lamp_Supply=由无线照明控制盒供电
+Powered_by_cable=导线供电
+Produced_power=发电功率
+Range\:_%1$_blocks=范围: %1$ 方块
+Really_useless=真的没用
 Redstone_slot=槽(红石)
-Regulator_slot=槽(校准器)
+Redstone_value=红石信号强度
+Regulator_slot=槽(温控组件)
 Reset=重置
-Resistance\:_%1$Ω=电阻\:%1$Ω
-Smallest=最小的
-Specify_the_channel=指定通道
-Stored_energy\:_%1$J_(%2$%)=储存的能量\:%1$J(%2$%)
-Temperature\:_%1$°C=温度\:%1$°C
+Resistance=电阻
+Resistance\:_%1$Ω=电阻: %1$Ω
+Signal_Voltage=信号电压
+Smallest=与
+Specify_the_channel=指定频道
+Specify_the_supply_channel=指定供电频道
+State=状态
+Stored_energy\:_%1$J_(%2$%)=储存能量: %1$J (%2$%)
+Temperature=温度
+Temperature\:_%1$°C=温度: %1$°C
 Temperature_gauge=温度计
-Thermal_isolator_slot=槽(隔热器)
+Thermal_isolator_slot=槽(石棉网)
+Thermal_power=散热功率
 Toggle=切换
 Toggle_switch=切换开关
-Toggles_the_output_each_time\nan_emitter's_value_rises.\nUseful_to_allow_multiple_buttons\nto_control_the_same_light.=按按钮时增大输出\n在多个开关控制同一灯泡时很有用
-Used_to_cool_down_turbines.=用来冷却涡轮
-Uses_the_biggest\nvalue_on_the_channel.=使用通道上最高的值
-Uses_the_smallest\nvalue_on_the_channel.=使用通道上最低的值
-Validate=证实
-Voltage\:_%1$V=电压\:%1$V
+Toggles_the_output_each_time\nan_emitter's_value_rises.\nUseful_to_allow_multiple_buttons\nto_control_the_same_light.=无线信号频道中有按钮切换状态则切换状态\n在多个开关控制同一频道时很有用
+Used_to_cool_down_turbines.=用来散热
+useless=无用
+Uses_the_biggest\nvalue_on_the_channel.=无线信号频道中有一个开关开启则状态为高电平
+Uses_the_smallest\nvalue_on_the_channel.=无线信号频道中所有频道开启则状态为高电平
+Validate=确认
+Voltage=电压
+Voltage\:_%1$V=电压: %1$V
+Voltage_drop=压降
+Voltages=电压
+Yes=是
 You_can't_place_this_block_at_this_side=不能把方块放在这一边哟~
+_O\:_= O:
+
+# FIXME
+Grid_DC-DC_Converter.name=电网变压器
+Transmission_Tower.name=T2输电塔
+Utility_Pole.name=T1电线杆
+Utility_Pole_w/DC-DC_Converter.name=T1电线杆(变压器)
+
+# some other stuff
+
+Portable_NaN.name=便携式NaN(开发项目)
+Old_800V_Arc_Furnace.name=电弧炉(800V,10kW)
+Christmas_Tree.name=圣诞树
+Holiday_Candle.name=假日蜡烛
+String_Lights.name=一串灯
+Radial_Motor.name=发动机(燃气,64mB/s)
+Thermal_Heat_Exchanger.name=热交换器
+Current_Source.name=电流源
+Improved_Flashlight.name=改进的手电筒
+Thermal_Insulation.name=石棉网
+Organic_Asbestos™=有机石棉™
+Upgrade_for_the_Stone_Heat_Furnace=石制加热炉的升级
+__Heat_tolerance\:=  耐热性:
+__Insulation\:=  隔热率:
+Cuts_down_trees._Right-click_to_make_it_act_like_a_regular_axe.=砍树，右键开启连锁模式
+Opens_holes._Right-click_to_open_smaller_holes.=挖3*3，右键开启1*1模式
+Silicon_Wafer.name=硅晶圆
+Transistor.name=晶体管
+NTC_Thermistor.name=负温度系数热敏电阻
+Nibble_Memory_Chip.name=半字节存储器芯片
+Arithmetic_Logic_Unit.name=算术逻辑单元
+Fabricator.name=制造机
+Multicolor_LED_vuMeter.name=信号计(多色LED)
+Grid_Switch.name=电网开关
+Direct_Utility_Pole.name=直连电线杆
+Crank_Shaft.name=曲轴
+Rolling_Shaft_Machine.name=滚轴机
+Low_Current_Relay.name=继电器(5A)
+Medium_Current_Relay.name=继电器(20A)
+High_Current_Relay.name=继电器(100A)
+Type_E_Socket.name=E型插座
+Type_J_Socket.name=J型插座
+Conduit.name=管道电缆
+tile.eln.Conduit.name=埋管块
+Subsystem_Matrix_Size=子系统矩阵大小
+Charging...=充电中...
+Batteries_empty=电量耗尽
+Fully_charged=充满了
+Simple=总量
+Slots=格子
+Inputs=输入
+Min=最小
+Max=最大
+Speed=转速
+Speeds=转速
+Energies=动能
+Clutching=制动力信号
+Fuel_usage=燃料消耗速度
+Process_State=加工进度
+Can_Process=可以工作
+Not_as_warm_as_it_could_be=没有达到预期的温暖程度
+It_probably_works_if_you_apply_~200v_to_the_xmas_wireless_channel=如果你在"xmas"无线照明频道中输入200V，它可能会工作
+Control=控制
+input_tank_level=热冷却液
+output_tank_level=冷却液
+input_mB_t=输入速率(mB/t)
+output_mB_t=输出速率(mB/t)
+joules_per_tick=热交换速度(J/tick)
+thermal_power=热功率
+Left=左
+Right=右
+Transfer=转换
+Drive=负载
+Signal=信号
+Closed?=关闭中?
+Digit=数字
+Blank=黯淡
+Dots=小数点
+No_wireless_signal_in_area!=范围内没有无线信号!
+_Strength= 强度
+_Value= 值
+Control_Voltage=控制电压
+Operation=目标

--- a/src/main/resources/assets/eln/lang/zh_CN.lang
+++ b/src/main/resources/assets/eln/lang/zh_CN.lang
@@ -432,16 +432,15 @@ Can_rotate_slowly=右键慢速转动
 
 # ./src/main/java/mods/eln/mechanical/Generator.kt
 Converts_mechanical_energy_into_electricity,_or_(badly)_vice_versa.=将机械能转换为电能，或反之(低效)。
-Voltage_out\:_%1$=输出电压:
-Power_out\:_%1$=输出功率: %1$
-Rads\:_%1$=最佳转速: %1$
+__Voltage_out\:_=  输出电压:
+__Rads\:_=  最佳转速:
 
 # ./src/main/java/mods/eln/mechanical/Motor.kt
 Converts_electricity_into_mechanical_energy,_or_(badly)_vice_versa.=将电能转换为机械能，或反之(低效)。
-Voltage_in\:_%1$=输入电压: %1$
-Power_in\:_%1$=输入功率: %1$
-rad_s\:_%1$=最佳转速: %1$
-Max_rad_s\:_%1$=最大转速: %1$
+__Voltage_in\:_=  输入电压:
+__Power_in\:_=  输入功率:
+__rad_s\:_=  最佳转速:
+Max_rad_s\:_=最大转速:
 
 # ./src/main/java/mods/eln/mechanical/Tachometer.kt
 Rads_s_corresponding\nto_0%_output=对应 0% 输出的Rads/s(转速)
@@ -452,10 +451,10 @@ Converts_%1$_into_mechanical_energy.=消耗%1$产生机械能
 Nominal_usage_->=额定参数:
 %1$_input\:_%2$_mB_s=%1$输入: %2$ mB/s
 No_valid_fluids_for_this_turbine!=没有有效的流体用于这个发动机!
-Power_out\:_%1$=输出功率: %1$
+__Power_out\:_=输出功率:
 Power_out\:_%1$-_%2$=输出功率: %1$- %2$
-Optimal_rads\:_%1$=最佳转速: %1$
-Max_rads\:__%1$=最大转速:  %1$
+__Optimal_rads\:_=最佳转速:
+Max_rads\:__=最大转速:
 
 # ./src/main/java/mods/eln/misc/UtilsClient.java
 Hold_[shift]_for_details=按住 [shift] 查看细节
@@ -658,7 +657,7 @@ A_relay_is_an_electrical\ncontact_that_conducts\ncurrent_when_a_signal\nvoltage_
 The_relay's_input_behaves\nlike_a_Schmitt_Trigger.=继电器的输入行为类似于施密特触发器
 
 # ./src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayElement.java
-Default_position=Default position
+Default_position=触点默认状态
 
 # ./src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayGui.java
 Normally_closed=默认合上
@@ -769,6 +768,7 @@ Wireless_mode_of_lights_intended_to_pretend_wires_are_in_the_walls=用于假装�
 
 # ./src/main/java/mods/eln/sixnode/lampsocket/LampSocketElement.java
 Bulb=灯泡
+Life_Left\:_=剩余寿命
 
 # ./src/main/java/mods/eln/sixnode/lampsocket/LampSocketGuiDraw.java
 Cable_slot_empty=导线槽没有导线
@@ -849,8 +849,8 @@ Coal_dust_slot=槽(煤粉)
 It's_a_resistor=这是一个电阻
 
 # ./src/main/java/mods/eln/sixnode/thermalcable/ThermalCableDescriptor.java
-High_parallel_resistance\n_⇨_Low_power_dissipation.=高并联热阻\n ⇨ 低热损
-Low_serial_resistance\n_⇨_High_conductivity.=低串联热阻\n ⇨ 高热导.
+High_parallel_resistance\n_->_Low_power_dissipation.=高并联热阻\n -> 低热损
+Low_serial_resistance\n_->_High_conductivity.=低串联热阻\n -> 高热导.
 Parallel_resistance\:_%1$K_W=并联热阻: %1$K/W
 Serial_resistance\:_%1$K_W=串联热阻: %1$K/W
 The_thermal_simulator_doesn't_properly_manage_heat=热量模拟器无法正确管理热量
@@ -902,14 +902,14 @@ Nominal_voltage\:_%1$_V=额定电压: %1$ V
 Produces_electricity_using_gasoline.=燃烧轻油发电
 
 # ./src/main/java/mods/eln/transparentnode/FuelHeatFurnace.kt
-Actual\:_%1$=实际温度: %1$
+Actual\:_=实际温度:
 Analog_regulator_slot=槽(温控组件)
-Control_value_at_%1$=控制值 %1$
+Control_value_at_=控制值
 Fuel_burner_slot=槽(燃料燃烧器)
 Furnace_is_off=加热炉已停止
 Furnace_is_on=加热炉正在工作
-Heat_Power\:_%1$=加热功率: %1$
-Set_point\:_%1$=设定温度: %1$
+Heat_Power\:_=加热功率:
+Set_point\:_=设定温度:
 __Max._temperature\:_=  最大温度:
 
 # ./src/main/java/mods/eln/transparentnode/LargeRheostat.kt
@@ -965,7 +965,7 @@ __*_Voltage_oriented_uses_two_smaller_batteries_in_series_to_increase_voltage=  
 Charged=充满了
 Discharge=放电
 Energy\:=电量:
-Energy\:_%1$=电量: %1$
+Energy\:_=电量:
 Life\:=寿命:
 No_charge=没有充电
 Power_in\:=充电功率:
@@ -1334,7 +1334,7 @@ Clutching=制动力信号
 Fuel_usage=燃料消耗速度
 Process_State=加工进度
 Can_Process=工作中
-Not_as_warm_as_it_could_be=没有达到预期的温暖程度
+Not_as_warm_as_it_could_be=不如本应温暖
 It_probably_works_if_you_apply_~200v_to_the_xmas_wireless_channel=如果你在"xmas"无线照明频道中输入200V，它可能会工作
 Control=控制
 input_tank_level=热冷却液

--- a/src/main/resources/assets/eln/lang/zh_CN.lang
+++ b/src/main/resources/assets/eln/lang/zh_CN.lang
@@ -1,212 +1,155 @@
 #<ELN_LANGFILE_V1_1>
 
 # ./src/main/java/mods/eln/Achievements.java
-Electrical_Age_[WIP]=电力时代Electrical Age\n(translate by KLsz and polish by aneBlack,later polished by Eternal130)
+Electrical_Age_[WIP]=电力时代Electrical Age\n(translate by KLsz and polish by aneBlack)
 achievement.craft_50v_macerator=初入粉碎之法
-achievement.craft_50v_macerator.desc=合成一个粉碎机(50v)
+achievement.craft_50v_macerator.desc=50V的粉碎工艺！
 achievement.open_guide=学会内置Wiki
 achievement.open_guide.desc=内置Wiki的能量,超乎你想象
 
 # ./src/main/java/mods/eln/Eln.java
 10A_Diode.name=二极管(10A)
-800V_Arc_Furnace.name=电弧炉(800V,10kW)
-Experimental_Battery.name=实验电池
-Creative_Cable.name=创造超导体导线
-2x_Graphite_Rods.name=2联碳棒
-200V_Active_Thermal_Dissipator.name=散热器(主动,冷却功率:200W+1.2kW,最高温度:130°C,风扇参数:200V,60W)
+200V_Active_Thermal_Dissipator.name=散热器(T\:200W+1.2kW,200°C;E\:200V,60W)
 200V_Battery_Charger.name=电池充电器(200V,1kW)
-200V_Compressor.name=压缩机(200V,2.00kW)
+200V_Compressor.name=压缩机(200V)
 200V_Condensator.name=电容(200V)
-200V_Copper_Heating_Corp.name=加热器(铜,200V,600W)
+200V_Copper_Heating_Corp.name=铜电热丝(200V,600W)
 200V_Economic_Light_Bulb.name=节能灯泡(200V,15W)
-200V_Emergency_Lamp.name=应急灯(200V)
 200V_Farming_Lamp.name=暖箱灯泡(200V,120W)
-200V_Fuel_Generator.name=发电机(轻油,200V,6kW)
+200V_Fuel_Generator.name=200V Fuel Generator
 200V_Incandescent_Light_Bulb.name=白炽灯泡(200V,30W)
-200V_Iron_Heating_Corp.name=加热器(铁,200V,900W)
-200V_LED_Bulb.name=LED灯泡(200V,15W)
-200V_Macerator.name=粉碎机(200V,2.00kW)
-200V_Magnetizer.name=磁化机(200V,2.00kW)
-200V_Plate_Machine.name=冷轧机(200V,2.00kW)
-200V_Power_Socket.name=插座(200V)
-200V_Tungsten_Heating_Corp.name=加热器(钨,200V,1.2kW)
-200V_Turbine.name=发电机(温差,200V,2.00kW,Δ350°C)
+200V_Iron_Heating_Corp.name=铁电热丝(200V,900W)
+200V_LED_Bulb.name=200V LED Bulb
+200V_Macerator.name=粉碎机(200V,400W)
+200V_Magnetizer.name=磁化器(200V,400W)
+200V_Plate_Machine.name=冷轧机(200V,400W)
+200V_Power_Socket.name=能源接口(200V)
+200V_Tungsten_Heating_Corp.name=钨电热丝(200V,1.2kW)
+200V_Turbine.name=发电机(温差,200V,500W,Δ350°C)
 25A_Diode.name=二极管(25A)
-2x3_Rotating_Solar_Panel.name=2x3自适应太阳能板
-2x3_Solar_Panel.name=2x3太阳能板
-3.2kV_Tungsten_Heating_Corp.name=加热器(钨,3.2kV,12.0kW)
-3x_Graphite_Rods.name=3联碳棒
-4x_Graphite_Rods.name=4联碳棒
 50V_Battery_Charger.name=电池充电器(50V,400W)
 50V_Carbon_Incandescent_Light_Bulb.name=碳丝灯泡(50V,25W)
-50V_Compressor.name=压缩机(50V,200W)
+50V_Compressor.name=压缩机(50V)
 50V_Condensator.name=电容(50V)
-50V_Copper_Heating_Corp.name=加热器(铜,50V,250W)
+50V_Copper_Heating_Corp.name=铜电热丝(50V,250W)
 50V_Economic_Light_Bulb.name=节能灯泡(50V,15W)
 50V_Egg_Incubator.name=鸡蛋孵化器(50V)
-50V_Emergency_Lamp.name=应急灯(50V)
 50V_Farming_Lamp.name=暖箱灯泡(50V,120W)
-50V_Fuel_Generator.name=发电机(轻油,50V,1.2kW)
+50V_Fuel_Generator.name=50V Fuel Generator
 50V_Incandescent_Light_Bulb.name=白炽灯泡(50V,30W)
-50V_Iron_Heating_Corp.name=加热器(铁,50V,375W)
-50V_LED_Bulb.name=LED灯泡(50V,15W)
+50V_Iron_Heating_Corp.name=铁电热丝(50V,375W)
+50V_LED_Bulb.name=50V LED Bulb
 50V_Macerator.name=粉碎机(50V,200W)
 50V_Magnetizer.name=磁化机(50V,200W)
 50V_Plate_Machine.name=冷轧机(50V,200W)
-50V_Power_Socket.name=插座(50V)
-50V_Tungsten_Heating_Corp.name=加热器(钨,50V,500W)
+50V_Power_Socket.name=能源接口(50V)
+50V_Tungsten_Heating_Corp.name=钨电热丝(50V,500W)
 50V_Turbine.name=发电机(温差,50V,300W,Δ250°C)
-800V_Defence_Turret.name=防御塔(800V,最低100W,最高10kW)
-800V_Tungsten_Heating_Corp.name=加热器(钨,800V,4.81kW)
-AND_Chip.name=数字集成电路(与)
+800V_Defence_Turret.name=防御塔(800V,min-50W,max-1kW)
+AND_Chip.name=AND Chip
 Advanced_Chip.name=芯片(高级)
 Advanced_Electrical_Motor.name=电机(高级)
-Advanced_Energy_Meter.name=电表(高级)
+Advanced_Energy_Meter.name=电能表(高级)
 Advanced_Machine_Block.name=机器方块(高级)
 Advanced_Magnet.name=磁铁(高级)
 AllMeter.name=通用表
 Alloy_Dust.name=钨钢合金粉
 Alloy_Ingot.name=钨钢合金锭
 Alloy_Plate.name=钨钢合金板
-Amplifier.name=模拟集成电路(功率放大器)
 Analog_Watch.name=模拟时钟
-Analog_vuMeter.name=信号计(模拟)
-Analogic_Regulator.name=温控组件(敏感度:模拟)
+Analog_vuMeter.name=模拟电压表(信号)
+Analogic_Regulator.name=模拟温控组件
 Animal_Filter.name=动物筛选组件
-Arc_Clay_Ingot.name=铝锭
-Arc_Metal_Ingot.name=钢锭
 Auto_Miner.name=自动挖矿机(800V)
-Average_Electrical_Drill.name=钻头(1kW,5")
-Average_Ferromagnetic_Core.name=铁磁芯(50.0)
+Average_Electrical_Drill.name=电钻(1kW,5")
+Average_Ferromagnetic_Core.name=磁能核心(4.0)
 Basic_Magnet.name=磁铁(基础)
-Big_Fuel_Burner.name=大型燃料燃烧器
 Black_Brush.name=刷子(黑)
-Blown_Lead_Fuse.name=铅保险丝
 Blue_Brush.name=刷子(蓝)
 Brown_Brush.name=刷子(棕)
-Capacity_Oriented_Battery.name=电池(容量更大,12.5V,125W,480KJ)
-Canister_of_Arc_Water.name=惰性炭罐(电弧液)
-Canister_of_Water.name=惰性炭罐(水)
-Casing.name=变压器罩
+Capacity_Oriented_Battery.name=电源(容量更大,12V,125W,240kJ)
 Cheap_Chip.name=芯片(基础)
-Cheap_Electrical_Drill.name=钻头(500W,8")
-Cheap_Ferromagnetic_Core.name=劣质铁磁芯(100.0)
+Cheap_Electrical_Drill.name=电钻(500W,8")
+Cheap_Ferromagnetic_Core.name=磁能核心(10.0)
 Cinnabar_Dust.name=朱砂粉
 Cinnabar_Ore.name=朱砂矿石
-Clutch.name=离合器
-Clutch_Pin.name=离合器销
-Coal_Clutch_Plate.name=碳离合器片
-Coal_Dust.name=碳粉
-Coal_Plate.name=碳板
-Combustion_Chamber.name=燃烧室
-Config_Copy_Tool.name=配置复制工具
-Configurable_summing_unit.name=模拟集成电路(可配置求和单元)
+Coal_Dust.name=煤粉
+Coal_Plate.name=煤板
+Combustion_Chamber.name=炉膛组件
 Copper_Cable.name=导线(铜)
-Copper_Clutch_Plate.name=铜离合器片
 Copper_Dust.name=铜粉
 Copper_Ingot.name=铜锭
 Copper_Ore.name=铜矿
 Copper_Plate.name=铜板
-Copper_Thermal_Cable.name=热管(铜,980°C)
-Cost_Oriented_Battery.name=电池(更廉价,50V,250W,120KJ)
-Current_Oriented_Battery.name=电池(电流更大,50V,1.0kW,80KJ)
+Copper_Thermal_Cable.name=导热管(铜,1k°C)
+Cost_Oriented_Battery.name=电源(更廉价,50V,250W,60KJ)
+Current_Oriented_Battery.name=电源(电流更大,50V,1000W,40KJ)
 Cyan_Brush.name=刷子(青)
-Legacy_DC-DC_Converter.name=直流-直流 变压器(传统)
-DC-DC_Converter.name=直流-直流 变压器
-Variable_DC-DC_Converter.name=直流-直流 变压器(可调)
-D_Flip_Flop_Chip.name=数字集成电路(边缘D触发器)
+D_Flip_Flop_Chip.name=D Flip Flop Chip
 Data_Logger.name=示波器(台式,信号)
 Data_Logger_Print.name=示波器(打印,信号)
-Diamond_Dust.name=钻石粉
 Dielectric.name=绝缘体
-Digital_Display.name=信号显示器
 Digital_Watch.name=数字时钟
 Electrical_Anemometer_Sensor.name=传感器(风力)
 Electrical_Breaker.name=断路器
-Electrical_Daylight_Sensor.name=传感器(阳光)
-Electrical_Entity_Sensor.name=传感器(实体)
-Electrical_Fire_Buzzer.name=蜂鸣器(火警)
-Electrical_Fire_Detector.name=传感器(火警)
+Electrical_Daylight_Sensor.name=感应器(阳光)
+Electrical_Entity_Sensor.name=感应器(实体)
+Electrical_Fire_Detector.name=电气火花传感器
 Electrical_Furnace.name=电炉
-Electrical_Fuse_Holder.name=保险盒
-Electrical_Light_Sensor.name=传感器(光)
+Electrical_Light_Sensor.name=感应器(光)
 Electrical_Motor.name=电机
-Electrical_Probe.name=探测器(电气)
-Electrical_Probe_Chip.name=芯片(电气探测器)
-Electrical_Source.name=电压源
+Electrical_Probe.name=电力传感器
+Electrical_Probe_Chip.name=芯片(电力传感器)
+Electrical_Source.name=电源
 Electrical_Timer.name=断路延时器
 Electrical_Weather_Sensor.name=传感器(天气)
-Electrical_age_wrench,\nCan_be_used_to_turn\nsmall_wall_blocks=扳手用来旋转一些小设备或打开设置界面
-Energy_Meter.name=电表
-Experimental_Transporter.name=传送机(实验性)
-Fast_Electrical_Drill.name=钻头(2kW,3")
+Electrical_age_wrench,\nCan_be_used_to_turn\nsmall_wall_blocks=扳手用来翻转一些小方块
+Energy_Meter.name=电能表
+Experimental_Transporter.name=传送机
+Fast_Electrical_Drill.name=电钻(2kW,3")
 Ferrite_Ingot.name=铁氧体锭
-Fixed_Shaft.name=固定轴
 Flat_Lamp_Socket.name=灯座(扁平)
 Fluorescent_Lamp_Socket.name=灯座(荧光)
-Flywheel.name=飞轮
-Fuel_Heat_Furnace.name=燃油加热炉
-Gas_Turbine.name=发动机(燃气,4mB/s)
-Generator.name=发电机(动能,3.2kV,4.0kW)
-Shaft_Motor.name=发动机(电力,3.2kV,1.2kW)
-Gold_Clutch_Plate.name=金离合器片
+Generator.name=Generator
 Gold_Dust.name=金粉
 Gold_Plate.name=金板
-Graphite_Rod.name=碳棒
 Gray_Brush.name=刷子(灰)
 Green_Brush.name=刷子(绿)
 Ground_Cable.name=导线(接地)
-High_Current_Cable.name=导线(100A,12.0MW)
-High_Power_Receiver_Antenna.name=天线(接收,800V,2kW)
-High_Power_Transmitter_Antenna.name=天线(发射,800V,2kW,300m)
+High_Power_Receiver_Antenna.name=天线(接收)(800V,2kW)
+High_Power_Transmitter_Antenna.name=天线(发射)(800V,2kW,300m)
 High_Voltage_Cable.name=导线(800V,5kW)
 High_Voltage_Relay.name=继电器(800V)
 High_Voltage_Switch.name=开关(800V)
 Hub.name=集线器
 Industrial_Data_Logger.name=示波器(工业,信号)
-Inert_Canister.name=惰性炭罐
 Iron_Cable.name=导线(铁)
-Iron_Clutch_Plate.name=铁离合器片
 Iron_Dust.name=铁粉
 Iron_Plate.name=铁板
-Irresponsible_Electrical_Drill.name=钻头(200kW,0.1")
-JK_Flip_Flop_Chip.name=数字集成电路(JK触发器)
-Joint.name=转轴
-Joint_hub.name=万向节轮毂
-LED_vuMeter.name=信号计(LED)
+JK_Flip_Flop_Chip.name=JK Flip Flop Chip
+LED_vuMeter.name=LED指示灯
 Lamp_Socket_A.name=灯座(圆盘式)
 Lamp_Socket_B_Projector.name=灯座(圆盘式,高级)
 Lamp_Supply.name=无线照明控制盒
-Lapis_Dust.name=青金石粉
-Large_Rheostat.name=变阻器(大型)
-Lead_Clutch_Plate.name=铅离合器片
+Large_Rheostat.name=Large Rheostat
 Lead_Dust.name=铅粉
-Lead_Fuse_for_high_voltage_cables.name=铅保险丝(高压)
-Lead_Fuse_for_low_voltage_cables.name=铅保险丝(低压)
-Lead_Fuse_for_medium_voltage_cables.name=铅保险丝(中压)
-Lead_Fuse_for_very_high_voltage_cables.name=铅保险丝(超高压)
 Lead_Ingot.name=铅锭
 Lead_Ore.name=铅矿石
 Lead_Plate.name=铅板
-Life_Oriented_Battery.name=电池(寿命更长,50V,250W,120KJ)
+Life_Oriented_Battery.name=电源(生命更长,50V,250W,60KJ)
 Light_Blue_Brush.name=刷子(浅蓝)
 Lime_Brush.name=刷子(黄绿)
 Long_Suspended_Lamp_Socket.name=灯座(吊挂,长)
-Long_Suspended_Lamp_Socket_(No_Swing).name=灯座(吊挂,长,无摆动)
-Low_Current_Cable.name=导线(5A,600kW)
-Low_Power_Receiver_Antenna.name=天线(接收,50V,250W)
-Low_Power_Transmitter_Antenna.name=天线(发射,50V,250W,200m)
+Low_Power_Receiver_Antenna.name=天线(接收)(50V,250W)
+Low_Power_Transmitter_Antenna.name=天线(发射)(50V,250W,200m)
 Low_Voltage_Cable.name=导线(50V,1kW)
 Low_Voltage_Relay.name=继电器(50V)
 Low_Voltage_Switch.name=开关(50V)
-Lowpass_filter.name=模拟集成电路(低通滤波器)
 Machine_Block.name=机器方块
-Machine_Booster.name=增压升级
+Machine_Booster.name=增压器
 Magenta_Brush.name=刷子(品红)
-Medium_Current_Cable.name=导线(20A,2.40MW)
-Medium_Fuel_Burner.name=中型燃料燃烧器
-Medium_Power_Receiver_Antenna.name=天线(接收,200V,1kW)
-Medium_Power_Transmitter_Antenna.name=天线(发射,200V,1kW,250m)
+Medium_Power_Receiver_Antenna.name=天线(接收)(200V,1kW)
+Medium_Power_Transmitter_Antenna.name=天线(发射)(200V,1kW,250m)
 Medium_Voltage_Cable.name=导线(200V,2kW)
 Medium_Voltage_Relay.name=继电器(200V)
 Medium_Voltage_Switch.name=开关(200V)
@@ -216,30 +159,27 @@ Modbus_RTU.name=Modbus RTU通讯协议
 Modern_Data_Logger.name=示波器(薄屏,信号)
 Monster_Filter.name=怪物筛选组件
 MultiMeter.name=万用表
-NAND_Chip.name=数字集成电路(与非)
-NOR_Chip.name=数字集成电路(或非)
-NOT_Chip.name=数字集成电路(非)
-Nixie_Tube.name=辉光管
-Nuclear_Alarm.name=警报器(声音:核打击)
-OR_Chip.name=数字集成电路(或)
-On/OFF_Regulator_10_Percent.name=温控组件(敏感度:10%)
-On/OFF_Regulator_1_Percent.name=温控组件(敏感度:1%)
-OpAmp.name=模拟集成电路(运算放大器)
-Optimal_Ferromagnetic_Core.name=优质铁磁芯(1.0)
+NAND_Chip.name=NAND Chip
+NOR_Chip.name=NOR Chip
+NOT_Chip.name=NOT Chip
+Nuclear_Alarm.name=警报(核)
+OR_Chip.name=OR Chip
+On_OFF_Regulator_10_Percent.name=开/关温控10%
+On_OFF_Regulator_1_Percent.name=开/关温控1%
+Optimal_Ferromagnetic_Core.name=磁能核心(1.0)
 Orange_Brush.name=刷子(橙)
 Ore_Scanner.name=矿物扫描仪
-Oscillator_Chip.name=数字集成电路(振荡器)
+Oscillator_Chip.name=Oscillator Chip
 Overheating_Protection.name=保护装置(过热)
 Overvoltage_Protection.name=保护装置(过压)
-PAL_Chip.name=数字集成电路(PAL)
-PID_Regulator.name=模拟集成电路(PID调节器)
+PAL_Chip.name=PAL Chip
 Pink_Brush.name=刷子(粉)
 Player_Filter.name=玩家筛选组件
-Portable_Battery.name=便携电池
-Portable_Battery_Pack.name=便携电池包
-Portable_Condensator.name=移便携电容
-Portable_Condensator_Pack.name=便携电容包
-Portable_Electrical_Axe.name=电锯
+Portable_Battery.name=移动电池
+Portable_Battery_Pack.name=移动电池包
+Portable_Condensator.name=移动电容
+Portable_Condensator_Pack.name=移动电容包
+Portable_Electrical_Axe.name=电斧
 Portable_Electrical_Mining_Drill.name=电钻
 Power_Capacitor.name=电容
 Power_Inductor.name=电感
@@ -248,17 +188,14 @@ Power_capacitor.name=电容
 Power_inductor.name=电感
 Purple_Brush.name=刷子(紫)
 Red_Brush.name=刷子(红)
-Redstone-to-Voltage_Converter.name=红石-电压转换器
+Redstone-to-Voltage_Converter.name=转换器(红石→电)
 Rheostat.name=变阻器
 Robust_Lamp_Socket.name=灯座(小)
 Rubber.name=橡胶
-Sample_and_hold.name=模拟集成电路(采样保持)
-Scanner.name=扫描仪
-Schmitt_Trigger_Chip.name=数字集成电路(施密特触发器)
+Schmitt_Trigger_Chip.name=Schmitt Trigger Chip
 Sconce_Lamp_Socket.name=灯座(壁挂)
 Signal_20H_inductor.name=电感(20H)(信号)
-Signal_Antenna.name=信号天线
-Signal_Bus_Cable.name=信号总线电缆
+Signal_Antenna.name=天线(信号)
 Signal_Button.name=按钮(信号)
 Signal_Cable.name=导线(信号)
 Signal_Diode.name=二极管(信号)
@@ -266,317 +203,199 @@ Signal_Processor.name=信号处理器
 Signal_Relay.name=继电器(信号)
 Signal_Source.name=信号源
 Signal_Switch.name=开关(信号)
-Signal_Switch_with_LED.name=开关(信号,LED)
+Signal_Switch_with_LED.name=开关(信号)(LED)
 Signal_Trimmer.name=信号发生器
 Silicon_Dust.name=硅粉
 Silicon_Ingot.name=硅锭
 Silicon_Plate.name=硅板
-Silver_Brush.name=刷子(淡灰)
+Silver_Brush.name=刷子(银)
 Simple_Lamp_Socket.name=灯座(普通)
-Single-use_Battery.name=电池(一次性,50V,500W,60KJ)
-Small_200V_Copper_Heating_Corp.name=加热器(铜,200V,400W)
-Small_200V_Iron_Heating_Corp.name=加热器(铁,200V,600W)
-Small_200V_Tungsten_Heating_Corp.name=加热器(钨,200V,800W)
-Small_3.2kV_Tungsten_Heating_Corp.name=加热器(钨,3.2kV,4.0kW)
-Small_50V_Carbon_Incandescent_Light_Bulb.name=碳丝灯泡(50V,15W)
-Small_50V_Copper_Heating_Corp.name=加热器(铜,50V,150W)
-Small_50V_Economic_Light_Bulb.name=节能灯泡(50V,10W)
-Small_50V_Incandescent_Light_Bulb.name=白炽灯泡(50V,20W)
-Small_50V_Iron_Heating_Corp.name=加热器(铁,50V,180W)
-Small_50V_Tungsten_Heating_Corp.name=加热器(钨,50V,240W)
-Small_800V_Tungsten_Heating_Corp.name=加热器(钨,800V,3.60kW)
-Small_Active_Thermal_Dissipator.name=散热器(主动,冷却功率:200W+800W,最高温度:130°C,风扇参数:50V,50W)
+Single-use_Battery.name=电源(一次性,50V,500W,120kJ)
+Small_200V_Copper_Heating_Corp.name=加热核心(铜,200V,小)
+Small_200V_Iron_Heating_Corp.name=加热核心(铁,200V,小)
+Small_200V_Tungsten_Heating_Corp.name=加热核心(钨,200V,小)
+Small_50V_Carbon_Incandescent_Light_Bulb.name=小型碳丝灯泡(50V)
+Small_50V_Copper_Heating_Corp.name=加热核心(铜,50V,小)
+Small_50V_Economic_Light_Bulb.name=小型节能灯泡(50V)
+Small_50V_Incandescent_Light_Bulb.name=小型白炽灯泡(50V)
+Small_50V_Iron_Heating_Corp.name=加热核心(铁,50V,小)
+Small_50V_Tungsten_Heating_Corp.name=加热核心(钨,50V,小)
+Small_Active_Thermal_Dissipator.name=散热器(T\:200W+800W,150°C;E\:50V,50W)
 Small_Flashlight.name=手电筒
-Small_Fuel_Burner.name=小型燃料燃烧器
-Small_Passive_Thermal_Dissipator.name=散热器(被动,冷却功率:250W,最高温度:200°C)
-Small_Rotating_Solar_Panel.name=太阳能板(追踪,14.8V,65W)
-Small_Solar_Panel.name=太阳能板(14.8V,65W)
+Small_Passive_Thermal_Dissipator.name=散热器(250W,220°C)
+Small_Rotating_Solar_Panel.name=太阳能电池板(追踪,14.8V,65W)
+Small_Solar_Panel.name=太阳能电板(14.8V,65W)
 Solar_Tracker.name=太阳追踪组件
-Standard_Alarm.name=警报器(声音:标准)
-Steam_Turbine.name=发动机(蒸汽,7200mB/s)
-Stone_Heat_Furnace.name=石制加热炉(780°C,4.00kW)
+Standard_Alarm.name=警报(基础)
+Steam_Turbine.name=Steam Turbine
+Stone_Heat_Furnace.name=燃烧器(800°C,1kW)
 Street_Light.name=灯座(路灯)
 Suspended_Lamp_Socket.name=灯座(吊挂)
-Suspended_Lamp_Socket_(No_Swing).name=灯座(吊挂,无摆动)
-Synthetic_Diamond.name=人造金刚石
-Tachometer.name=转速计
-Temperature_Probe.name=探测器(温度)
-Thermal_Probe.name=探测器(热量)
-Thermal_Probe_Chip.name=芯片(热能探测器)
+Temperature_Probe.name=温度传感器
+Thermal_Probe.name=热能传感器
+Thermal_Probe_Chip.name=芯片(热能传感器)
 Thermistor.name=热敏电阻
-Thermometer.name=温度计
+ThermoMeter.name=温度计
+Transformer.name=变压器
 Tree_Resin.name=树脂
 Tree_Resin_Collector.name=树脂收集器
 Tungsten_Cable.name=导线(钨)
 Tungsten_Dust.name=钨粉
 Tungsten_Ingot.name=钨锭
 Tungsten_Ore.name=钨矿石
-Turbo_Electrical_Drill.name=钻头(10kW,1")
 Tutorial_Sign.name=指示标志
-unreleasedium.name=铀(未释放)
-Very_High_Voltage_Cable.name=导线(3200V,15kW)
+Very_High_Voltage_Cable.name=导线(3200V)
 Very_High_Voltage_Relay.name=继电器(3200V)
 Very_High_Voltage_Switch.name=开关(3200V)
-Voltage-to-Redstone_Converter.name=电压-红石转换器
-Voltage_Oriented_Battery.name=电池(电压更大,200V,250W,120KJ)
-Voltage_Probe.name=探测器(电压)
-Voltage_controlled_amplifier.name=模拟集成电路(压控放大器)
-Voltage_controlled_sawtooth_oscillator.name=模拟集成电路(压控振荡器,锯齿)
-Voltage_controlled_sine_oscillator.name=模拟集成电路(压控振荡器,正弦)
+Voltage-to-Redstone_Converter.name=转换器(电→红石)
+Voltage_Oriented_Battery.name=电源(电压更大,200V,250W)
+Voltage_Probe.name=电压传感器
 Water_Turbine.name=发电机(水力,50V,30W)
 Weak_50V_Battery_Charger.name=电池充电器(50V,200W)
 White_Brush.name=刷子(白)
 Wind_Turbine.name=发电机(风力,59V,160W)
 Wireless_Analyser.name=监测仪(无线)
 Wireless_Button.name=按钮(无线)
-Wireless_Signal_Receiver.name=无线信号接收器
-Wireless_Signal_Repeater.name=无线信号中继器
-Wireless_Signal_Transmitter.name=无线信号发射器
+Wireless_Signal_Receiver.name=信号接收器(无线)
+Wireless_Signal_Repeater.name=信号加强器(无线)
+Wireless_Signal_Transmitter.name=信号发射器(无线)
 Wireless_Switch.name=开关(无线)
 Wrench.name=扳手
 X-Ray_Scanner.name=扫描仪
-XNOR_Chip.name=数字集成电路(同或)
-XOR_Chip.name=数字集成电路(异或)
+XNOR_Chip.name=XNOR Chip
+XOR_Chip.name=XOR Chip
 Yellow_Brush.name=刷子(黄)
 entity.EAReplicator.name=复制机
-item.Copper Axe.name=铜斧
-item.Copper Boots.name=铜靴
-item.Copper Chestplate.name=铜胸甲
-item.Copper Helmet.name=铜头盔
-item.Copper Hoe.name=铜锄
-item.Copper Leggings.name=铜护腿
-item.Copper Pickaxe.name=铜镐
-item.Copper Shovel.name=铜铲
-item.Copper Sword.name=铜剑
-item.E-Coal Boots.name=电力碳纤维靴子
-item.E-Coal Chestplate.name=电力碳纤维胸甲
-item.E-Coal Helmet.name=电力碳纤维头盔
-item.E-Coal Leggings.name=电力碳纤维护腿
+item.Copper Axe.name\=铜镐
+item.Copper Axe.name\=铜镐
+item.Copper Axe.name\=铜镐
+item.Copper Axe.name\=铜镐
+item.Copper Axe.name\=铜镐
+item.Copper Axe.name\=铜镐
+item.Copper Axe.name\=铜镐
+item.Copper Axe.name\=铜镐
+item.Copper Axe.name\=铜镐
+item.E-Coal Boots.name\=EC鞋
+item.E-Coal Boots.name\=EC鞋
+item.E-Coal Boots.name\=EC鞋
+item.E-Coal Boots.name\=EC鞋
 itemGroup.Eln=电力时代
-mod.meta.desc=你的基地,因使用电力产生红热的光芒\!!
-tile.arc_clay_block.name=铝块
-tile.arc_metal_block.name=钢块
+mod.meta.desc=你的基地,因使用电力产生红热的光芒\!
 tile.eln.ElnProbe.name=电力时代电脑传感器
-tile.eln.EnergyConverter.name=能量转换器
-tile.hot_water.name=热水
-fluid.hot_water=热水
-item.hot_water_bucket.name=热水桶
-tile.cold_water.name=冷水
-fluid.cold_water=冷水
-item.cold_water_bucket.name=冷水桶
+tile.eln.EnergyConverterElnToOtherHVUBlock.name=电力时代能源(800V)转至其他能源
+tile.eln.EnergyConverterElnToOtherLVUBlock.name=电力时代能源(50V)转至其他能源
+tile.eln.EnergyConverterElnToOtherMVUBlock.name=电力时代能源(200V)转至其他能源
 
 # ./src/main/java/mods/eln/i18n/I18N.java
 You_have_%1$_lives_left=你还剩%1$条生命
 
-# ./src/main/java/mods/eln/item/BrushDescriptor.kt
+# ./src/main/java/mods/eln/item/BrushDescriptor.java
 Brush_is_dry=刷子干了
 Can_paint_%1$_blocks=可以继续漆%1$个方块
 
-# ./src/main/java/mods/eln/item/CaseItemDescriptor.kt
-Can_be_used_to_encase_EA_items_that_support_it=可以用来封装变压器
-
 # ./src/main/java/mods/eln/item/CombustionChamber.java
-Upgrade_for_the_Stone_Heat_Furnace.=升级石头加热炉。
+Upgrade_for_the_Stone_Heat_Furnace.=你的发电机升级啦~
 
 # ./src/main/java/mods/eln/item/ElectricalDrillDescriptor.java
-Energy_per_operation\:_%1$J=每次操作需要能量: %1$J
-Time_per_operation\:_%1$h=每次操作需要时间: %1$s
+Energy_per_operation\:_%1$J=启动需要能量\:%1$J
+Time_per_operation\:_%1$s=启动所需时间\:%1$s
 
 # ./src/main/java/mods/eln/item/FerromagneticCoreDescriptor.java
-Cable_loss_factor\:_%1$=导线损耗系数: %1$
-
-# ./src/main/java/mods/eln/item/FuelBurnerDescriptor.kt
-Burn_unit_for_the_gas_heat_furnace.=燃油加热炉的燃烧装置。
-Produced_heat_power\:_=产热功率:
+Cable_loss_factor\:_%1$=导线损耗系数\:%1$
 
 # ./src/main/java/mods/eln/item/HeatingCorpElement.java
 
 # ./src/main/java/mods/eln/item/LampDescriptor.java
 Bad=差
-Condition\:=状态:
-End_of_life=即将损坏
+Condition\:=条件\:
+End_of_life=生命就此终结
 Good=好
 New=新
-Nominal_lifetime\:_%1$h=额定寿命: %1$h
-Technology\:_%1$=技术: %1$
+Nominal_lifetime\:_%1$h=理论寿命\:%1$h
+Technology\:_%1$=科技\:%1$
 Used=旧
 
 # ./src/main/java/mods/eln/item/LampSlot.java
-Lamp_slot=槽(灯泡)
+Lamp_slot=槽(灯)
 
 # ./src/main/java/mods/eln/item/OverHeatingProtectionDescriptor.java
-Useful_to_prevent_overheating\nof_Batteries=有效防止电池过热
+Useful_to_prevent_overheating\nof_Batteries=有效防止电源过热
 
 # ./src/main/java/mods/eln/item/OverVoltageProtectionDescriptor.java
-Useful_to_prevent_over-voltage\nof_Batteries=有效防止电池过压
+Useful_to_prevent_over-voltage\nof_Batteries=有效防止电源过压
 
 # ./src/main/java/mods/eln/item/SolarTrackerDescriptor.java
-Solar_panel_upgrade=太阳能板升级
+Solar_panel_upgrade=太阳能电板升级
 
-# ./src/main/java/mods/eln/item/electricalitem/ElectricalArmor.java
+# ./src/main/java/mods/eln/item/electricalitem/BatteryItem.java
 
 # ./src/main/java/mods/eln/item/electricalitem/ElectricalLampItem.java
-State\:=状态:
-Stored_Energy\:_%1$J_(%2$%)=储存的能量: %1$J (%2$%)
+Off=关
+On=开
+State\:=状态\:
+Stored_Energy\:_%1$J_(%2$%)=储存的能量\:%1$J(%2$%)
 
 # ./src/main/java/mods/eln/item/regulator/RegulatorSlot.java
 
-# ./src/main/java/mods/eln/mechanical/Clutch.kt
-Prevents_clutches_from_slipping\nagain_after_they_stop.=防止离合器停止后打滑。
-
-# ./src/main/java/mods/eln/mechanical/CrankableShaft.kt
-Player_crankable_shaft=手动曲轴
-Can_rotate_slowly=右键慢速转动
-
-# ./src/main/java/mods/eln/mechanical/Generator.kt
-Converts_mechanical_energy_into_electricity,_or_(badly)_vice_versa.=将机械能转换为电能，或反之(低效)。
-Voltage_out\:_%1$=输出电压:
-Power_out\:_%1$=输出功率: %1$
-Rads\:_%1$=最佳转速: %1$
-
-# ./src/main/java/mods/eln/mechanical/Motor.kt
-Converts_electricity_into_mechanical_energy,_or_(badly)_vice_versa.=将电能转换为机械能，或反之(低效)。
-Voltage_in\:_%1$=输入电压: %1$
-Power_in\:_%1$=输入功率: %1$
-rad_s\:_%1$=最佳转速: %1$
-Max_rad_s\:_%1$=最大转速: %1$
-
-# ./src/main/java/mods/eln/mechanical/Tachometer.kt
-Rads_s_corresponding\nto_0%_output=对应 0% 输出的Rads/s(转速)
-Rads_s_corresponding\nto_100%_output=对应 100% 输出的Rads/s(转速)
-
-# ./src/main/java/mods/eln/mechanical/Turbines.kt
-Converts_%1$_into_mechanical_energy.=消耗%1$产生机械能
-Nominal_usage_->=额定参数:
-%1$_input\:_%2$_mB_s=%1$输入: %2$ mB/s
-No_valid_fluids_for_this_turbine!=没有有效的流体用于这个发动机!
-Power_out\:_%1$=输出功率: %1$
-Power_out\:_%1$-_%2$=输出功率: %1$- %2$
-Optimal_rads\:_%1$=最佳转速: %1$
-Max_rads\:__%1$=最大转速:  %1$
-
 # ./src/main/java/mods/eln/misc/UtilsClient.java
-Hold_[shift]_for_details=按住 [shift] 查看细节
-Hold_[ctrl]_for_realism_details=按住 [ctrl] 查看拟真细节
+Hold_shift=请戳Shift
 
 # ./src/main/java/mods/eln/misc/Version.java
 mod.name=电力时代
 
-# ./src/main/java/mods/eln/node/transparent/TransparentNodeDescriptor.java
+# ./src/main/java/mods/eln/node/six/SixNodeDescriptor.java
 
 # ./src/main/java/mods/eln/simplenode/energyconverter/EnergyConverterElnToOtherGui.java
-Input_power_is_limited_to_%1$W=输入功率限制 %1$W
-
-# ./src/main/java/mods/eln/sixnode/AnalogChips.kt
-A_voltage-controlled_amplifier_(VCA)\nis_an_electronic_amplifier_that_varies\nits_gain_depending_on_the_control_voltage.=压控放大器(Voltage Controlled Amplifier，VCA)\n是一种根据控制电压来调节增益的信号放大器。
-A_voltage-controlled_oscillator_or_VCO_is\nan_electronic_oscillator_whose_oscillation\nfrequency_is_controlled_by_a_voltage_input.=压控振荡器(Voltage-Controlled Oscillator，VCO)\n是一种振荡电路，其振荡频率由输入电压控制。
-An_amplifier_increases_the_voltage\nof_an_input_signal_by_a_configurable\ngain_and_outputs_that_voltage.=放大器通过可配置的增益增加输入信号的电压并输出该电压。
-Cut-off_frequency_%1$_Hz=截止频率%1$ Hz
-Gain=增益
-Gains=增益
-Gain_for_input_\u00a713=输入增益 \u00a713
-Gain_for_input_\u00a722=输入增益 \u00a722
-Gain_for_input_\u00a741=输入增益 \u00a741
-Lowpass_filter_-_Passes_signals_with_a\nfrequency_lower_than_a_certain_cutoff_frequency\nand_attenuates_signals_with_frequencies_higher\nthan_the_cutoff_frequency.=低通滤波器 \n- 传递低于特定截止频率的信号，\n并衰减高于截止频率的信号。
-Operational_Amplifier_-_DC_coupled\nhigh-gain_voltage_amplifier_with\ndifferential_input._Can_be_used_to\ncompare_voltages_or_as_configurable_amplifier.=运算放大器 \n- 直流耦合高增益电压放大器，具有差分输入。\n可以用于比较电压或作为可配置的放大器。
-Params=参数
-Proportional–integral–derivative_controller._A_PID\ncontroller_continuously_calculates_an_error_value_as\nthe_difference_between_a_desired_setpoint_and_a_measured\nprocess_variable_and_applies_a_correction_based_on\nproportional,_integral,_and_derivative_terms.=比例积分微分控制器(Proportional-Integral-Derivative Controller，PID控制器)。\nPID控制器持续计算误差值，\n即期望设定值与测量的过程变量之间的差异，\n并基于比例、积分和微分项进行校正。
-Samples_the_voltage_of_a_varying_analog_signal_when\nthe_clock_input_changes_from_0_to_1_and_holds_its\noutput_voltage_at_a_constant_level_until_next_clock_pulse.\nYou_can_see_it_as_an_analog_D-Flipflop.=当时钟输入从0变为1时，\n对变化的模拟信号进行采样，\n并将其输出电压保持在恒定水平，直到下一个时钟脉冲。\n可以将其视为模拟D触发器。
-The_summing_unit_outputs_the_sum_of\nthe_three_weighted_inputs.The\ngain_for_each_input_can_be_configured.=求和单元输出三个加权输入的和。\n可以配置每个输入的增益。
-
-# ./src/main/java/mods/eln/sixnode/ElectricalFuse.kt
-Protects_electrical_components.\nFuse_melts_if_current_exceeds_the\nfuse_limit=保护电气元件。如果电流超过保险丝的限制，保险丝会熔断。
-
-# ./src/main/java/mods/eln/sixnode/EmergencyLamp.kt
+Input_power_is_limited_to_%1$W=输入功率限制\:%1$W
 
 # ./src/main/java/mods/eln/sixnode/LogicGate.kt
-A_Programmable_Array_Logic_(PAL)_is_a_programmable\nlogic_device_semiconductors_used_to__implement_any_logic\nfunction_in_only_one_digital_circuit._The_function_is\nstateless,_which_means_that_no_intermediate_state_is_saved.=可编程阵列逻辑(PAL)是一种可编程的逻辑器件半导体，\n用于在一个数字电路中实现任何逻辑功能。\n该功能是无状态的，意味着没有保存中间状态。
-If_the_input_J_is_1_(high)_and_K_is_0_(low)\nduring_a_clock_pulse,_the_output_becomes_1_(high).\nIf_J_is_0_(low)_and_K_is_1_(high)_during_the_pulse,\nthe_output_becomes_0_(low)._If_both_inputs_are_0_(low)\nduring_the_clock_pulse,_the_state_is_maintained._If_both\ninputs_are_1_(high)_the_input_is_toggled_if_a_rising_edge\nwas_detected_at_the_clock_input.=如果在时钟脉冲期间输入J为1(高电平)，K为0(低电平)，\n输出变为1(高电平)。\n如果在脉冲期间J为0(低电平)，K为1(高电平)，\n输出变为0(低电平)。\n如果在时钟脉冲期间两个输入都为0(低电平)，\n状态保持不变。\n如果两个输入都为1(高电平)，\n当在时钟输入检测到上升沿时，输入会切换。
-If_the_input_voltage_is_lower_than_10V,_the\noutput_is_0_(low),_if_the_output_is_bigger_or\nequal_to_30V,_the_output_will_be_1_(high)._For\nall_voltages_in_between,_the_output_does_not_change.=如果输入电压低于10V，则输出为0(低电平)；\n如果输出大于或等于30V，则输出为1(高电平)；\n对于介于两者之间的所有电压，输出不变。
-Implements_an_exclusive_or.\nAn_output_of_1_(high)_results_if_one_or\nall_three_inputs_to_the_gate_are_1_(high).=实现逻辑:异或。\n如果集成电路的三个输入中奇数个输入为1(高电平)，\n则输出为1(高电平)。
-Implements_logical_conjunction.\nA_1_(high)_output_results_only_if_all_of\nthe_three_inputs_to_the_AND_gate_are_1_(high).=实现逻辑:与。\n只有当集成电路的三个输入全部为1(高电平)时，\n才会输出1(高电平)。
-Implements_logical_disjunction.\nA_1_(high)_output_results_if_at_least\none_input_to_the_gate_is_1_(high).=实现逻辑:或。\n如果集成电路的至少一个输入为1(高电平)，\n则输出为1(高电平)。
-Inverts_the_input_signal.\nOutputs_a_voltage_representing_the\nopposite_logic-level_to_its_input.=实现逻辑:非。\n输出与输入相反逻辑电平。
-Its_output_is_complement_(inverted)\nto_that_of_the_AND_gate.=实现逻辑:与非。\n输出与与门相反逻辑电平。
-Its_output_is_complement_(inverted)\nto_that_of_the_OR_gate.=实现逻辑:或非。\n输出与或门相反逻辑电平。
-Its_output_is_complement_(inverted)\nto_that_of_the_XOR_gate.=实现逻辑:同或。\n输出与异或门相反逻辑电平。
-Outputs_a_rectangular_signal_which's_frequency\ndepends_to_the_input_voltage._The_higher_the\ninput_voltage_-_the_higher_the_frequency.=输出方波信号，\n其频率取决于输入电压，\n输入电压越高频率越高。
-The_D_flip-flop_captures_the_value\nof_the_D-input_at_a_rising_edge\nportion_of_the_clock_cycle.=边缘D触发器在时钟周期的上升沿将输出更改为输入值。
-UNDEF=未定义
-
-# ./src/main/java/mods/eln/sixnode/Scanner.kt
--_For_inventories,_outputs_either_total_fill_or_fraction_of_slots_with_any_items.=- 对于物品容器，输出可以是总填充量百分比，或者是有物品的格子比例。
--_For_tanks,_outputs_fill_percentage.=- 对于液体容器，输出填充百分比。
-Otherwise_behaves_as_a_vanilla_comparator.=或者作为普通比较器。
-Right-click_to_change_mode.=右键改变模式。
-Scans_blocks_to_produce_signals.=扫描方块以产生信号。
+_O\:_= O\:
 
 # ./src/main/java/mods/eln/sixnode/TreeResinCollector/TreeResinCollectorDescriptor.java
-Produces_Tree_Resin_over\ntime_when_put_on_a_tree.=放在树上即可生产树脂。
-This_block_can_only_be_placed_on_the_side_of_a_tree!=只能在树的侧面放置！
+Produces_Tree_Resin_over\ntime_when_put_on_a_tree.=放在树上即可生产树脂
+This_block_can_only_be_placed_on_the_side_of_a_tree!=这只能在一棵树的侧面防止啊
 
 # ./src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerContainer.java
 Battery_slot=槽(电池)
 
 # ./src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerDescriptor.java
-Can_be_used_to_recharge\nelectrical_items_like\:\nFlash_Light,_X-Ray_scanner\nand_Portable_Battery_...=可以用来给电力时代的东西充电\n例如便携电池，手电筒，扫描仪 ...
-This_battery_charger_doesn't_take_into_account_battery_chemistry=这个电池充电器不考虑电池的化学成分
+Can_be_used_to_recharge\nelectrical_items_like\:\nFlash_Light,_X-Ray_scanner\nand_Portable_Battery_...=可以用来给电力时代的东西充电\n例如移动电池,手电筒,扫描仪
 
-# ./src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerElement.java
-Charge_Current=充电电流
+# ./src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerGui.java
 
 # ./src/main/java/mods/eln/sixnode/diode/DiodeDescriptor.java
-Electrical_current_can_only\nflow_through_the_diode\nfrom_anode_to_cathode=电流只能从二极管的阳极流向阴极。
-Works,_with_the_caveat_that_it's_delayed_a_sim_tick=有效，但需要注意的是，它会延迟一个模拟时钟周期。
-
-# ./src/main/java/mods/eln/sixnode/diode/DiodeElement.java
-Forward_Voltage=正向电压
+Electrical_current_can_only\nflow_through_the_diode\nfrom_anode_to_cathode=电流只能从二极管的一端流到另一端
 
 # ./src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmDescriptor.java
-Emits_an_acoustic_alarm_if\nthe_input_signal_is_high=当输入高电平信号时\n发出巨大的警报声
-
-# ./src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmElement.java
-Engaged=激活中
-Input_Voltage=输入电压
+=
+Emits_an_acoustic_alarm_if\nthe_input_signal_is_high=当输入信号高的时候\n发出巨大的警报声
 
 # ./src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmGui.java
-Sound_is_muted=声音:关
-Sound_is_not_muted=声音:开
+Sound_is_muted=声音已静音
+Sound_is_not_muted=声音已开启
 
 # ./src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerContainer.java
 
 # ./src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerDescriptor.java
-Protects_electrical_components\nOpens_contact_if\:\n__-_Voltage_exceeds_a_certain_level\n__-_Current_exceeds_the_cable_limit=保护电气元件，当满足以下条件之一时断开:\n - 电压超过一定水平 \n- 电流超过电缆的限制。
-
-# ./src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerElement.java
-Contact=触点
+Protects_electrical_components\nOpens_contact_if\:\n__-_Voltage_exceeds_a_certain_level\n-_Current_exceeds_the_cable_limit=保护电路\n如果电压过大或电流过载都会打开
 
 # ./src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerGui.java
-Maximum_voltage_before_cutting_off=Maximum voltage before cutting off
-Minimum_voltage_before_cutting_off=Minimum voltage before cutting off
-Switch_is_off=开关已断开
-Switch_is_on=开关已合上
+Maximum_voltage_before_cutting_off=切断前最大电压
+Minimum_voltage_before_cutting_off=切断前最小电压
+Switch_is_off=开关关闭
+Switch_is_on=开关打开
 
 # ./src/main/java/mods/eln/sixnode/electricalcable/ElectricalCableDescriptor.java
-A_signal_is_electrical_information\nwhich_must_be_between_0V_and_%1$=信号用于传输电子信号\n必须在 0V 到 %1$之间
+A_signal_is_electrical_information\nwhich_must_be_between_0V_and_%1$V=信号用来传递电气信息\n必须要在0V和%1$V之间
 Cable_is_adapted_to_conduct\nelectrical_signals.=该电缆适用于传输电子信号
-Current\:_%1$A=电流: %1$A
-Nominal_Ratings\:=额定参数:
-Not_adapted_to_transport_power.=没有适配到传送功率.
-Serial_resistance\:_%1$Ω=串联电阻: %1$Ω
-__*_Wire_resistance_is_much_higher_than_normal=  * 导线电阻远高于正常值
-__*_Wire_resistance_is_not_impacted_by_temperature=  * 导线电阻不受温度影响
-__*_Wire_voltage_current_limits_are_arbitrary_values,_added_as_a_gameplay_mechanic=  * 导线无电压/电流限制，作为游戏机制添加
-__*_Wire_voltage_limits_are_arbitrary_values,_picked_to_within_reasonable_simulator_error=  * 导线无电压限制，选择合理的模拟器误差
-__*_Wire_current_limits_are_arbitrary_values,_added_as_a_gameplay_mechanic=  * 导线无电流限制，作为游戏机制添加
-
-# ./src/main/java/mods/eln/sixnode/electricalcable/ElectricalCableElement.java
+Current\:_%1$A=电流\:%1$A
+Not_adapted_to_transport_power.=没有适配到传送功率
+Save_usage\:=保存用法\:
+Serial_resistance\:_%1$Ω=串联电阻\:%1$Ω
 
 # ./src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerDescriptor.java
-It_can_store_up_to_256_points.=最多可以储存256个点.
-Measures_the_voltage_of_an\nelectrical_signal_and_plots\nthe_data_in_real_time.=测量电信号的电压并实时绘制数据。
-
-# ./src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerElement.java
+It_can_store_up_to_256_points.=它最多可以储存256个单位
+Measures_the_voltage_of_an\nelectrical_signal_and_plots\nthe_data_in_real_time.=测量电子信号的实时电压
 
 # ./src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerGui.java
 Back_to_display=回到显示
@@ -592,46 +411,32 @@ Voltage_[V]=电压(V)
 Y-axis_max=Y轴最大值
 Y-axis_min=Y轴最小值
 
-# ./src/main/java/mods/eln/sixnode/electricaldigitaldisplay/ElectricalDigitalDisplayDescriptor.java
-Displays_signal_value.=显示信号值。
+# ./src/main/java/mods/eln/sixnode/electricalentitysensor/ElectricalEntitySensorContainer.java
 
 # ./src/main/java/mods/eln/sixnode/electricalentitysensor/ElectricalEntitySensorDescriptor.java
 Output_voltage_increases\nif_entities_are_moving_around.=如果有生物在周围移动那么增大输出电压
 
-# ./src/main/java/mods/eln/sixnode/electricalentitysensor/ElectricalEntitySensorElement.java
-Entity_present=存在实体
-
 # ./src/main/java/mods/eln/sixnode/electricalfiredetector/ElectricalFireDetectorDescriptor.java
-Battery_powered_buzzer_\nactivated_in_presence_of_fire.=电池供电的蜂鸣器在发生火灾时启动
 Output_voltage_increases\nif_a_fire_has_been_detected.=如果周围有火那么增大输出电压
-
-# ./src/main/java/mods/eln/sixnode/electricalfiredetector/ElectricalFireDetectorElement.java
-Fire_detected\:_=火灾探测:
-Fire_present=发生火灾
 
 # ./src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceDescriptor.java
 Provides_configurable_signal\nvoltage.=提供可调整的信号电压
 
 # ./src/main/java/mods/eln/sixnode/electricalgatesource/ElectricalGateSourceGui.java
-Output_at_%1$%=输出: %1$%
+Output_at_%1$%=输出\:%1$%
 
 # ./src/main/java/mods/eln/sixnode/electricallightsensor/ElectricalLightSensorDescriptor.java
 0V_at_night,_%1$V_at_noon.=夜间0V,午时%1$V
 Provides_an_electrical_voltage\nin_the_presence_of_light.=接受到光的时候提供电压
 Provides_an_electrical_voltage\nwhich_is_proportional_to\nthe_intensity_of_daylight.=接收到日光的时候提供电压\n电压与日光强度成正比
 
-# ./src/main/java/mods/eln/sixnode/electricallightsensor/ElectricalLightSensorElement.java
-Light_level=光照等级
+# ./src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathContainer.java
 
 # ./src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathDescriptor.java
-Applicable_boolean_operators\:=适用于布尔(boolean)算子:
-Applicable_functions\:=适用于:
-Applicable_mathematical_operators\:=适用于数学算子:
+Applicable_boolean_operators\:=适用于布尔(boolean)算子\:
+Applicable_functions\:=适用于\:
+Applicable_mathematical_operators\:=适用于数学算子
 Calculates_an_output_signal_from\n3_inputs_(A,_B,_C)_using_an_equation.=用3个输入(A,B,C)值\n进行函数计算\n然后输出信号
-
-# ./src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathElement.java
-Equation=方程式
-Input_voltages=输入电压
 
 # ./src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathGui.java
 %1$_Redstone(s)_required=需要%1$个红石粉
@@ -644,162 +449,112 @@ Waiting_for_completion...=请稍后...
 # ./src/main/java/mods/eln/sixnode/electricalredstoneinput/ElectricalRedstoneInputDescriptor.java
 Converts_Redstone_signal\nto_an_electrical_voltage.=把红石信号转换为电压
 
-# ./src/main/java/mods/eln/sixnode/electricalredstoneinput/ElectricalRedstoneInputElement.java
-
 # ./src/main/java/mods/eln/sixnode/electricalredstoneoutput/ElectricalRedstoneOutputDescriptor.java
 Converts_electrical_voltage\ninto_a_Redstone_signal.=把电压转换为红石信号
 
-# ./src/main/java/mods/eln/sixnode/electricalredstoneoutput/ElectricalRedstoneOutputElement.java
-
 # ./src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayDescriptor.java
-A_relay_is_an_electrical\ncontact_that_conducts\ncurrent_when_a_signal\nvoltage_is_applied.=继电器是根据信号电压的有无\n控制电路闭合断开的仪器
-The_relay's_input_behaves\nlike_a_Schmitt_Trigger.=继电器的输入行为类似于施密特触发器
-
-# ./src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayElement.java
-Default_position=Default position
+A_relay_is_an_electrical\ncontact_that_conducts_electric\ncurrent_or_not,_depending\nthe_actual_input_signal_voltage.=继电器是根据信号电压的有无\n控制电路闭合断开的仪器
 
 # ./src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayGui.java
-Normally_closed=默认合上
+Normally_closed=默认关闭
 Normally_open=默认打开
-
-# ./src/main/java/mods/eln/sixnode/electricalsensor/ElectricalSensorDescriptor.java
-Can_measure_Voltage_Power_Current=可以测量电压/功率/电流
-Measures_electrical_values_on_cables.=测量导线的电气值
-Measures_voltage_on_cables.=测量导线上的电压
-
-# ./src/main/java/mods/eln/sixnode/electricalsensor/ElectricalSensorElement.java
-Measured_current=实测电流
-Measured_power=实测功率
-Measured_voltage=实测电压
-
-# ./src/main/java/mods/eln/sixnode/electricalsensor/ElectricalSensorGui.java
-Measured_voltage\ncorresponding\nto_0%_output=对应于0%输出的测量电压
-Measured_voltage\ncorresponding\nto_100%_output=对应于100%输出的测量电压
 
 # ./src/main/java/mods/eln/sixnode/electricalsource/ElectricalSourceDescriptor.java
 Creative_block.=创造方块
-Provides_an_ideal_current_source\nwithout_energy_or_power_limitation.=无功率/能量限制的理想电流源
-Provides_an_ideal_voltage_source\nwithout_energy_or_power_limitation.=无功率/能量限制的理想电压源
-Acts_as_an_ideal_voltage_source,_with_a_small_inline_resistance=作为理想电压源，内阻很小
-Acts_as_an_ideal_current_source,_with_a_small_inline_resistance=作为理想电流源，内阻很小
+Provides_an_ideal_voltage_source\nwithout_energy_or_power_limitation.=无限制的永久能源(创造专用)
+
+# ./src/main/java/mods/eln/sixnode/electricalsource/ElectricalSourceGui.java
+Output_voltage=输出电压
 
 # ./src/main/java/mods/eln/sixnode/electricalswitch/ElectricalSwitchDescriptor.java
-Can_break_an_electrical_circuit\ninterrupting_the_current.=能切断导线以中断电流
+Can_break_an_electrical_circuit\ninterrupting_the_current.=能破坏导线以中断电流
 
 # ./src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutDescriptor.java
-Upon_application_of_a_high_signal,\nthe_timer_maintains_the_output_high_for\na_configurable_interval._Can_be_re-triggered.=当提供高电平信号时\n断路延时器在接下来可配置时间间隔内会输出高电平信号。\n可以重复触发
-
-# ./src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutElement.java
-Output=输出
-Remaining=剩余
+Upon_application_of_a_high_signal,\nthe_timer_maintains_the_output_high_for\na_configurable_interval._Can_be_re-triggered.=当应用于高强度信号时\n定时器一定输出间隔后会输出高强度信号。\n可以循环进行
 
 # ./src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutGui.java
-Set=激活
-The_time_interval_the\noutput_is_kept_high.=高电平输出时间
+Set=设置
+The_time_interval_the\noutput_is_kept_high.=保持高输出间隔
 
 # ./src/main/java/mods/eln/sixnode/electricalvumeter/ElectricalVuMeterDescriptor.java
-Displays_a_color_based_on_the_value_of_a_signal=基于信号值显示颜色
 Displays_the_value_of_a_signal.=显示信号的值
 
 # ./src/main/java/mods/eln/sixnode/electricalwatch/ElectricalWatchContainer.java
-
-# ./src/main/java/mods/eln/sixnode/electricalwatch/ElectricalWatchDescriptor.java
-Requires_batteries_for_operation.=需要电池进行工作
-Tells_the_time.=告诉你时间
-
-# ./src/main/java/mods/eln/sixnode/electricalwatch/ElectricalWatchElement.java
+Portable_battery_slot=槽(移动电池)
 
 # ./src/main/java/mods/eln/sixnode/electricalweathersensor/ElectricalWeatherSensorDescriptor.java
-Clear\:_%1$V=晴朗: %1$V
+Clear\:_%1$V=晴朗\:%1$V
 Provides_an_electrical_signal\ndepending_the_actual_weather.=提供信号,强度由天气决定
-Rain\:_%1$V=阴雨: %1$V
-Storm\:_%1$V=雷暴: %1$V
+Rain\:_%1$V=阴雨\:%1$V
+Storm\:_%1$V=雷暴\:%1$V
 
 # ./src/main/java/mods/eln/sixnode/electricalwindsensor/ElectricalWindSensorDescriptor.java
 Maximum_wind_speed_is_%1$m_s=最高风速%1$m/s
 Provides_an_electrical_signal\ndependant_on_wind_speed.=提供信号,强度由风速决定
-You_can't_place_this_block_on_the_floor_or_the_ceiling=你不能将这个方块放置于天花板底部和地板上
+You_can't_place_this_block_on_the_floor_or_the_ceiling=You can't place this block on the floor or the ceiling
 
-# ./src/main/java/mods/eln/sixnode/emergencylamp/EmergencyLampDescriptor.java
-As_long_as_power_is_provided,_the_internal_battery=通电时,内部电池
-is_charged_and_the_lamp_is_off._On_a_power_failure,=充电,灯泡关闭.断电时,
-the_lamp_turns_on_and_runs_on_batteries.=灯泡打开并使用电池供电.
-Nominal_voltage\:=额定电压:
-Battery_capacity\:=电池容量:
+# ./src/main/java/mods/eln/sixnode/electricasensor/ElectricalSensorDescriptor.java
+Can_measure_Voltage_Power_Current=可以测量电压/功率/电流
+Measures_electrical_values_on_cables.=测量电缆的电气值
+Measures_voltage_on_cables.=测量导线上的电压
 
-# ./src/main/java/mods/eln/sixnode/energymeter/EnergyMeterElement.java
-Counter=计量
-Energy_left=剩余能量
-Mode=模式
-Prepay=预付款
+# ./src/main/java/mods/eln/sixnode/electricasensor/ElectricalSensorGui.java
+Current=电流
+Measured_voltage\ncorresponding\nto_0%_output=测量电压\n对应\n0%输出
+Measured_voltage\ncorresponding\nto_100%_output=测量电压\n对应\n0%输出
+Voltage=电压
 
 # ./src/main/java/mods/eln/sixnode/energymeter/EnergyMeterGui.java
 Change_password=修改密码
-Counter_Mode=计量模式
-Counts_the_energy_conducted_from\n\u00a74red\u00a7f_to_\u00a71blue\u00a7f.=计量从\n\u00a74red\u00a7f到\u00a71blue\u00a7f通过的电量
-Energy_counter\:_%1$J=能量计算: %1$J
-Enter_new_energy=输入新的能量
+Counter_Mode=计数模式
+Counts_the_energy_conducted_from\n\u00a74red\u00a7f_to_\u00a71blue\u00a7f.=计算从\\u00a74red\\u00a7f到\\u00a71blue\\u00a7f的能量
+Energy_counter\:_%1$J=能量计算\:%1$J
+Enter_new_energy=输入新能源
 Enter_password=输入密码
 Prepay_Mode=预付费模式
 Reset_time_counter=重置计时器
-Set_energy_counter=设置计数器
-Time_counter\:=计时器:
-Try_password=尝试密码
-You_can_set_an_initial\namount_of_available_energy.\nWhen_the_counter_arrives_at_0\nthe_contact_will_be_opened.=你可以设置一个初始的可用电量。\n当计数器到达0时,电路断开。
-is_off=电路断开
-is_on=电路连通
+Set_energy_counter=设置计时器
+Time_counter\:=计时器\:
+Try_password=测试密码
+You_can_set_an_initial\namount_of_available_energy.\nWhen_the_counter_arrives_at_0\nthe_contact_will_be_opened.=你可以设置一个初始的可用能量。\n当计时器到达0时，电路联通。
+is_off=关闭了
+is_on=打开着
 value_in_kJ=单位是kJ
 
 # ./src/main/java/mods/eln/sixnode/groundcable/GroundCableDescriptor.java
-Can_be_used_to_set_a_point_of_an\nelectrical_network_to_0V_potential.\nFor_example_to_ground_negative_battery_contacts.=可用于将电网中的某一点设为0V电位，例如将电池负极接地。
-Provides_a_zero_volt_reference.=提供0V参考点
-Acts_as_a_ground_reference.=作为接地点供参考
-Has_a_small_resistance_inline=内阻很小
+Can_be_used_to_set_a_point_of_an\nelectrical_network_to_0V_potential.\nFor_example_to_ground_negative_battery_contacts.=可以用来设置0V的点位\n例如电池负极
+Provides_a_zero_volt_reference.=提供0V电路供参考
 
 # ./src/main/java/mods/eln/sixnode/hub/HubDescriptor.java
 Allows_crossing_cables\non_one_single_block.=允许导线在一个方块上面交叉
-A_bit_contrived,_as_the_wires_could_just_cross_over_each_other._Realism_depends_on_the_wires_used.=有点牵强，因为导线可以互相交叉。真实性取决于使用的导线。
 
 # ./src/main/java/mods/eln/sixnode/lampsocket/LampSocketDescriptor.java
-Angle\:_%1$°_to_%2$°=角度: %1$° 到 %2$°
-Spot_range\:_%1$_blocks=光照范围: %1$个方块
-Wireless_mode_of_lights_intended_to_pretend_wires_are_in_the_walls=用于假装电线在墙里的无线模式
-
-# ./src/main/java/mods/eln/sixnode/lampsocket/LampSocketElement.java
-Bulb=灯泡
+Angle\:_%1$°_to_%2$°=角度\:%1$°到%2$°
+Spot_range\:_%1$_blocks=污染范围\:%1$个方块
 
 # ./src/main/java/mods/eln/sixnode/lampsocket/LampSocketGuiDraw.java
-Cable_slot_empty=导线槽没有导线
-Orientation\:_%1$°=方向: %1$°
+%1$_is_not_in_range!=%1$不在范围内
+Cable_slot_empty=槽(导线)
+Orientation\:_%1$°=方向\:%1$°
 Parallel=并联
+Powered_by_Lamp_Supply=由无线照明控制盒供电
+Powered_by_cable=导线供电
 Serial=串联
+Specify_the_supply_channel=指定供应通道
 
 # ./src/main/java/mods/eln/sixnode/lampsupply/LampSupplyContainer.java
-Electrical_cable_slot\nBase_range_is_32_blocks.\nEach_additional_cable\nincreases_range_by_one.=导线槽\n初始范围为32格\n每加入一条导线\n增加一格的范围
+Electrical_cable_slot\nBase_range_is_32_blocks.\nEach_additional_cable\nincreases_range_by_one.=电力导线槽\n基本范围为32格\n每加入一条电线\n增加一格的范围
 
 # ./src/main/java/mods/eln/sixnode/lampsupply/LampSupplyDescriptor.java
-Capable_of_operating_3_light_channels.=可以控制3个照明频道
-Supplies_power_to_nearby_lamps.=向周围的灯提供能量
-Supports_control_from_a_wireless_signal\nchannel_for_each_lighting_channel.=可以通过无线信号频道对每个照明频道进行控制
-Most_homes_have_a_circuit_breaker_panel_for_lights=大多数家庭都有一个用于照明的断路器面板。
-The_wireless_power_aspect_is_pretending_there_are_wires_in_the_walls=无线照明控制盒是假装墙里有电线。
-Wireless_control_signals_are_totally_possible=无线控制信号是完全有可能的。
-
-# ./src/main/java/mods/eln/sixnode/lampsupply/LampSupplyElement.java
-Total_power=总功率
+Supplies_all_lamps_on_the_channel.=给接入该通道的每个电灯供电
 
 # ./src/main/java/mods/eln/sixnode/lampsupply/LampSupplyGui.java
-Power_channel_name=供电频道名称
-Wireless_channel_name=无线信号频道名称
-
-# ./src/main/java/mods/eln/sixnode/modbusrtu/ModbusRtuElement.java
-Modbus_TCP=Modbus TCP通讯协议
-Modbus_Unit_ID=Modbus独立ID
-Modbus_is_disabled,_enable_it_in_Eln.cfg=Modbus被停用,从Eln.cfg中启用
+Power_channel_name=供电通道名称
+Wireless_channel_name=无限通道名称
 
 # ./src/main/java/mods/eln/sixnode/modbusrtu/ModbusRtuGui.java
 Add=增加
-Channel_name=频道名称
+Channel_name=通道名称
 Modbus_ID=Modbus网关
 Modbus_RTU=Modbus RTU通讯协议
 Station_ID=站点ID
@@ -807,118 +562,60 @@ Station_name=站点名称
 Wireless_RX=无线接收
 Wireless_TX=无线发送
 
-# ./src/main/java/mods/eln/sixnode/PortableNaN.kt
-Voltage\:_Yes=电压: 是
-Current\:_No=电流: 否
-Serial_Resistance\:_OK_Ω=串联电阻: OK Ω
-A_debugging_feature_that_throws_NaN_(Not_a_Number)_anywhere_it_can_in_the_simulator_to_find_bugs=一个调试功能，可以在模拟器中的任何位置抛出NaN（不是数字）来查找错误
-
 # ./src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixContainer.java
 (Increases_maximum_voltage)=(增大最大电压)
 
-# ./src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixElement.java
-Capacity=电容
+# ./src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixGui.java
 
-# ./src/main/java/mods/eln/sixnode/powercapacitorsix/PowerCapacitorSixDescriptor.java
-Provides_capacitance._Use_with_dielectrics_and_redstone=提供电容,需要绝缘体和红石
-It_doesn't_really_behave_well_for_DC=它不适合直流电
+# ./src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixContainer.java
 
-# ./src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixElement.java
-Inductance=电感
-
-# ./src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixDescriptor.java
-Provides_inductance._Use_with_iron_cores_and_bare_copper_cables=提供电感,需要铁磁芯和铜导线
-*_Missing_an_inductive_voltage_spike_on_field_collapse=*磁场崩溃时缺少感应电压尖峰
+# ./src/main/java/mods/eln/sixnode/powerinductorsix/PowerInductorSixGui.java
 
 # ./src/main/java/mods/eln/sixnode/powersocket/PowerSocketDescriptor.java
-Supplies_any_device\nplugged_in_with_energy.=给任何接入的设备提供能量。
-Homes_have_power_sockets._These_are_not_them.=这些不是家庭的电源插座。
+Supplies_any_device\nplugged_in_with_energy.=给任何接入的设备提供能量
 
 # ./src/main/java/mods/eln/sixnode/powersocket/PowerSocketGui.java
-Specify_the_device_to_supply_through_this_socket.=指定要通过此插座供电的设备。
+Specify_the_device_to_supply_through_this_socket.=提供给指定的已连接的某设备
 
 # ./src/main/java/mods/eln/sixnode/resistor/ResistorContainer.java
 (Sets_resistance)=(设置电阻)
 Coal_dust_slot=槽(煤粉)
 
-# ./src/main/java/mods/eln/sixnode/resistor/ResistorElement.java
-
-# ./src/main/java/mods/eln/sixnode/resistor/ResistorDescriptor.java
-It's_a_resistor=这是一个电阻
-
 # ./src/main/java/mods/eln/sixnode/thermalcable/ThermalCableDescriptor.java
-High_parallel_resistance\n_⇨_Low_power_dissipation.=高并联热阻\n ⇨ 低热损
-Low_serial_resistance\n_⇨_High_conductivity.=低串联热阻\n ⇨ 高热导.
-Parallel_resistance\:_%1$K_W=并联热阻: %1$K/W
-Serial_resistance\:_%1$K_W=串联热阻: %1$K/W
-The_thermal_simulator_doesn't_properly_manage_heat=热量模拟器无法正确管理热量
-
-# ./src/main/java/mods/eln/sixnode/thermalcable/ThermalCableElement.java
-Thermic_power=热功率
+High_parallel_resistance\n_\=>_Low_power_dissipation.=并联大阻抗的电阻\n以获得低功耗
+Low_serial_resistance\n_\=>_High_conductivity.=并联小阻抗的电阻\n以获得高功耗
+Parallel_resistance\:_%1$K_W=并联\:%1$K/W
+Serial_resistance\:_%1$K_W=串联\:%1$K/W
 
 # ./src/main/java/mods/eln/sixnode/thermalsensor/ThermalSensorContainer.java
-Cable_slot=槽(热管)
+Cable_slot=槽(导线)
 
 # ./src/main/java/mods/eln/sixnode/thermalsensor/ThermalSensorDescriptor.java
-Can_measure\:=可以测量:
-Measures_temperature_of_cables.=测量导线的温度.
-Measures_thermal_values_on_cables.=测量热管的热力属性.
-__Temperature_Power_conducted=温度/热功率
-
-# ./src/main/java/mods/eln/sixnode/thermalsensor/ThermalSensorElement.java
-Measured_temperature=实测温度
-Measured_thermal_power=实测热功率
+Can_measure\:=可以测量\:
+Measures_temperature_of_cables.=测量导线的温度
+Measures_thermal_values_on_cables.=测量导线的温度
+__Temperature_Power_conducted=热/电传导
 
 # ./src/main/java/mods/eln/sixnode/thermalsensor/ThermalSensorGui.java
-Measured_temperature\ncorresponding\nto_0%_output=对应于0%输出的测量温度
-Measured_temperature\ncorresponding\nto_100%_output=对应于100%输出的测量温度
+Measured_temperature\ncorresponding\nto_0%_output=测量温度\n对应\n0%输出
+Measured_temperature\ncorresponding\nto_100%_output=测量温度\n对应\n0%输出
+Temperature=温度
 
 # ./src/main/java/mods/eln/sixnode/tutorialsign/TutorialSignElement.java
-No_text_associated_to_this_beacon=没有关联到这个标志的文本
+No_text_associated_to_this_beacon=没有关联到这个信标的文本
 
 # ./src/main/java/mods/eln/sixnode/tutorialsign/TutorialSignGui.java
-Set_beacon_name=设置标志名称
+Set_beacon_name=设置信标名称
 
 # ./src/main/java/mods/eln/sixnode/wirelesssignal/rx/WirelessSignalRxGui.java
 
-# ./src/main/java/mods/eln/sixnode/wirelesssignal/rx/WirelessSignalRxDescriptor.java
-Receive_signal_voltage_on_selected_wireless_signal_channel=接收选定无线信号频道的信号电压
-It_should_require_power_to_receive_and_propogate_the_signal_realistically=它应该需要供电以接收和传播信号，以实现真实性
-
-# ./src/main/java/mods/eln/sixnode/wirelesssignal/tx/WirelessSignalTxDescriptor.java
-Sends_signal_voltage_on_selected_wireless_signal_channel=在选定无线信号频道上发送信号电压
-It_should_require_power_to_transmit_realistically=它应该需要供电以实现真实性
-
-# ./src/main/java/mods/eln/sixnode/wirelesssignal/repeater/WirelessSignalRepeaterDescriptor.java
-Repeats_all_wireless_signals_in_range=重复范围内的所有无线信号
-It_should_require_power_realistically=它应该需要供电以实现真实性
-
 # ./src/main/java/mods/eln/transparentnode/FuelGenerator.kt
-Fuel_level=燃油含量
-Nominal_power\:_%1$_W=额定功率: %1$W
-Nominal_voltage\:_%1$_V=额定电压: %1$ V
-Produces_electricity_using_gasoline.=燃烧轻油发电
-
-# ./src/main/java/mods/eln/transparentnode/FuelHeatFurnace.kt
-Actual\:_%1$=实际温度: %1$
-Analog_regulator_slot=槽(温控组件)
-Control_value_at_%1$=控制值 %1$
-Fuel_burner_slot=槽(燃料燃烧器)
-Furnace_is_off=加热炉已停止
-Furnace_is_on=加热炉正在工作
-Heat_Power\:_%1$=加热功率: %1$
-Set_point\:_%1$=设定温度: %1$
-__Max._temperature\:_=  最大温度:
+Nominal_power\:_%1$_W=Nominal power\: %1$ W
+Nominal_voltage\:_%1$_V=Nominal voltage\: %1$ V
+Produces_electricity_using_fuel.=用燃料来发电
 
 # ./src/main/java/mods/eln/transparentnode/LargeRheostat.kt
-Control_resistance_with_signal=用信号控制电阻
-Dissapates_~4kW_of_heat_passively=提供4000W的被动散热
-Nom._Resistance\:_%1$=当前电阻: %1$
-Power_loss=功率损耗
-Set_resistance_with_coal_dust=用煤粉增加电阻
-Has_some_caveats\:=注意事项:
-__*_Resistance_is_not_impacted_by_temperature=  * 电阻不受温度影响
-__*_Signal_input_doesn't_require_power=  * 信号输入不需要电源
+Nom._Resistance\:_%1$=Nom. Resistance\: %1$
 
 # ./src/main/java/mods/eln/transparentnode/autominer/AutoMinerContainer.java
 Drill_slot=槽(钻头)
@@ -926,432 +623,207 @@ Mining_pipe_slot=槽(挖矿管道)
 Ore_scanner_slot=槽(矿物扫描仪)
 
 # ./src/main/java/mods/eln/transparentnode/autominer/AutoMinerDescriptor.java
-Excavates_on_a_small_radius.\nExtracts_ore_on_a_bigger_radius\:\n10_blocks_radius_after_10_blocks_depth.=小范围全部挖掘\n大范围挖掘矿石:10格深度后10格半径
-
-# ./src/main/java/mods/eln/transparentnode/autominer/AutoMinerElement.java
-Depth=深度
-Silk_touch=精准
+Excavates_on_a_small_radius.\nExtracts_ore_on_a_bigger_radius\:\n10_blocks_radius_after_10_blocks_depth.=小搜索范围挖掘\n挖了10格深后以10个方块为半径挖掘
 
 # ./src/main/java/mods/eln/transparentnode/autominer/AutoMinerGuiDraw.java
 Chest_missing_on_the\nback_of_the_auto_miner!=自动挖矿机背部没有检测到箱子耶
-Halves_speed,_triples_power_draw=挖掘速度减半，三倍功率消耗
-Silk_Touch=精准
+Halves_speed,_triples_power_draw=Halves speed, triples power draw
+Silk_Touch_Off=Silk Touch Off
+Silk_Touch_On=Silk Touch On
+Silk_touch=Silk touch
 
 # ./src/main/java/mods/eln/transparentnode/battery/BatteryContainer.java
 Overheating_protection=保护装置(过热)
-Overvoltage_protection=保护装置(过压)
+Overvoltage_protection=当压力过大时提供保护
 
 # ./src/main/java/mods/eln/transparentnode/battery/BatteryDescriptor.java
-Actual_charge\:_=实际电量:
-Energy_capacity\:_=能量容量:
-Internal_resistance\:_=内阻:
-Life\:_=寿命:
-Nominal_power\:_=额定功率:
-Nominal_voltage\:_=额定电压:
-_charged_at_=剩余电量
-Battery_could_be_realistic_in_the_future=电池在未来会更真实
-__*_Batteries_have_internal_resistance=  * 电池有内阻
-__*_Not_currently_simulating_any_particular_chemistry_of_battery=  * 目前没有模拟任何特定的电池化学反应
-Batteries_are_based_in_realistic_battery_designs_that_someone_might_implement_realistically\:=电池基于现实的电池设计(可能有某些人在游戏中实现):
-__*_Single_use_batteries_emulate_a_voltaic_pile=  * 一次性电池模拟伏打堆
-__*_Current_oriented_uses_two_smaller_batteries_in_parallel_to_increase_current_capability=  * 大电流电池使用两个较小的电池并联以增加输出电流
-__*_Voltage_oriented_uses_two_smaller_batteries_in_series_to_increase_voltage=  * 大电压电池使用两个较小的电池串联以增加输出电压
-
-# ./src/main/java/mods/eln/transparentnode/battery/BatteryElement.java
+Actual_charge\:_%1$%=实际电量\:%1$%
+Energy_capacity\:_%1$J=能量容量\:%1$J
+_charged_at_%1$%=剩余电量\:%1$%
 
 # ./src/main/java/mods/eln/transparentnode/battery/BatteryGuiDraw.java
+Charge=充电
 Charged=充满了
-Discharge=放电
-Energy\:=电量:
-Energy\:_%1$=电量: %1$
-Life\:=寿命:
+Discharge=放点
+Energy\:=能量\:
+Energy\:_%1$=能量\:%1$
+Life\:=寿命\:
 No_charge=没有充电
-Power_in\:=充电功率:
-Power_out\:=放电功率:
+Power_in\:=输入能量\:
+Power_out\:=输出能量
 
 # ./src/main/java/mods/eln/transparentnode/eggincubator/EggIncubatorContainer.java
-Egg_slot=槽(鸡蛋)
-
-# ./src/main/java/mods/eln/transparentnode/eggincubator/EggIncubatorElement.java
-Has_egg=有蛋
+Egg_slot=槽(蛋)
 
 # ./src/main/java/mods/eln/transparentnode/electricalantennarx/ElectricalAntennaRxDescriptor.java
-Wireless_energy_receiver.=无线接收能量
-
-# ./src/main/java/mods/eln/transparentnode/electricalantennarx/ElectricalAntennaRxElement.java
-Effective_power=有效功率
-Power_received=接收功率
-Receiving=接收
+Wireless_energy_receiver.=能源无线接收
 
 # ./src/main/java/mods/eln/transparentnode/electricalantennatx/ElectricalAntennaTxDescriptor.java
-Efficiency\:_%1$%_up_to_%2$%=效率: %1$%至%2$%
-Wireless_energy_transmitter.=无线发送能量
-
-# ./src/main/java/mods/eln/transparentnode/electricalantennatx/ElectricalAntennaTxElement.java
-Efficiency=效率
-Transmitting=传输
+Efficiency\:_%1$%_up_to_%2$%=效率\:%1$%至%2$%
+Wireless_energy_transmitter.=能源无线发送
 
 # ./src/main/java/mods/eln/transparentnode/electricalfurnace/ElectricalFurnaceContainer.java
-Heating_corp_slot=槽(加热器)
+Heating_corp_slot=槽(加热核心)
 
 # ./src/main/java/mods/eln/transparentnode/electricalfurnace/ElectricalFurnaceDescriptor.java
 Similar_to_a_vanilla_furnace,\nbut_heats_with_electricity.=跟一个正常的熔炉一样,只是用电驱动
 
-# ./src/main/java/mods/eln/transparentnode/electricalfurnace/ElectricalFurnaceElement.java
-Heating_element=加热器
-
 # ./src/main/java/mods/eln/transparentnode/electricalfurnace/ElectricalFurnaceGuiDraw.java
-Auto_shutdown=自动启停
-Manual_shutdown=手动启停
-Set_point\:_%1$°C=设置温度: %1$°C
-
-# ./src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineContainer.java
+Auto_shutdown=自动关闭
+Manual_shutdown=手动关闭
+Set_point\:_%1$°C=设置温度\:%1$°C
 
 # ./src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineDescriptor.java
-Cost=消耗
-
-# ./src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineElement.java
-Power_provided=供应功率
-
-# ./src/main/java/mods/eln/transparentnode/Fabricator.kt
-The_Fabricator_creates_chips\nfrom_silicon_and_copper_plates=制造机使用铜板和硅晶圆制造芯片
-Nominal_Ohms\:_%1$=额定电阻: %1$
+Cost=价格
 
 # ./src/main/java/mods/eln/transparentnode/heatfurnace/HeatFurnaceContainer.java
 Combustion_chamber_slot=槽(燃烧室)
 Fuel_slot=槽(燃料)
 
-# ./src/main/java/mods/eln/transparentnode/heatfurnace/HeatFurnaceElement.java
-Set_temperature=设定温度
+# ./src/main/java/mods/eln/transparentnode/heatfurnace/HeatFurnaceDescriptor.java
+Generates_heat_when_supplied_with_fuel.=提供燃料的时候产生热
 
 # ./src/main/java/mods/eln/transparentnode/heatfurnace/HeatFurnaceGuiDraw.java
-Control_gauge_at_%1$%=Control gauge at %1$%
-Decline_fuel=待机中
-Take_fuel=运行中
-
-# ./src/main/java/mods/eln/transparentnode/NixieTube.kt
-Displays_a_single_glowing_digit.=显示一个发光的数字
-Signal_input_doesn't_require_power,_and_interfaces_are_tailored_to_gameplay=信号输入不需要能量，接口根据游戏情况量身定制
-Nixie_tube_has_been_textured_realistically=辉光管具有拟真材质
+Control_gauge_at_%1$%=操作规范\:%1$%
+Decline_fuel=减少燃料
+External_control=手动控制
+Internal_control=自动控制
+Take_fuel=取走燃料
 
 # ./src/main/java/mods/eln/transparentnode/powercapacitor/PowerCapacitorContainer.java
-(Increases_maximal_voltage)=(Increases maximal voltage)
-
-# ./src/main/java/mods/eln/transparentnode/powercapacitor/PowerCapacitorGui.java
-
-# ./src/main/java/mods/eln/transparentnode/powerinductor/PowerInductorContainer.java
-
-# ./src/main/java/mods/eln/transparentnode/powerinductor/PowerInductorGui.java
+(Increases_maximal_voltage)=(增大最大电压)
 
 # ./src/main/java/mods/eln/transparentnode/solarpanel/SolarPanelContainer.java
-Solar_tracker_slot=槽(太阳追踪组件)
+Solar_tracker_slot=槽(太阳能跟踪器)
 
 # ./src/main/java/mods/eln/transparentnode/solarpanel/SolarPanelDescriptor.java
-Can_be_geared_towards_the_sun.=可以使太阳能板直指太阳以接收更多能量
-Max._power\:_%1$W=最大功率: %1$W
-Max._voltage\:_%1$V=最大电压: %1$V
-Produces_power_from_solar_radiation.=从太阳辐射中获取能量
-
-# ./src/main/java/mods/eln/transparentnode/solarpanel/SolarPanelElement.java
-Panel_angle=太阳能板角度(与法线夹角)
-Producing_energy=发电中
-Sun_angle=太阳角度(与法线夹角)
+Can_be_geared_towards_the_sun.=可以使太阳能板直指太阳以获得更多的能源
+Max._power\:_%1$W=最大功率\:%1$W
+Max._voltage\:_%1$V=最大电压\:%1$V
+Produces_power_from_solar_radiation.=从太阳辐射获取能量
 
 # ./src/main/java/mods/eln/transparentnode/solarpanel/SolarPannelGuiDraw.java
 It_is_night=晚上了
-Solar_panel_angle\:_%1$°=太阳能板角度(与法线夹角): %1$°
-Sun_angle\:_%1$°=太阳角度(与法线夹角): %1$°
-
-# ./src/main/java/mods/eln/transparentnode/teleporter/TeleporterDescriptor.java
-It's_experimental!=这是实验性的！
-
-# ./src/main/java/mods/eln/transparentnode/teleporter/TeleporterElement.java
-Destination=目的地
-Distance=距离
-Required_energy=所需能量
+Solar_panel_angle\:_%1$°=太阳能电板角度\:%1$°
+Sun_angle\:_%1$°=太阳角度\:%1$°
 
 # ./src/main/java/mods/eln/transparentnode/teleporter/TeleporterGui.java
-Destination_transporter=目的传送机名称
-Power_consumption\:=消耗功率:
-Power_consumption\:_%1$W=使用功率: %1$W
-Required_energy\:_%1$J=需要能量: %1$J
-Start=开始传送
+Destination_transporter=传送至目的地
+Power_consumption\:=消耗功率\:
+Power_consumption\:_%1$W=使用功率\:%1$W
+Required_energy\:_%1$J=需要功率\:%1$J
+Start=开始
 Transporter_name=传送机名称
 
 # ./src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveDescriptor.java
-Fan_cooling_power\:_%1$W=风冷功率: %1$W
-Fan_power_consumption\:_%1$W=风扇功率: %1$W
-Fan_voltage\:_%1$V=风扇电压: %1$V
-
-# ./src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveElement.java
-
-# ./src/main/java/mods/eln/transparentnode/ThermalHeatExchanger.kt
-Generates_heat_when_supplied_with_ic2\:hotcoolant=提取ic2热冷却液的热量
-Ejects_out_ic2\:coolant=排出ic2冷却液
-
-# ./src/main/java/mods/eln/transparentnode/transformer/TransformerContainer.java
-Casing_slot=槽(变压器罩)
+Fan_cooling_power\:_%1$W=风冷功率\:%1$W
+Fan_power_consumption\:_%1$W=风扇功率\:%1$W
+Fan_voltage\:_%1$V=风扇电压\:%1$V
 
 # ./src/main/java/mods/eln/transparentnode/transformer/TransformerDescriptor.java
-The_voltage_ratio_is_proportional\nto_the_cable_stacks_count_ratio.=电压比与铜导线数目比成正比
+The_voltage_ratio_is_proportional\nto_the_cable_stacks_count_ratio.=电压与导线的数目成正比
 Transforms_an_input_voltage_to\nan_output_voltage.=将输入电压转换为输出电压
-The_output_voltage_is_controlled\nfrom_a_signal_input=输出电压由输入信号控制
-This_variable_DC_DC_has_unrealistic_capacitance_effects_and_can_sink_source_power_that_violates_Newton's_laws=这种可变 直流-直流 变压器具有不切实际的电容效应，可能会消耗/产生违反牛顿定律的功率
-It_is_made_this_way_to_improve_the_performance_of_the_simulator_in_large_power_networks=这样做是为了提高大型电网中模拟器的性能
-This_DC_DC_has_unrealistic_capacitance_effects_and_can_sink_source_power_that_violates_Newton's_laws=这种 直流-直流 变压器具有不切实际的电容效应，可能会消耗/产生违反牛顿定律的功率
-
-# ./src/main/java/mods/eln/transparentnode/transformer/TransformerElement.java
-Core_factor=核心要素
-Isolated=隔离
-Ratio=转换比
 
 # ./src/main/java/mods/eln/transparentnode/turbine/TurbineDescriptor.java
 Generates_electricity_using_heat.=用热能来发电
-Temperature_difference\:_%1$°C=温差: %1$°C
-
-# ./src/main/java/mods/eln/transparentnode/turbine/TurbineElement.java
-Nominal=额定
-
-# ./src/main/java/mods/eln/transparentnode/turret/TurretContainer.java
+Temperature_difference\:_%1$°C=温度差\:%1$°C
 
 # ./src/main/java/mods/eln/transparentnode/turret/TurretDescriptor.java
-CAUTION\:_Cables_can_get_quite_hot!=警告:小心导线过热
-Laser_charge_power\:_%1$W...%2$kW=激光充电功率: %1$W...%2$kW
-Scans_for_entities_and_shoots_if_the\nentity_matches_the_configurable_filter_criteria.=范围内如果找到的实体与过滤器一致\n那么开始攻击该实体直至实体从范围内消失
-Standby_power\:_%1$W=待机功率: %1$W
-
-# ./src/main/java/mods/eln/transparentnode/turret/TurretElement.java
-??=??
-Charge_level=功率
-Shoot_=攻击
-Shoot_everything=攻击所有
-Shoot_nothing=不攻击
-Target=目标
-animals=动物
-monsters=怪物
-players=玩家
+CAUTION\:_Cables_can_get_quite_hot!=警告\:导线过热
+Laser_charge_power\:_%1$W...%2$kW=激光充电功率\:%1$W...%2$kW
+Scans_for_entities_and_shoots_if_the\nentity_matches_the_configurable_filter_criteria.=范围内如果找到的实体与过滤器一致\n那么开始攻击该实体直至实体从范围内移除
+Standby_power\:_%1$W=备用功率\:%1$W
 
 # ./src/main/java/mods/eln/transparentnode/turret/TurretGui.java
-Attack\:=攻击:
-Do_not_attack\:=不攻击:
-Recharge_power\:=放电功率:
+Attack\:=攻击\:
+Do_not_attack\:=不攻击\:
+Recharge_power\:=放电功率
 
 # ./src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineDescriptor.java
 Generates_energy_using_water_stream.=用流动水来发电
-No_place_for_water_turbine!=没有足够的空间放置水力发电机
-
-# ./src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineElement.java
+No_place_for_water_turbine!=没有足够的空间供水力发电机工作
 
 # ./src/main/java/mods/eln/transparentnode/windturbine/WindTurbineDescriptor.java
-Front\:_%1$=前: %1$ 格
+Front\:_%1$=前面\:%1$
 Generates_energy_from_wind.=用风来发电
-Left_Right\:_%1$=左右: %1$ 格
-Up_Down\:_%1$=上下: %1$ 格
-Wind_area\:=风区:
+Left_Right\:_%1$=左/右\:%1$
+Up_Down\:_%1$=上/下\:%1$
+Wind_area\:=风区
 
 # ./src/main/java/mods/eln/wiki/Data.java
-Light=照明
+Energy=功率
+Light=亮度
 Machine=机器
-Ore=矿石
+Ore=kuang'shi
 Portable=便携式
-Resource=材料
+Resource=源
 Signal=信号
 Thermal=热能
 Upgrade=升级
-Utilities=实用
+Utilities=公用
 Wiring=布线
 
 # ./src/main/java/mods/eln/wiki/Default.java
-Previous=后退
+Previous=过去的
 
 # ./src/main/java/mods/eln/wiki/ItemDefault.java
-Can_be_used_to_craft\:=可以作为合成材料:
-Cannot_be_crafted!=无法通过合成获得!
-Cost_%1$J=消耗能量 %1$J
-Created_by\:=生产于:
-Is_not_a_crafting_material!=不能合成其他物品!
-Recipe\:=合成表:
+Can_be_used_to_craft\:=可以用来合成\:
+Cannot_be_crafted!=不能合成而得\!
+Cost_%1$J=消耗能量\:%1$J
+Created_by\:=制作原料\:
+Is_not_a_crafting_material!=不能合成其他物品\!
+Recipe\:=合成表\:
 
 # Appearing in multiple source files
-%1$_is_not_in_range!=%1$ 不在范围内!
-(Increases_capacity)=(增大电容)
+(Increases_capacity)=(增大容量)
 (Increases_inductance)=(增大电感)
-Acts_like_a\npush_button.=就像一个按钮
-Acts_like_a\ntoggle_switch.=就像一个拉杆
-Actual\:_%1$°C=实际温度: %1$°C
-Battery_level=电池电量
-Biggest=或
-Booster_slot=槽(增压升级)
-Can_create\:=可以用于生产:
-Capacity\:_%1$F=电容: %1$F
-Channel=频道
-Charge=电量
-Charge_power=充电功率
-Charge_power\:_%1$W=充电功率: %1$W
-Closed=合上
+Actual\:_%1$°C=实际温度\:%1$°C
+Biggest=最大的
+Booster_slot=槽(增压器)
+Can_create\:=可以合成\:
+Capacity\:_%1$F=容量\:%1$F
+Charge_power\:_%1$W=充电功率\:%1$W
 Connected=已连接
-Cooling_power\:_%1$W=冷却功率: %1$W
+Cooling_power\:_%1$W=冷却功率\:%1$W
 Copper_cable_slot=槽(铜导线)
-Current=电流
 Dielectric_slot=槽(绝缘体)
-Discharge_power\:_%1$W=放电功率: %1$W
-Electrical_cable_slot=槽(导线)
-Energy=能量
-Entity_filter_slot=槽(生物筛选组件)
-External_control=外部控制中
-Ferromagnetic_core_slot=槽(铁磁芯)
-Generated_power=发电功率
-Generates_heat_when_supplied_with_fuel.=燃烧燃油产热
-Generating=发电中
+Discharge_power\:_%1$W=输出功率\:%1$W
+Electrical_cable_slot=槽(电力导线)
+Entity_filter_slot=槽(生物过滤器)
+Ferromagnetic_core_slot=槽(磁能核心)
 Has_a_signal_output.=有一个信号输出
-Inductance\:_%1$H=电感: %1$H
-Input=输入
-Input_voltage=输入电压
-Internal_control=内部控制中
-Internal_resistance\:_%1$Ω=内阻: %1$Ω
-Is_off=待机中
-Is_on=工作中
-Life=寿命
-Max._temperature\:_%1$°C=最高温度: %1$°C
-miaou=喵呜~
-Min._temperature\:_%1$°C=最低温度: %1$°C
-Measured_value\ncorresponding\nto_0%_output=对应于0%输出的测量值
-Measured_value\ncorresponding\nto_100%_output=对应于100%输出的测量值
-No=否
-Nominal\:=额定参数:
-Nominal_power\:_%1$W=额定功率: %1$W
-Nominal_usage\:=额定参数:
-Nominal_voltage\:_%1$V=额定电压: %1$V
-None=无
+Inductance\:_%1$H=电感\:%1$H
+Internal_resistance\:_%1$Ω=内阻\:%1$Ω
+Is_off=关
+Is_on=开
+Max._temperature\:_%1$°C=最高温度\:%1$°C
+Measured_value\ncorresponding\nto_0%_output=测量zhi\n对应\n0%输出
+Measured_value\ncorresponding\nto_100%_output=测量zhi\n对应\n0%输出
+Nominal\:=理论\:
+Nominal_power\:_%1$W=理论功率\:%1$W
+Nominal_usage\:=理论使用\:
+Nominal_voltage\:_%1$V=理论电压\:%1$V
 Not_connected=未连接
 Not_enough_space_for_this_block=没有足够空间放置这个方块
-OFF=关
-ON=开
-Off=关
-On=开
-Open=打开
-Output_voltage=输出电压
-Portable_battery_slot=槽(便携电池)
-Position=触点
 Power=功率
-Power\:_%1$W=功率: %1$W
-Power_consumption=消耗功率
-Powered_by_Lamp_Supply=由无线照明控制盒供电
-Powered_by_cable=导线供电
-Produced_power=发电功率
-Range\:_%1$_blocks=范围: %1$ 方块
-Really_useless=真的没用
+Power\:_%1$W=功率\:%1$W
+Range\:_%1$_blocks=范围\:%1$个方块
 Redstone_slot=槽(红石)
-Redstone_value=红石信号强度
-Regulator_slot=槽(温控组件)
+Regulator_slot=槽(校准器)
 Reset=重置
-Resistance=电阻
-Resistance\:_%1$Ω=电阻: %1$Ω
-Signal_Voltage=信号电压
-Smallest=与
-Specify_the_channel=指定频道
-Specify_the_supply_channel=指定供电频道
-State=状态
-Stored_energy\:_%1$J_(%2$%)=储存能量: %1$J (%2$%)
-Temperature=温度
-Temperature\:_%1$°C=温度: %1$°C
+Resistance\:_%1$Ω=电阻\:%1$Ω
+Smallest=最小的
+Specify_the_channel=指定通道
+Stored_energy\:_%1$J_(%2$%)=储存的能量\:%1$J(%2$%)
+Temperature\:_%1$°C=温度\:%1$°C
 Temperature_gauge=温度计
-Thermal_isolator_slot=槽(石棉网)
-Thermal_power=散热功率
+Thermal_isolator_slot=槽(隔热器)
 Toggle=切换
 Toggle_switch=切换开关
-Toggles_the_output_each_time\nan_emitter's_value_rises.\nUseful_to_allow_multiple_buttons\nto_control_the_same_light.=无线信号频道中有按钮切换状态则切换状态\n在多个开关控制同一频道时很有用
-Used_to_cool_down_turbines.=用来散热
-useless=无用
-Uses_the_biggest\nvalue_on_the_channel.=无线信号频道中有一个开关开启则状态为高电平
-Uses_the_smallest\nvalue_on_the_channel.=无线信号频道中所有频道开启则状态为高电平
-Validate=确认
-Voltage=电压
-Voltage\:_%1$V=电压: %1$V
-Voltage_drop=压降
-Voltages=电压
-Yes=是
+Toggles_the_output_each_time\nan_emitter's_value_rises.\nUseful_to_allow_multiple_buttons\nto_control_the_same_light.=按按钮时增大输出\n在多个开关控制同一灯泡时很有用
+Used_to_cool_down_turbines.=用来冷却涡轮
+Uses_the_biggest\nvalue_on_the_channel.=使用通道上最高的值
+Uses_the_smallest\nvalue_on_the_channel.=使用通道上最低的值
+Validate=证实
+Voltage\:_%1$V=电压\:%1$V
 You_can't_place_this_block_at_this_side=不能把方块放在这一边哟~
-_O\:_= O:
-
-# FIXME
-Grid_DC-DC_Converter.name=电网变压器
-Transmission_Tower.name=T2输电塔
-Utility_Pole.name=T1电线杆
-Utility_Pole_w/DC-DC_Converter.name=T1电线杆(变压器)
-
-# some other stuff
-
-Portable_NaN.name=便携式NaN(开发项目)
-Old_800V_Arc_Furnace.name=电弧炉(800V,10kW)
-Christmas_Tree.name=圣诞树
-Holiday_Candle.name=假日蜡烛
-String_Lights.name=一串灯
-Radial_Motor.name=发动机(燃气,64mB/s)
-Thermal_Heat_Exchanger.name=热交换器
-Current_Source.name=电流源
-Improved_Flashlight.name=改进的手电筒
-Thermal_Insulation.name=石棉网
-Organic_Asbestos™=有机石棉™
-Upgrade_for_the_Stone_Heat_Furnace=石制加热炉的升级
-__Heat_tolerance\:=  耐热性:
-__Insulation\:=  隔热率:
-Cuts_down_trees._Right-click_to_make_it_act_like_a_regular_axe.=砍树，右键开启连锁模式
-Opens_holes._Right-click_to_open_smaller_holes.=挖3*3，右键开启1*1模式
-Silicon_Wafer.name=硅晶圆
-Transistor.name=晶体管
-NTC_Thermistor.name=负温度系数热敏电阻
-Nibble_Memory_Chip.name=半字节存储器芯片
-Arithmetic_Logic_Unit.name=算术逻辑单元
-Fabricator.name=制造机
-Multicolor_LED_vuMeter.name=信号计(多色LED)
-Grid_Switch.name=电网开关
-Direct_Utility_Pole.name=直连电线杆
-Crank_Shaft.name=曲轴
-Rolling_Shaft_Machine.name=滚轴机
-Low_Current_Relay.name=继电器(5A)
-Medium_Current_Relay.name=继电器(20A)
-High_Current_Relay.name=继电器(100A)
-Type_E_Socket.name=E型插座
-Type_J_Socket.name=J型插座
-Conduit.name=管道电缆
-tile.eln.Conduit.name=埋管块
-Subsystem_Matrix_Size=子系统矩阵大小
-Charging...=充电中...
-Batteries_empty=电量耗尽
-Fully_charged=充满了
-Simple=总量
-Slots=格子
-Inputs=输入
-Min=最小
-Max=最大
-Speed=转速
-Speeds=转速
-Energies=动能
-Clutching=制动力信号
-Fuel_usage=燃料消耗速度
-Process_State=加工进度
-Can_Process=可以工作
-Not_as_warm_as_it_could_be=没有达到预期的温暖程度
-It_probably_works_if_you_apply_~200v_to_the_xmas_wireless_channel=如果你在"xmas"无线照明频道中输入200V，它可能会工作
-Control=控制
-input_tank_level=热冷却液
-output_tank_level=冷却液
-input_mB_t=输入速率(mB/t)
-output_mB_t=输出速率(mB/t)
-joules_per_tick=热交换速度(J/tick)
-thermal_power=热功率
-Left=左
-Right=右
-Transfer=转换
-Drive=负载
-Signal=信号
-Closed?=关闭中?
-Digit=数字
-Blank=黯淡
-Dots=小数点
-No_wireless_signal_in_area!=范围内没有无线信号!
-_Strength= 强度
-_Value= 值
-Control_Voltage=控制电压
-Operation=目标


### PR DESCRIPTION
Localize all the visible strings in the game, modifying the previously untranslatable entries: from "High_parallel_resistance\n_=>Low_power_dissipation." to "High_parallel_resistance\n⇨_Low_power_dissipation.", add all translatable entries to en_US.lang, and improve the localization for Simplified Chinese.