### PR TITLE
Fixed translation error for the shaft generator.

### DIFF
--- a/src/main/kotlin/mods/eln/craft/CraftingRecipes.kt
+++ b/src/main/kotlin/mods/eln/craft/CraftingRecipes.kt
@@ -122,8 +122,7 @@ object CraftingRecipes {
         craftBrush()
         val cal: Calendar = Calendar.getInstance()
         val month: Int = cal.get(Calendar.MONTH) + 1
-        val day: Int = cal.get(Calendar.DAY_OF_MONTH)
-        if(month == 12 && day == 25) {
+        if(month == 12 ) {
             recipeChristmas()
         }
 

--- a/src/main/resources/assets/eln/lang/en_US.lang
+++ b/src/main/resources/assets/eln/lang/en_US.lang
@@ -431,7 +431,7 @@ Player_crankable_shaft=Player crankable shaft
 Can_rotate_slowly=Can rotate slowly
 
 # ./src/main/java/mods/eln/mechanical/Generator.kt
-Converts_mechanical_energy_into_electricity,_or_(badly)_vice_versa.=Converts_mechanical_energy_into_electricity,_or_(badly)_vice_versa.
+Converts_mechanical_energy_into_electricity,_or_(badly)_vice_versa.=Converts mechanical energy into electricity, or (badly) vice versa.
 __Voltage_out\:_=Voltage out:
 __Rads\:_%1$=  Rads: %1$
 

--- a/src/main/resources/assets/eln/lang/en_US.lang
+++ b/src/main/resources/assets/eln/lang/en_US.lang
@@ -431,7 +431,7 @@ Player_crankable_shaft=Player crankable shaft
 Can_rotate_slowly=Can rotate slowly
 
 # ./src/main/java/mods/eln/mechanical/Generator.kt
-Converts_mechanical_energy_into_electricity,_or_(badly)_vice_versa.=将机械能转换为电能，或反之(低效)。
+Converts_mechanical_energy_into_electricity,_or_(badly)_vice_versa.=Converts_mechanical_energy_into_electricity,_or_(badly)_vice_versa.
 __Voltage_out\:_=Voltage out:
 __Rads\:_%1$=  Rads: %1$
 


### PR DESCRIPTION
Line 434 in the `en_US.lang` file (`Converts_mechanical_energy_into_electricity,_or_(badly)_vice_versa.`) was mistakenly translated to Chinese instead of English.