### PR TITLE
Fixes the version issue if you try to run this from a fork

### DIFF
--- a/src/main/kotlin/mods/eln/misc/Version.kt
+++ b/src/main/kotlin/mods/eln/misc/Version.kt
@@ -15,7 +15,8 @@ object Version {
     /**
      * SemVer Version
      */
-    val SEMVER = Semver.parse(Tags.VERSION.replace(".dirty", ""))
+    val SEMVER = Semver.parse(Tags.VERSION.replace(".dirty", "+dirty"))?:
+        Semver.parse("0.0.0-${Tags.VERSION}".replace(".dirty", "+dirty"))
 
     /**
      * Major version code.


### PR DESCRIPTION
Semver's developers have a try catch that returns null instead of the exception if it can't parse the crap we provide from RFG; there's no actual "version" information provided, which probably breaks the code. It could also be the `.dirty` is to blame, not root causing that as it's unnecessary.