### PR TITLE
Update build.gradle to reference new default buildscript

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1283,7 +1283,7 @@ tasks.register('faq') {
 }
 
 static URL availableBuildScriptUrl() {
-    new URL("https://raw.githubusercontent.com/GTNewHorizons/ExampleMod1.7.10/master/build.gradle")
+    new URL("https://raw.githubusercontent.com/GTNewHorizons/ExampleMod1.7.10/master/build.gradle.kts")
 }
 
 static URL exampleSettingsGradleUrl() {


### PR DESCRIPTION
Quick single-line change in build.gradle for ELN. See https://github.com/GTNewHorizons/ExampleMod1.7.10/releases/tag/master-packages for details on updated default buildscript.