### PR TITLE
Fix ReplicatorEntity crashing world on empty drop list

### DIFF
--- a/src/main/java/mods/eln/entity/ReplicatorEntity.java
+++ b/src/main/java/mods/eln/entity/ReplicatorEntity.java
@@ -131,8 +131,9 @@ public class ReplicatorEntity extends EntityMob {
 
     @Override
     protected void dropFewItems(boolean par1, int par2) {
-        this.entityDropItem(dropList.get(new Random().nextInt(dropList.size())).copy(), 0.5f);
-
+        if (!dropList.isEmpty()) {
+            this.entityDropItem(dropList.get(new Random().nextInt(dropList.size())).copy(), 0.5f);
+        }
         if (isSpawnedFromWeather) {
             if (Math.random() < 0.33) {
                 for (Object s : EntityList.IDtoClassMapping.entrySet()) {


### PR DESCRIPTION
While playing, occasionally the game/world will crash with an error from Electrical Age (at least CoreTweaks catches the crash so the whole client doesn't go kaput). Apparently it is caused by `ReplicatorEntity` trying to roll `Random().nextInt` on an empty dropList. This is the error that appears:

```
[14:53:08] [Client thread/ERROR] [coretweaks/]: #@!@# Game crashed! CoreTweaks will attempt to keep the game running.
[14:53:08] [Client thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: java.lang.RuntimeException: Exception on server thread
[14:53:08] [Client thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:8009)
[14:53:08] [Client thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at net.minecraft.client.main.Main.main(SourceFile:148)
[14:53:08] [Client thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[14:53:08] [Client thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[14:53:08] [Client thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[14:53:08] [Client thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at java.lang.reflect.Method.invoke(Method.java:498)
[14:53:08] [Client thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
[14:53:08] [Client thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
[14:53:08] [Client thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:105)
[14:53:08] [Client thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
[14:53:08] [Client thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:749]: 	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
[14:53:08] [Client thread/INFO] [coretweaks/]: ---- Minecraft Crash Report ----
// Why did you do that?

Time: 12/09/25 2:53 PM
Description: Ticking entity

java.lang.IllegalArgumentException: bound must be positive
	at java.util.Random.nextInt(Random.java:388)
	at mods.eln.entity.ReplicatorEntity.func_70628_a(ReplicatorEntity.java:134)
	at net.minecraft.entity.EntityLivingBase.func_70645_a(EntityLivingBase.java:923)
	at net.minecraft.entity.EntityLivingBase.func_70097_a(EntityLivingBase.java:855)
	at net.minecraft.entity.monster.EntityMob.func_70097_a(SourceFile:54)
	at mods.eln.entity.ReplicatorEntity.func_70629_bd(ReplicatorEntity.java:79)
	at net.minecraft.entity.EntityLiving.func_70619_bc(EntityLiving.java:646)
	at net.minecraft.entity.EntityLivingBase.func_70636_d(EntityLivingBase.java:1774)
	at net.minecraft.entity.EntityLiving.func_70636_d(EntityLiving.java:452)
	at net.minecraft.entity.monster.EntityMob.func_70636_d(SourceFile:25)
	at net.minecraft.entity.EntityLivingBase.func_70071_h_(EntityLivingBase.java:1611)
	at net.minecraft.entity.EntityLiving.func_70071_h_(EntityLiving.java:272)
	at net.minecraft.entity.monster.EntityMob.func_70071_h_(SourceFile:30)
	at net.minecraft.world.World.func_72866_a(World.java:2070)
	at net.minecraft.world.WorldServer.func_72866_a(WorldServer.java:648)
	at net.minecraft.world.World.func_72870_g(World.java:2034)
	at WorldServerOF.func_72870_g(WorldServerOF.java:347)
	at net.minecraft.world.World.func_72939_s(World.java:1887)
	at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:489)
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:636)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
	at net.minecraft.server.integrated.IntegratedServer.func_71217_p(IntegratedServer.java:186)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:396)
	at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)
```

This commit should fix it though I have not been able to test it because the crash only happens every so often. Unless you can spawn a replicator and kill it using commands for testing?

a8f1243