### PR TITLE
Fixing back the crafting recipies

### DIFF
--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -445,6 +445,11 @@ public class Eln {
         if (Other.ccLoaded) {
             PeripheralHandler.register();
         }
+        registerCraftingRecipes();
+    }
+
+    private static void registerCraftingRecipes() {
+        // Ensure every recipe defined in CraftingRecipes is registered.
         CraftingRecipes.INSTANCE.itemCrafting();
     }
 


### PR DESCRIPTION
* Updated the `modsLoaded` method to call `registerCraftingRecipes()` after peripheral handling.