### PR TITLE
Remove duplicate smelting for rubber

### DIFF
--- a/src/main/kotlin/mods/eln/craft/CraftingRecipes.kt
+++ b/src/main/kotlin/mods/eln/craft/CraftingRecipes.kt
@@ -83,7 +83,6 @@ object CraftingRecipes {
         recipeWindTurbine()
         recipeFuelGenerator()
 
-        recipeGeneral()
         recipeHeatingCorp()
         recipeRegulatorItem()
         recipeLampItem()
@@ -948,10 +947,6 @@ object CraftingRecipes {
                 "Advanced Machine Block"
             )
         )
-    }
-
-    private fun recipeGeneral() {
-        addSmelting(Eln.treeResin.parentItem, Eln.treeResin.parentItemDamage, Eln.findItemStack("Rubber", 1), 0f)
     }
 
     private fun recipeHeatingCorp() {


### PR DESCRIPTION
- Deleted unused `recipeGeneral` function and its associated call.
- Cleaned up redundant smelting recipe code for `treeResin`.