### PR TITLE
Clean up `ElectricalFurnaceProcess` code, fix #387

### DIFF
--- a/src/main/java/mods/eln/transparentnode/electricalfurnace/ElectricalFurnaceProcess.java
+++ b/src/main/java/mods/eln/transparentnode/electricalfurnace/ElectricalFurnaceProcess.java
@@ -38,7 +38,6 @@ public class ElectricalFurnaceProcess implements IProcess {
         }
 
         ItemStack itemStackIn = inventory.getStackInSlot(ElectricalFurnaceElement.inSlotId);
-        ItemStack itemStackOut = inventory.getStackInSlot(ElectricalFurnaceElement.outSlotId);
         if (itemStackInOld != itemStackIn || (!smeltCan()) || !smeltInProcess) {
             smeltInit();
             itemStackInOld = itemStackIn;
@@ -69,9 +68,6 @@ public class ElectricalFurnaceProcess implements IProcess {
                 furnace.setPowerOn(false);
             }
         }
-        int i = 0;
-        i++;
-        //Utils.println("FT : " + furnace.thermalLoad.Tc);
     }
 
     double getPower() {
@@ -81,11 +77,9 @@ public class ElectricalFurnaceProcess implements IProcess {
     public void smeltInit() {
         smeltInProcess = smeltCan();
         if (!smeltInProcess) {
-            smeltInProcess = false;
             energyNeeded = 1.0;
             energyCounter = 0.0;
         } else {
-            smeltInProcess = true;
             energyNeeded = energyNeededPerSmelt;
             energyCounter = 0.0;
         }
@@ -103,8 +97,6 @@ public class ElectricalFurnaceProcess implements IProcess {
             if (inventory.getStackInSlot(ElectricalFurnaceElement.outSlotId) == null) return true;
             if (!inventory.getStackInSlot(ElectricalFurnaceElement.outSlotId).isItemEqual(var1)) return false;
             int result = inventory.getStackInSlot(ElectricalFurnaceElement.outSlotId).stackSize + var1.stackSize;
-
-            //energyNeeded = 1000.0;
             return (result <= inventory.getInventoryStackLimit() && result <= var1.getMaxStackSize());
         }
     }
@@ -117,21 +109,17 @@ public class ElectricalFurnaceProcess implements IProcess {
      * Turn one item from the furnace source stack into the appropriate smelted item in the furnace result stack
      */
     public void smeltItem() {
-        if (this.smeltCan()) {
+        if (smeltCan()) {
             ItemStack var1 = getSmeltResult();
 
             if (inventory.getStackInSlot(ElectricalFurnaceElement.outSlotId) == null) {
-                inventory.setInventorySlotContents(1, var1.copy());
+                inventory.setInventorySlotContents(ElectricalFurnaceElement.outSlotId, var1.copy());
             } else if (inventory.getStackInSlot(ElectricalFurnaceElement.outSlotId).isItemEqual(var1)) {
                 inventory.decrStackSize(ElectricalFurnaceElement.outSlotId, -var1.stackSize);
             }
 
-            /*--this.furnaceItemStacks[0].stackSize;
-
-            if (this.furnaceItemStacks[0].stackSize <= 0) {
-                this.furnaceItemStacks[0] = null;
-            }*/
             inventory.decrStackSize(ElectricalFurnaceElement.inSlotId, 1);
+            inventory.markDirty();
         }
     }
 


### PR DESCRIPTION
Primarily, fixes #387, but also some cleanup

- Removed redundant variables and unnecessary assignments.
- Deleted commented-out and unused code for better readability.
- Simplified conditional logic in `smeltInit` and `smeltItem`.
- Enhanced clarity and reduced noise in the smelting process implementation.