### PR TITLE
Refactor `SixNodeBlock` breaking logic and improve raytrace handling

### DIFF
--- a/src/main/kotlin/mods/eln/node/six/SixNodeBlock.kt
+++ b/src/main/kotlin/mods/eln/node/six/SixNodeBlock.kt
@@ -174,7 +174,6 @@ class SixNodeBlock  // public static ArrayList<Integer> repertoriedItemStackId =
     override fun removedByPlayer(world: World, entityPlayer: EntityPlayer, x: Int, y: Int, z: Int, willHarvest: Boolean): Boolean {
         if (world.isRemote) return false
         val tileEntity = world.getTileEntity(x, y, z) as SixNodeEntity
-        val MOP = collisionRayTrace(world, x, y, z, entityPlayer) ?: return false
         val sixNode = tileEntity.node as SixNode? ?: return true
         if (sixNode.sixNodeCacheBlock !== Blocks.air) {
             if (isCreative((entityPlayer as EntityPlayerMP)) == false) {
@@ -190,9 +189,9 @@ class SixNodeBlock  // public static ArrayList<Integer> repertoriedItemStackId =
             sixNode.needPublish = true
             return false
         }
-        if (false == sixNode.playerAskToBreakSubBlock(entityPlayer as EntityPlayerMP, fromIntMinecraftSide(MOP.sideHit)!!)) return false
-        @Suppress("DEPRECATION")
-        return if (sixNode.ifSideRemain) true else super.removedByPlayer(world, entityPlayer, x, y, z)
+        val breakDirection = resolveBreakDirection(world, x, y, z, entityPlayer, sixNode) ?: return false
+        if (!sixNode.playerAskToBreakSubBlock(entityPlayer as EntityPlayerMP, breakDirection)) return false
+        return if (sixNode.ifSideRemain) true else super.removedByPlayer(world, entityPlayer, x, y, z, willHarvest)
     }
 
     override fun breakBlock(par1World: World, x: Int, y: Int, z: Int, par5: Block, par6: Int) {
@@ -352,12 +351,75 @@ class SixNodeBlock  // public static ArrayList<Integer> repertoriedItemStackId =
     fun collisionRayTrace(world: World, x: Int, y: Int, z: Int, entityLiving: EntityPlayer): MovingObjectPosition? {
 
         // double distanceMax = (double)Minecraft.getMinecraft().playerController.getBlockReachDistance();
-        val distanceMax = 5.0
+        // Server player state can lag a few ticks behind under low TPS; add margin so raytrace still resolves a side.
+        val distanceMax = 8.0
         val start = Vec3.createVectorHelper(entityLiving.posX, entityLiving.posY, entityLiving.posZ)
         if (!world.isRemote) start.yCoord += 1.62
         val var5 = entityLiving.getLook(0.5f)
         val end = start.addVector(var5.xCoord * distanceMax, var5.yCoord * distanceMax, var5.zCoord * distanceMax)
         return collisionRayTrace(world, x, y, z, start, end)
+    }
+
+    private fun resolveBreakDirection(world: World, x: Int, y: Int, z: Int, entityPlayer: EntityPlayer, sixNode: SixNode): Direction? {
+        val ray = collisionRayTrace(world, x, y, z, entityPlayer)
+        val rayDirection = ray?.let { fromIntMinecraftSide(it.sideHit) }
+        if (rayDirection != null && sixNode.getSideEnable(rayDirection)) {
+            return rayDirection
+        }
+
+        // Fallback: pick the enabled face most directly facing the player's look vector.
+        val look = entityPlayer.getLook(0.5f)
+        var bestDirection: Direction? = null
+        var bestScore = Double.NEGATIVE_INFINITY
+        for (direction in Direction.values()) {
+            if (!sixNode.getSideEnable(direction)) continue
+            val score = faceFacingPlayerScore(direction, look)
+            if (score > bestScore) {
+                bestScore = score
+                bestDirection = direction
+            }
+        }
+        return bestDirection
+    }
+
+    private fun faceFacingPlayerScore(direction: Direction, look: Vec3): Double {
+        val nx: Double
+        val ny: Double
+        val nz: Double
+        when (direction) {
+            Direction.XN -> {
+                nx = -1.0
+                ny = 0.0
+                nz = 0.0
+            }
+            Direction.XP -> {
+                nx = 1.0
+                ny = 0.0
+                nz = 0.0
+            }
+            Direction.YN -> {
+                nx = 0.0
+                ny = -1.0
+                nz = 0.0
+            }
+            Direction.YP -> {
+                nx = 0.0
+                ny = 1.0
+                nz = 0.0
+            }
+            Direction.ZN -> {
+                nx = 0.0
+                ny = 0.0
+                nz = -1.0
+            }
+            Direction.ZP -> {
+                nx = 0.0
+                ny = 0.0
+                nz = 1.0
+            }
+        }
+        // The clicked face points against the player look direction.
+        return -(look.xCoord * nx + look.yCoord * ny + look.zCoord * nz)
     }
 
     fun getIfOtherBlockIsSolid(world: World, x: Int, y: Int, z: Int, direction: Direction): Boolean {


### PR DESCRIPTION
- Introduced `resolveBreakDirection` to clean up and centralize direction resolution logic.
- Increased raytrace distance to mitigate issues under low TPS environments.
- Simplified and clarified player sub-block breaking flow with improved fallback handling.