### PR TITLE
Add configurable watchdog destruction toggles and commands

### DIFF
--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -200,7 +200,11 @@ public class Eln {
     public static boolean explosionEnable;
     public static boolean debugEnabled = false;  // Read from configuration file. Default is `false`.
     public static boolean simSnapshotEnabled = false;
-    public static boolean debugExplosions = false;
+    public static boolean watchdogThermalEnabled = true;
+    public static boolean watchdogResistorHeatEnabled = false;
+    public static boolean watchdogVoltageEnabled = true;
+    public static boolean watchdogShaftSpeedEnabled = true;
+    public static boolean watchdogOtherEnabled = true;
     public static boolean versionCheckEnabled = true; // Read from configuration file. Default is `true`.
     public static boolean analyticsEnabled = true; // Read from configuration file. Default is `true`.
     public static String playerUUID = null; // Read from configuration file. Default is `null`.

--- a/src/main/java/mods/eln/sixnode/resistor/ResistorElement.java
+++ b/src/main/java/mods/eln/sixnode/resistor/ResistorElement.java
@@ -54,7 +54,7 @@ public class ResistorElement extends SixNodeElement {
         super(SixNode, side, descriptor);
         this.descriptor = (ResistorDescriptor) descriptor;
 
-        thermalWatchdog = ambientAwareThermalWatchdog(new ThermalLoadWatchDog(thermalLoad));
+        thermalWatchdog = ambientAwareThermalWatchdog(new ThermalLoadWatchDog(thermalLoad).asResistorHeatWatchdog());
 
         electricalLoadList.add(aLoad);
         electricalLoadList.add(bLoad);

--- a/src/main/kotlin/mods/eln/config/ConfigHandler.kt
+++ b/src/main/kotlin/mods/eln/config/ConfigHandler.kt
@@ -38,9 +38,22 @@ object ConfigHandler {
         Eln.debugEnabled = Eln.config["debug", "enable", false, "Enables debug printing spam"].getBoolean(false)
         Eln.simSnapshotEnabled =
             Eln.config["debug", "simSnapshot", false, "Enable circuit snapshot logging (requires debug.enable)."].getBoolean(false)
-        Eln.debugExplosions = Eln.config["debug", "watchdog", false, "Watchdog Impl. check"].getBoolean(false)
+        Eln.config["debug", "watchdogDebugNoDestroy", false, "DEPRECATED: replaced by watchdog.* typed destruction toggles."].getBoolean(false)
+        Eln.config["debug", "watchdog", false, "DEPRECATED: ignored, replaced by watchdog.* typed destruction toggles."].getBoolean(false)
         Eln.explosionEnable =
             Eln.config["gameplay", "explosion", false, "Make explosions a bit bigger"].getBoolean(true)
+
+        Eln.watchdogThermalEnabled =
+            Eln.config["watchdog", "thermal", true, "Allow thermal watchdogs to destroy blocks (except resistor heat watchdogs)."].getBoolean(true)
+        Eln.watchdogResistorHeatEnabled =
+            Eln.config["watchdog", "resistorHeat", false, "Allow resistor heat watchdogs to destroy blocks."].getBoolean(false)
+        Eln.watchdogVoltageEnabled =
+            Eln.config["watchdog", "voltage", true, "Allow voltage watchdogs to destroy blocks."].getBoolean(true)
+        Eln.config["watchdog", "electrical", true, "DEPRECATED: renamed to watchdog.voltage."].getBoolean(true)
+        Eln.watchdogShaftSpeedEnabled =
+            Eln.config["watchdog", "shaftSpeed", true, "Allow shaft speed watchdogs to destroy blocks."].getBoolean(true)
+        Eln.watchdogOtherEnabled =
+            Eln.config["watchdog", "other", true, "Allow all other watchdog types to destroy blocks."].getBoolean(true)
 
         Eln.versionCheckEnabled =
             Eln.config["general", "versionCheckEnable", true, "Enable version checker"].getBoolean(true)

--- a/src/main/kotlin/mods/eln/server/console/ElnConsoleCommands.kt
+++ b/src/main/kotlin/mods/eln/server/console/ElnConsoleCommands.kt
@@ -1053,26 +1053,15 @@ class ElnExplosionsCommand: IConsoleCommand {
     override val name = "explosions"
 
     override fun runCommand(ics: ICommandSender, args: List<String>) {
-        when (args.size) {
-            1 -> {
-                val explosions = getArgBool(ics, args[0]) ?: return
-                Eln.explosionEnable = explosions
-                val nonsense = false
-                Eln.config.get("gameplay", "explosion", nonsense).set(Eln.explosionEnable)
-                Eln.config.save()
-                cprint(ics, "Explosions: ${FC.DARK_GREEN}${boolToStr(explosions)}", indent = 1)
-            }
-            2 -> {
-                if (!args[0].equals("debug", ignoreCase = true)) return
-                val debugWatchdog = getArgBool(ics, args[1]) ?: return
-                val nonsense = false
-                Eln.config.get("debug", "watchdog", nonsense).set(Eln.debugExplosions)
-                Eln.config.save()
-                cprint(ics, "The debug watchdog is now ${FC.DARK_GREEN}${boolToStr(debugWatchdog)}", indent = 1)
-            }
-            else -> {
-                cprint(ics, "This command only takes one argument - true or false")
-            }
+        if (args.size == 1) {
+            val explosions = getArgBool(ics, args[0]) ?: return
+            Eln.explosionEnable = explosions
+            val nonsense = false
+            Eln.config.get("gameplay", "explosion", nonsense).set(Eln.explosionEnable)
+            Eln.config.save()
+            cprint(ics, "Explosions: ${FC.DARK_GREEN}${boolToStr(explosions)}", indent = 1)
+        } else {
+            cprint(ics, "This command only takes one argument - true or false")
         }
     }
 
@@ -1094,6 +1083,101 @@ class ElnExplosionsCommand: IConsoleCommand {
         } else {
             return options.filter {it.startsWith(args[0], ignoreCase = true)}
         }
+    }
+}
+
+class ElnWatchdogCommand: IConsoleCommand {
+    override val name = "watchdog"
+    private val validTypes = listOf("all", "thermal", "resistorHeat", "voltage", "shaftSpeed", "other", "defaults")
+
+    override fun runCommand(ics: ICommandSender, args: List<String>) {
+        if (args.isEmpty() || args.size > 2) {
+            cprint(ics, "Usage: /eln watchdog <type> [true|false]", indent = 1)
+            cprint(ics, "Types: ${validTypes.joinToString(", ")}", indent = 1)
+            return
+        }
+        val type = validTypes.firstOrNull { it.equals(args[0], ignoreCase = true) } ?: run {
+            cprint(ics, "Unknown watchdog type '${args[0]}'.", indent = 1)
+            cprint(ics, "Types: ${validTypes.joinToString(", ")}", indent = 1)
+            return
+        }
+        if (type.equals("defaults", ignoreCase = true)) {
+            if (args.size != 1) {
+                cprint(ics, "Usage: /eln watchdog defaults", indent = 1)
+                return
+            }
+            applyDefaults()
+            saveWatchdogConfig()
+            cprint(ics, "Watchdog defaults restored (thermal=true, resistorHeat=false, voltage=true, shaftSpeed=true, other=true).", indent = 1)
+            return
+        }
+        if (args.size != 2) {
+            cprint(ics, "Usage: /eln watchdog <type> <true|false>", indent = 1)
+            return
+        }
+        val watchdogEnabled = getArgBool(ics, args[1]) ?: return
+
+        when (type.lowercase()) {
+            "all" -> {
+                Eln.watchdogThermalEnabled = watchdogEnabled
+                Eln.watchdogResistorHeatEnabled = watchdogEnabled
+                Eln.watchdogVoltageEnabled = watchdogEnabled
+                Eln.watchdogShaftSpeedEnabled = watchdogEnabled
+                Eln.watchdogOtherEnabled = watchdogEnabled
+            }
+            "thermal" -> Eln.watchdogThermalEnabled = watchdogEnabled
+            "resistorheat" -> Eln.watchdogResistorHeatEnabled = watchdogEnabled
+            "voltage" -> Eln.watchdogVoltageEnabled = watchdogEnabled
+            "shaftspeed" -> Eln.watchdogShaftSpeedEnabled = watchdogEnabled
+            "other" -> Eln.watchdogOtherEnabled = watchdogEnabled
+        }
+
+        saveWatchdogConfig()
+
+        if (type.equals("all", ignoreCase = true)) {
+            cprint(ics, "All watchdog destruction: ${FC.DARK_GREEN}${boolToStr(watchdogEnabled)}", indent = 1)
+        } else {
+            cprint(ics, "Watchdog '$type' destruction: ${FC.DARK_GREEN}${boolToStr(watchdogEnabled)}", indent = 1)
+        }
+    }
+
+    private fun applyDefaults() {
+        Eln.watchdogThermalEnabled = true
+        Eln.watchdogResistorHeatEnabled = false
+        Eln.watchdogVoltageEnabled = true
+        Eln.watchdogShaftSpeedEnabled = true
+        Eln.watchdogOtherEnabled = true
+    }
+
+    private fun saveWatchdogConfig() {
+        Eln.config.get("watchdog", "thermal", true).set(Eln.watchdogThermalEnabled)
+        Eln.config.get("watchdog", "resistorHeat", false).set(Eln.watchdogResistorHeatEnabled)
+        Eln.config.get("watchdog", "voltage", true).set(Eln.watchdogVoltageEnabled)
+        Eln.config.get("watchdog", "shaftSpeed", true).set(Eln.watchdogShaftSpeedEnabled)
+        Eln.config.get("watchdog", "other", true).set(Eln.watchdogOtherEnabled)
+        Eln.config.save()
+    }
+
+    override fun getManPage(ics: ICommandSender, args: List<String>) {
+        cprint(ics, "Enable or disable destruction for one watchdog category at runtime.", indent = 1)
+        cprint(ics, "Use defaults to restore the default watchdog profile.", indent = 1)
+        cprint(ics, "This also updates Eln.cfg.", indent = 1)
+        cprint(ics, "")
+        cprint(ics, "Parameters:", indent = 1)
+        cprint(ics, "@0:string : Watchdog type (all, thermal, resistorHeat, voltage, shaftSpeed, other, defaults).", indent = 2)
+        cprint(ics, "@1:bool : Destruction state (enabled/disabled). Not used by defaults.", indent = 2)
+        cprint(ics, "")
+    }
+
+    override fun requiredPermission() = listOf(UserPermission.IS_OPERATOR)
+
+    override fun getTabCompletion(args: List<String>): List<String> {
+        if (args.isEmpty() || args[0].isEmpty()) return validTypes
+        if (args.size == 1) return validTypes.filter { it.startsWith(args[0], ignoreCase = true) }
+        val boolOptions = listOf("true", "false")
+        if (args[0].equals("defaults", ignoreCase = true)) return listOf()
+        if (args.size == 2) return boolOptions.filter { it.startsWith(args[1], ignoreCase = true) }
+        return listOf()
     }
 }
 

--- a/src/main/kotlin/mods/eln/server/console/ElnConsoleHandler.kt
+++ b/src/main/kotlin/mods/eln/server/console/ElnConsoleHandler.kt
@@ -32,6 +32,7 @@ class ElnConsoleCommands: ICommand {
             ElnDebugCommand(),
             ElnSimSnapshotCommand(),
             ElnExplosionsCommand(),
+            ElnWatchdogCommand(),
             ElnIconsCommand(),
             ElnPoleMapCommand(),
             ElnStopShaftCommand(),

--- a/src/main/kotlin/mods/eln/sim/process/destruct/BipoleVoltageWatchdog.kt
+++ b/src/main/kotlin/mods/eln/sim/process/destruct/BipoleVoltageWatchdog.kt
@@ -3,6 +3,7 @@ package mods.eln.sim.process.destruct
 import mods.eln.sim.mna.component.Bipole
 
 class BipoleVoltageWatchdog(var bipole: Bipole) : ValueWatchdog() {
+    override val watchdogType = WatchdogType.VOLTAGE
 
     fun setNominalVoltage(nominalVoltage: Double): BipoleVoltageWatchdog {
         max = nominalVoltage * 1.3

--- a/src/main/kotlin/mods/eln/sim/process/destruct/ResistorPowerWatchdog.kt
+++ b/src/main/kotlin/mods/eln/sim/process/destruct/ResistorPowerWatchdog.kt
@@ -3,6 +3,7 @@ package mods.eln.sim.process.destruct
 import mods.eln.sim.mna.component.Resistor
 
 class ResistorPowerWatchdog(var resistor: Resistor) : ValueWatchdog() {
+    override val watchdogType = WatchdogType.RESISTOR_HEAT
 
     fun setMaximumPower(maximumPower: Double): ResistorPowerWatchdog {
         max = maximumPower

--- a/src/main/kotlin/mods/eln/sim/process/destruct/ShaftSpeedWatchdog.kt
+++ b/src/main/kotlin/mods/eln/sim/process/destruct/ShaftSpeedWatchdog.kt
@@ -3,6 +3,7 @@ package mods.eln.sim.process.destruct
 import mods.eln.mechanical.ShaftElement
 
 class ShaftSpeedWatchdog(private val shaftElement: ShaftElement, max: Double) : ValueWatchdog() {
+    override val watchdogType = WatchdogType.SHAFT_SPEED
 
     init {
         this.max = max

--- a/src/main/kotlin/mods/eln/sim/process/destruct/ThermalLoadWatchDog.kt
+++ b/src/main/kotlin/mods/eln/sim/process/destruct/ThermalLoadWatchDog.kt
@@ -8,6 +8,10 @@ import mods.eln.sim.ThermalLoadInitializerByPowerDrop
 import java.util.Locale
 
 class ThermalLoadWatchDog(var state: ThermalLoad): ValueWatchdog() {
+    private var type = WatchdogType.THERMAL
+    override val watchdogType: WatchdogType
+        get() = type
+
     private var lastTemperature = state.temperature
     private var lastDeltaPerSecond = 0.0
     private var matrixDumpSupplier: (() -> Any?)? = null
@@ -91,6 +95,11 @@ class ThermalLoadWatchDog(var state: ThermalLoad): ValueWatchdog() {
 
     fun setAmbientTemperatureProvider(provider: () -> Double): ThermalLoadWatchDog {
         ambientTemperatureProvider = provider
+        return this
+    }
+
+    fun asResistorHeatWatchdog(): ThermalLoadWatchDog {
+        type = WatchdogType.RESISTOR_HEAT
         return this
     }
 }

--- a/src/main/kotlin/mods/eln/sim/process/destruct/ValueWatchdog.kt
+++ b/src/main/kotlin/mods/eln/sim/process/destruct/ValueWatchdog.kt
@@ -5,6 +5,14 @@ import mods.eln.misc.Utils
 import mods.eln.misc.Utils.println
 import mods.eln.sim.IProcess
 
+enum class WatchdogType {
+    THERMAL,
+    RESISTOR_HEAT,
+    VOLTAGE,
+    SHAFT_SPEED,
+    OTHER
+}
+
 abstract class ValueWatchdog : IProcess {
     private var destructible: IDestructible? = null
     var min = 0.0
@@ -15,6 +23,8 @@ abstract class ValueWatchdog : IProcess {
 
     // TODO: Rename. Hysteresis?
     private var joker = true
+    protected open val watchdogType: WatchdogType = WatchdogType.OTHER
+
     override fun process(time: Double) {
         if (boot) {
             boot = false
@@ -36,12 +46,30 @@ abstract class ValueWatchdog : IProcess {
         }
         if (timeout < 0) {
             onDestroy(value, overflow)
-            println(
-                "%s destroying %s",
-                javaClass.name,
-                destructible?.describe()?: "Null destructible"
-            )
-            if (!Eln.debugExplosions) destructible?.destructImpl()
+            if (isWatchdogDestructionEnabled()) {
+                println(
+                    "%s destroying %s",
+                    javaClass.name,
+                    destructible?.describe()?: "Null destructible"
+                )
+                destructible?.destructImpl()
+            } else {
+                println(
+                    "%s tripped (destruction disabled) for %s",
+                    javaClass.name,
+                    destructible?.describe() ?: "Null destructible"
+                )
+            }
+        }
+    }
+
+    private fun isWatchdogDestructionEnabled(): Boolean {
+        return when (watchdogType) {
+            WatchdogType.THERMAL -> Eln.watchdogThermalEnabled
+            WatchdogType.RESISTOR_HEAT -> Eln.watchdogResistorHeatEnabled
+            WatchdogType.VOLTAGE -> Eln.watchdogVoltageEnabled
+            WatchdogType.SHAFT_SPEED -> Eln.watchdogShaftSpeedEnabled
+            WatchdogType.OTHER -> Eln.watchdogOtherEnabled
         }
     }
 

--- a/src/main/kotlin/mods/eln/sim/process/destruct/VoltageStateWatchDog.kt
+++ b/src/main/kotlin/mods/eln/sim/process/destruct/VoltageStateWatchDog.kt
@@ -3,6 +3,7 @@ package mods.eln.sim.process.destruct
 import mods.eln.sim.mna.state.VoltageState
 
 class VoltageStateWatchDog(var state: VoltageState): ValueWatchdog() {
+    override val watchdogType = WatchdogType.VOLTAGE
 
     override fun getValue(): Double {
         return state.voltage

--- a/src/test/kotlin/mods/eln/sim/process/destruct/ThermalLoadWatchDogTest.kt
+++ b/src/test/kotlin/mods/eln/sim/process/destruct/ThermalLoadWatchDogTest.kt
@@ -1,7 +1,9 @@
 package mods.eln.sim.process.destruct
 
+import mods.eln.Eln
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import mods.eln.sim.ThermalLoad
@@ -59,5 +61,37 @@ class ThermalLoadWatchDogTest {
             .setTemperatureLimits(100.0, -40.0)
 
         assertTrue(watchdog.getValue() > watchdog.max, "Absolute temperature should exceed configured max.")
+    }
+
+    @Test
+    fun resistorHeatModeUsesResistorHeatToggle() {
+        val previousResistor = Eln.watchdogResistorHeatEnabled
+        val previousThermal = Eln.watchdogThermalEnabled
+        Eln.watchdogResistorHeatEnabled = false
+        Eln.watchdogThermalEnabled = true
+        try {
+            val load = ThermalLoad().apply { temperatureCelsius = 100.0 }
+            val target = object : IDestructible {
+                var destroyed = false
+                override fun destructImpl() {
+                    destroyed = true
+                }
+
+                override fun describe(): String = "resistor"
+            }
+            val watchdog = ThermalLoadWatchDog(load).asResistorHeatWatchdog()
+            watchdog.setDestroys(target)
+            watchdog.max = 1.0
+            watchdog.min = -1.0
+            watchdog.timeoutReset = 0.0
+
+            watchdog.process(1.0)
+            watchdog.process(1.0)
+
+            assertFalse(target.destroyed)
+        } finally {
+            Eln.watchdogResistorHeatEnabled = previousResistor
+            Eln.watchdogThermalEnabled = previousThermal
+        }
     }
 }

--- a/src/test/kotlin/mods/eln/sim/process/destruct/ValueWatchdogTest.kt
+++ b/src/test/kotlin/mods/eln/sim/process/destruct/ValueWatchdogTest.kt
@@ -1,6 +1,8 @@
 package mods.eln.sim.process.destruct
 
+import mods.eln.Eln
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import mods.eln.disableLog4jJmx
 
@@ -14,7 +16,6 @@ private class StubDestructible : IDestructible {
 }
 
 private class TestWatchdog(private var watchedValue: Double) : ValueWatchdog() {
-    var destroyed = false
     var destroyCalled = false
 
     override fun getValue(): Double = watchedValue
@@ -48,5 +49,27 @@ class ValueWatchdogTest {
         watchdog.boot = false
         watchdog.reset()
         assertTrue(watchdog.boot)
+    }
+
+    @Test
+    fun disabledOtherWatchdogsDoNotDestroy() {
+        val previous = Eln.watchdogOtherEnabled
+        Eln.watchdogOtherEnabled = false
+        try {
+            val watchdog = TestWatchdog(10.0)
+            val target = StubDestructible()
+            watchdog.setDestroys(target)
+            watchdog.max = 1.0
+            watchdog.min = -1.0
+            watchdog.timeoutReset = 0.0
+
+            watchdog.process(1.0)
+            watchdog.process(1.0)
+
+            assertTrue(watchdog.destroyCalled)
+            assertFalse(target.destroyed)
+        } finally {
+            Eln.watchdogOtherEnabled = previous
+        }
     }
 }


### PR DESCRIPTION
Improves #399 

- Introduced per-type watchdog destruction toggles: `thermal`, `resistorHeat`, `voltage`, `shaftSpeed`, and `other` with corresponding configuration entries.
- Implemented `/eln watchdog` command for runtime toggle management and default restoration.
- Enhanced `ValueWatchdog` with `WatchdogType` enum for typed destruction handling.
- Updated `ThermalLoadWatchDog` to support `resistorHeat` mode destruction toggles.
- Refactored watchdogs to use typed destruction logic and maintain consistency.