### PR TITLE
Add simulator metrics subsystem with MQTT support

### DIFF
--- a/docs/sim-metrics-mqtt.md
+++ b/docs/sim-metrics-mqtt.md
@@ -1,0 +1,62 @@
+# Simulator MQTT Metrics
+
+This feature publishes low-overhead MNA simulator metrics to MQTT.
+
+The design goal is minimal simulator impact:
+
+- Metrics are captured with primitive counters in the MNA code path.
+- Publishing is batched by `integrations.mqtt.simMetrics.publishIntervalTicks`.
+- Network writes happen on a dedicated async thread (`eln-sim-metrics`), not on the simulator thread.
+
+## Configuration
+
+Configure in the main mod config under `integrations.mqtt`:
+
+- `enabled`: enables MQTT support globally.
+- `simMetrics.enabled`: enables simulator metrics publishing.
+- `simMetrics.server`: MQTT server name from `config/eln/mqtt.json`.
+- `simMetrics.id`: stream ID used in topic paths (default `server`).
+- `simMetrics.publishIntervalTicks`: number of simulator ticks per publish batch (default `20`).
+
+`config/eln/mqtt.json` still defines broker connection info (name/uri/credentials/prefix) as used by MQTT meters/controllers.
+
+## Topics
+
+`$id` below is `integrations.mqtt.simMetrics.id`.
+`$prefix` below is the optional per-server MQTT prefix from `config/eln/mqtt.json`.
+
+Base topic:
+
+- `$prefix/eln/sim/$id`
+
+Stat topics:
+
+- `.../stat/subsystems`
+- `.../stat/inversions`
+- `.../stat/singular_matrices`
+- `.../stat/inversion_avg_ns`
+- `.../stat/inversion_max_ns`
+- `.../stat/tick_us`
+- `.../stat/electrical_us`
+- `.../stat/thermal_fast_us`
+- `.../stat/thermal_slow_us`
+- `.../stat/slow_us`
+- `.../stat/subsystems_current`
+- `.../stat/electrical_processes`
+- `.../stat/thermal_fast_loads`
+- `.../stat/thermal_fast_connections`
+- `.../stat/thermal_fast_processes`
+- `.../stat/thermal_slow_loads`
+- `.../stat/thermal_slow_connections`
+- `.../stat/thermal_slow_processes`
+- `.../stat/slow_processes`
+
+Info topics (retained):
+
+- `.../info/source` (`simulator`)
+- `.../info/id` (stream ID)
+
+## Notes
+
+- If `integrations.mqtt.simMetrics.enabled=true` and `integrations.mqtt.simMetrics.server` is blank, metrics are not published and a warning is logged.
+- This replaces Prometheus/CloudWatch ingestion for simulator metrics with MQTT outputs only.

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -42,6 +42,7 @@ import mods.eln.lightblock.LightBlock;
 import mods.eln.lightblock.LightBlockEntity;
 import mods.eln.misc.*;
 import mods.eln.mqtt.MqttManager;
+import mods.eln.metrics.MetricsSubsystem;
 import mods.eln.node.NodeBlockEntity;
 import mods.eln.node.NodeManager;
 import mods.eln.node.NodeManagerNbt;
@@ -198,6 +199,12 @@ public class Eln {
     public static OreItem oreItem;
     public static PortableNaNDescriptor portableNaNDescriptor = null;
     public static CableRenderDescriptor stdPortableNaN = null;
+    public static boolean mqttEnabled = false;
+    public static boolean simMetricsEnabled = false;
+    public static String simMetricsMqttServer = "";
+    public static String simMetricsId = "server";
+    public static int simMetricsPublishIntervalTicks = 20;
+    public static boolean debugEnabled = false;
     public static SiliconWafer siliconWafer;
     public static Transistor transistor;
     public static Thermistor thermistor;
@@ -331,6 +338,7 @@ public class Eln {
         config.writeExampleFile();
         FuelRegistry.init(event.getSuggestedConfigurationFile());
         MqttManager.init();
+        MetricsSubsystem.refreshFromConfig();
 
         eventChannel = NetworkRegistry.INSTANCE.newEventDrivenChannel(channelName);
 
@@ -543,6 +551,7 @@ public class Eln {
         LampSupplyElement.channelMap.clear();
         WirelessSignalTxElement.channelMap.clear();
         MqttManager.shutdown();
+        MetricsSubsystem.shutdown();
     }
 
     @EventHandler

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -41,6 +41,7 @@ import mods.eln.item.electricalitem.OreColorMapping;
 import mods.eln.item.electricalitem.PortableOreScannerItem.RenderStorage.OreScannerConfigElement;
 import mods.eln.misc.*;
 import mods.eln.mqtt.MqttManager;
+import mods.eln.metrics.MetricsSubsystem;
 import mods.eln.node.NodeBlockEntity;
 import mods.eln.node.NodeManager;
 import mods.eln.node.NodeManagerNbt;
@@ -196,6 +197,12 @@ public class Eln {
     public static OreItem oreItem;
     public static PortableNaNDescriptor portableNaNDescriptor = null;
     public static CableRenderDescriptor stdPortableNaN = null;
+    public static boolean mqttEnabled = false;
+    public static boolean simMetricsEnabled = false;
+    public static String simMetricsMqttServer = "";
+    public static String simMetricsId = "server";
+    public static int simMetricsPublishIntervalTicks = 20;
+    public static boolean debugEnabled = false;
     public static SiliconWafer siliconWafer;
     public static Transistor transistor;
     public static Thermistor thermistor;
@@ -329,6 +336,7 @@ public class Eln {
         config.writeExampleFile();
         FuelRegistry.init(event.getSuggestedConfigurationFile());
         MqttManager.init();
+        MetricsSubsystem.refreshFromConfig();
 
         eventChannel = NetworkRegistry.INSTANCE.newEventDrivenChannel(channelName);
 
@@ -539,6 +547,7 @@ public class Eln {
         LampSupplyElement.channelMap.clear();
         WirelessSignalTxElement.channelMap.clear();
         MqttManager.shutdown();
+        MetricsSubsystem.shutdown();
     }
 
     @EventHandler

--- a/src/main/java/mods/eln/sim/Simulator.java
+++ b/src/main/java/mods/eln/sim/Simulator.java
@@ -4,8 +4,10 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent.Phase;
 import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
+import mods.eln.Eln;
 import mods.eln.environment.RoomThermalManager;
 import mods.eln.item.lampitem.LampLists;
+import mods.eln.metrics.MetricsSubsystem;
 import mods.eln.misc.Utils;
 import mods.eln.sim.mna.RootSystem;
 import mods.eln.sim.mna.component.Component;
@@ -431,6 +433,11 @@ public class Simulator /* ,IPacketHandler */ {
             thermalFastNsStack /= 20;
             thermalSlowNsStack /= 20;
             slowNsStack /= 20;
+            double avgTickMicroseconds = avgTickTime;
+            double electricalMicroseconds = electricalNsStack / 1000.0;
+            double thermalFastMicroseconds = thermalFastNsStack / 1000.0;
+            double thermalSlowMicroseconds = thermalSlowNsStack / 1000.0;
+            double slowMicroseconds = slowNsStack / 1000.0;
 
             Utils.println("ticks " + new DecimalFormat("#").format((int) avgTickTime) + " us" + "  E " + electricalNsStack / 1000 + "  TF " + thermalFastNsStack / 1000 + "  TS " + thermalSlowNsStack / 1000 + "  S " + slowNsStack / 1000
 
@@ -444,6 +451,24 @@ public class Simulator /* ,IPacketHandler */ {
                 + "    " + thermalSlowProcessList.size() + " TSP"
                 + "    " + slowProcessList.size() + " SP"
             );
+            if (Eln.simMetricsEnabled) {
+                MetricsSubsystem.publishSimulatorRuntimeMetrics(
+                    avgTickMicroseconds,
+                    electricalMicroseconds,
+                    thermalFastMicroseconds,
+                    thermalSlowMicroseconds,
+                    slowMicroseconds,
+                    mna.getSubSystemCount(),
+                    electricalProcessList.size(),
+                    thermalFastLoadList.size(),
+                    thermalFastConnectionList.size(),
+                    thermalFastProcessList.size(),
+                    thermalSlowLoadList.size(),
+                    thermalSlowConnectionList.size(),
+                    thermalSlowProcessList.size(),
+                    slowProcessList.size()
+                );
+            }
 
             avgTickTime = 0;
 

--- a/src/main/java/mods/eln/sim/Simulator.java
+++ b/src/main/java/mods/eln/sim/Simulator.java
@@ -451,7 +451,7 @@ public class Simulator /* ,IPacketHandler */ {
                 + "    " + thermalSlowProcessList.size() + " TSP"
                 + "    " + slowProcessList.size() + " SP"
             );
-            if (Eln.simMetricsEnabled) {
+            if (MetricsSubsystem.isSimulatorMetricsActive()) {
                 MetricsSubsystem.publishSimulatorRuntimeMetrics(
                     avgTickMicroseconds,
                     electricalMicroseconds,

--- a/src/main/java/mods/eln/sim/Simulator.java
+++ b/src/main/java/mods/eln/sim/Simulator.java
@@ -4,7 +4,9 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent.Phase;
 import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
+import mods.eln.Eln;
 import mods.eln.environment.RoomThermalManager;
+import mods.eln.metrics.MetricsSubsystem;
 import mods.eln.misc.Utils;
 import mods.eln.sim.mna.RootSystem;
 import mods.eln.sim.mna.component.Component;
@@ -429,6 +431,11 @@ public class Simulator /* ,IPacketHandler */ {
             thermalFastNsStack /= 20;
             thermalSlowNsStack /= 20;
             slowNsStack /= 20;
+            double avgTickMicroseconds = avgTickTime;
+            double electricalMicroseconds = electricalNsStack / 1000.0;
+            double thermalFastMicroseconds = thermalFastNsStack / 1000.0;
+            double thermalSlowMicroseconds = thermalSlowNsStack / 1000.0;
+            double slowMicroseconds = slowNsStack / 1000.0;
 
             Utils.println("ticks " + new DecimalFormat("#").format((int) avgTickTime) + " us" + "  E " + electricalNsStack / 1000 + "  TF " + thermalFastNsStack / 1000 + "  TS " + thermalSlowNsStack / 1000 + "  S " + slowNsStack / 1000
 
@@ -442,6 +449,24 @@ public class Simulator /* ,IPacketHandler */ {
                 + "    " + thermalSlowProcessList.size() + " TSP"
                 + "    " + slowProcessList.size() + " SP"
             );
+            if (Eln.simMetricsEnabled) {
+                MetricsSubsystem.publishSimulatorRuntimeMetrics(
+                    avgTickMicroseconds,
+                    electricalMicroseconds,
+                    thermalFastMicroseconds,
+                    thermalSlowMicroseconds,
+                    slowMicroseconds,
+                    mna.getSubSystemCount(),
+                    electricalProcessList.size(),
+                    thermalFastLoadList.size(),
+                    thermalFastConnectionList.size(),
+                    thermalFastProcessList.size(),
+                    thermalSlowLoadList.size(),
+                    thermalSlowConnectionList.size(),
+                    thermalSlowProcessList.size(),
+                    slowProcessList.size()
+                );
+            }
 
             avgTickTime = 0;
 

--- a/src/main/java/mods/eln/sim/mna/MnaStepMetricsAccumulator.java
+++ b/src/main/java/mods/eln/sim/mna/MnaStepMetricsAccumulator.java
@@ -1,0 +1,76 @@
+package mods.eln.sim.mna;
+
+public class MnaStepMetricsAccumulator {
+    private int subSystemCount;
+    private int inversionCount;
+    private int singularMatrixCount;
+    private long inversionTotalNanoseconds;
+    private long inversionMaxNanoseconds;
+
+    public void reset() {
+        subSystemCount = 0;
+        inversionCount = 0;
+        singularMatrixCount = 0;
+        inversionTotalNanoseconds = 0L;
+        inversionMaxNanoseconds = 0L;
+    }
+
+    public void setSubSystemCount(int value) {
+        subSystemCount = value;
+    }
+
+    public void addInversion(long nanoseconds) {
+        inversionCount++;
+        inversionTotalNanoseconds += nanoseconds;
+        if (nanoseconds > inversionMaxNanoseconds) {
+            inversionMaxNanoseconds = nanoseconds;
+        }
+    }
+
+    public void addInversions(int count, long totalNanoseconds, long maxNanoseconds) {
+        if (count <= 0) {
+            return;
+        }
+        inversionCount += count;
+        inversionTotalNanoseconds += totalNanoseconds;
+        if (maxNanoseconds > inversionMaxNanoseconds) {
+            inversionMaxNanoseconds = maxNanoseconds;
+        }
+    }
+
+    public void addSingular(int count) {
+        singularMatrixCount += count;
+    }
+
+    public void add(MnaStepMetricsAccumulator other) {
+        inversionCount += other.inversionCount;
+        singularMatrixCount += other.singularMatrixCount;
+        inversionTotalNanoseconds += other.inversionTotalNanoseconds;
+        if (other.inversionMaxNanoseconds > inversionMaxNanoseconds) {
+            inversionMaxNanoseconds = other.inversionMaxNanoseconds;
+        }
+    }
+
+    public int getSubSystemCount() {
+        return subSystemCount;
+    }
+
+    public int getInversionCount() {
+        return inversionCount;
+    }
+
+    public int getSingularMatrixCount() {
+        return singularMatrixCount;
+    }
+
+    public long getInversionMaxNanoseconds() {
+        return inversionMaxNanoseconds;
+    }
+
+    public double getInversionAverageNanoseconds() {
+        if (inversionCount <= 0) {
+            return 0.0;
+        }
+        return (double) inversionTotalNanoseconds / inversionCount;
+    }
+}

--- a/src/main/java/mods/eln/sim/mna/RootSystem.java
+++ b/src/main/java/mods/eln/sim/mna/RootSystem.java
@@ -1,5 +1,7 @@
 package mods.eln.sim.mna;
 
+import mods.eln.Eln;
+import mods.eln.metrics.MetricsSubsystem;
 import mods.eln.misc.Profiler;
 import mods.eln.misc.Utils;
 import mods.eln.sim.ElectricalLoad;
@@ -12,6 +14,9 @@ import mods.eln.sim.mna.state.VoltageState;
 import java.util.*;
 
 public class RootSystem {
+    private final MnaStepMetricsAccumulator stepMetricsAccumulator = new MnaStepMetricsAccumulator();
+    private final MnaStepMetricsAccumulator publishMetricsAccumulator = new MnaStepMetricsAccumulator();
+    private int publishTickCounter = 0;
 
     double dt;
     int interSystemOverSampling;
@@ -240,6 +245,32 @@ public class RootSystem {
         }
 
         profiler.stop();
+
+        if (Eln.simMetricsEnabled) {
+            collectAndPublishSimMetrics();
+        }
+    }
+
+    private void collectAndPublishSimMetrics() {
+        stepMetricsAccumulator.reset();
+        stepMetricsAccumulator.setSubSystemCount(systems.size());
+        for (SubSystem s : systems) {
+            s.drainMnaMetrics(stepMetricsAccumulator);
+        }
+        publishMetricsAccumulator.setSubSystemCount(stepMetricsAccumulator.getSubSystemCount());
+        publishMetricsAccumulator.add(stepMetricsAccumulator);
+        publishTickCounter++;
+        if (publishTickCounter >= Eln.simMetricsPublishIntervalTicks) {
+            MetricsSubsystem.publishMnaMetrics(
+                    publishMetricsAccumulator.getSubSystemCount(),
+                    publishMetricsAccumulator.getInversionCount(),
+                    publishMetricsAccumulator.getSingularMatrixCount(),
+                    publishMetricsAccumulator.getInversionAverageNanoseconds(),
+                    publishMetricsAccumulator.getInversionMaxNanoseconds()
+            );
+            publishMetricsAccumulator.reset();
+            publishTickCounter = 0;
+        }
     }
 
     private void buildSubSystem(State root) {

--- a/src/main/java/mods/eln/sim/mna/RootSystem.java
+++ b/src/main/java/mods/eln/sim/mna/RootSystem.java
@@ -246,7 +246,7 @@ public class RootSystem {
 
         profiler.stop();
 
-        if (Eln.simMetricsEnabled) {
+        if (MetricsSubsystem.isSimulatorMetricsActive()) {
             collectAndPublishSimMetrics();
         }
     }

--- a/src/main/java/mods/eln/sim/mna/SubSystem.java
+++ b/src/main/java/mods/eln/sim/mna/SubSystem.java
@@ -32,6 +32,10 @@ public class SubSystem {
     int stateCount;
     double[][] A;
     boolean singularMatrix;
+    private int singularMatrixCountSinceLastDrain = 0;
+    private int inversionCountSinceLastDrain = 0;
+    private long inversionTotalNanosecondsSinceLastDrain = 0L;
+    private long inversionMaximumNanosecondsSinceLastDrain = 0L;
 
     DD[][] AInvdata;
     double[] Idata;
@@ -122,15 +126,23 @@ public class SubSystem {
 
         //	org.apache.commons.math3.linear.
 
+        long inversionStartNanoseconds = Eln.simMetricsEnabled ? System.nanoTime() : 0L;
         try {
             AInvdata = invertMatrix(A);
             singularMatrix = false;
+            if (Eln.simMetricsEnabled) {
+                long inversionTimeNanoseconds = System.nanoTime() - inversionStartNanoseconds;
+                inversionCountSinceLastDrain++;
+                inversionTotalNanosecondsSinceLastDrain += inversionTimeNanoseconds;
+                if (inversionTimeNanoseconds > inversionMaximumNanosecondsSinceLastDrain) {
+                    inversionMaximumNanosecondsSinceLastDrain = inversionTimeNanoseconds;
+                }
+            }
         } catch (Exception e) {
             singularMatrix = true;
             AInvdata = null;
             if (stateCount > 1) {
-                int idx = 0;
-                idx++;
+                singularMatrixCountSinceLastDrain++;
                 Utils.println("//////////SingularMatrix////////////");
             }
         }
@@ -234,6 +246,23 @@ public class SubSystem {
     public void step() {
         stepCalc();
         stepFlush();
+    }
+
+    public void drainMnaMetrics(MnaStepMetricsAccumulator accumulator) {
+        if (singularMatrixCountSinceLastDrain != 0) {
+            accumulator.addSingular(singularMatrixCountSinceLastDrain);
+            singularMatrixCountSinceLastDrain = 0;
+        }
+        if (inversionCountSinceLastDrain != 0) {
+            accumulator.addInversions(
+                    inversionCountSinceLastDrain,
+                    inversionTotalNanosecondsSinceLastDrain,
+                    inversionMaximumNanosecondsSinceLastDrain
+            );
+            inversionCountSinceLastDrain = 0;
+            inversionTotalNanosecondsSinceLastDrain = 0L;
+            inversionMaximumNanosecondsSinceLastDrain = 0L;
+        }
     }
 
     public void stepCalc() {

--- a/src/main/java/mods/eln/sim/mna/SubSystem.java
+++ b/src/main/java/mods/eln/sim/mna/SubSystem.java
@@ -2,6 +2,7 @@ package mods.eln.sim.mna;
 
 import mods.eln.misc.Profiler;
 import mods.eln.misc.Utils;
+import mods.eln.metrics.MetricsSubsystem;
 import mods.eln.sim.mna.component.*;
 import mods.eln.sim.mna.misc.IDestructor;
 import mods.eln.sim.mna.misc.ISubSystemProcessFlush;
@@ -126,11 +127,12 @@ public class SubSystem {
 
         //	org.apache.commons.math3.linear.
 
-        long inversionStartNanoseconds = Eln.simMetricsEnabled ? System.nanoTime() : 0L;
+        boolean captureMetrics = MetricsSubsystem.isSimulatorMetricsActive();
+        long inversionStartNanoseconds = captureMetrics ? System.nanoTime() : 0L;
         try {
             AInvdata = invertMatrix(A);
             singularMatrix = false;
-            if (Eln.simMetricsEnabled) {
+            if (captureMetrics) {
                 long inversionTimeNanoseconds = System.nanoTime() - inversionStartNanoseconds;
                 inversionCountSinceLastDrain++;
                 inversionTotalNanosecondsSinceLastDrain += inversionTimeNanoseconds;

--- a/src/main/kotlin/mods/eln/config/JsonConfig.kt
+++ b/src/main/kotlin/mods/eln/config/JsonConfig.kt
@@ -4,6 +4,7 @@ import com.google.gson.GsonBuilder
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import mods.eln.Eln
 import mods.eln.Other
 import mods.eln.item.TurbineBladeLists
 import mods.eln.item.lampitem.BoilerplateLampData
@@ -80,6 +81,10 @@ class JsonConfig @JvmOverloads constructor(
         spec(path = "integrations.modbus.enabled", defaultValue = false, comment = "Enable Modbus RTU."),
         spec(path = "integrations.modbus.port", defaultValue = 1502, comment = "TCP port for Modbus RTU."),
         spec(path = "integrations.mqtt.enabled", defaultValue = false, comment = "Enable MQTT devices. Server endpoints live in config/eln/mqtt.json."),
+        spec(path = "integrations.mqtt.simMetrics.enabled", defaultValue = false, comment = "Publish simulator MNA metrics to MQTT."),
+        spec(path = "integrations.mqtt.simMetrics.server", defaultValue = "", comment = "MQTT server name in config/eln/mqtt.json used for simulator metrics."),
+        spec(path = "integrations.mqtt.simMetrics.id", defaultValue = "server", comment = "Topic ID used under eln/sim/<id>/... for simulator metrics."),
+        spec(path = "integrations.mqtt.simMetrics.publishIntervalTicks", defaultValue = 20, comment = "Simulator ticks to aggregate before MQTT publish. Higher values reduce overhead."),
         spec(path = "integrations.computerProbe.enabled", defaultValue = true, comment = "Enable the OC/CC to Eln computer probe."),
         spec(path = "integrations.energyExporter.enabled", defaultValue = true, comment = "Enable the Eln energy exporter."),
         spec(path = "integrations.oredict.tungstenEnabled", defaultValue = false, comment = "Use shared ore dictionary entries for tungsten."),
@@ -246,6 +251,12 @@ class JsonConfig @JvmOverloads constructor(
         Other.wattsToEu = getDoubleOrElse("balance.integrationConversion.wattsToEu", 1.0 / 3.0)
         Other.wattsToOC = getDoubleOrElse("balance.integrationConversion.wattsToOc", 1.0 / 3.0 / 2.5)
         Other.wattsToRf = getDoubleOrElse("balance.integrationConversion.wattsToRf", 1.0 / 3.0 * 4)
+        Eln.mqttEnabled = getBooleanOrElse("integrations.mqtt.enabled", false)
+        Eln.simMetricsEnabled = getBooleanOrElse("integrations.mqtt.simMetrics.enabled", false)
+        Eln.simMetricsMqttServer = getStringOrElse("integrations.mqtt.simMetrics.server", "")
+        Eln.simMetricsId = getStringOrElse("integrations.mqtt.simMetrics.id", "server")
+        Eln.simMetricsPublishIntervalTicks = max(1, getIntOrElse("integrations.mqtt.simMetrics.publishIntervalTicks", 20))
+        Eln.debugEnabled = getBooleanOrElse("debug.logging.enabled", false)
 
         setRuntimeValue(
             "runtime.items.batteries.standardHalfLifeTicks",
@@ -906,6 +917,10 @@ class JsonConfig @JvmOverloads constructor(
         "integrations.modbus.enabled" -> listOf(LegacyKey("modbus", "enable"))
         "integrations.modbus.port" -> listOf(LegacyKey("modbus", "port"))
         "integrations.mqtt.enabled" -> listOf(LegacyKey("mqtt", "enable"))
+        "integrations.mqtt.simMetrics.enabled" -> listOf(LegacyKey("mqtt", "simMetricsEnable"))
+        "integrations.mqtt.simMetrics.server" -> listOf(LegacyKey("mqtt", "simMetricsServer"))
+        "integrations.mqtt.simMetrics.id" -> listOf(LegacyKey("mqtt", "simMetricsId"))
+        "integrations.mqtt.simMetrics.publishIntervalTicks" -> listOf(LegacyKey("mqtt", "simMetricsPublishIntervalTicks"))
         "integrations.computerProbe.enabled" -> listOf(LegacyKey("compatibility", "ComputerProbeEnable"))
         "integrations.energyExporter.enabled" -> listOf(LegacyKey("compatibility", "ElnToOtherEnergyConverterEnable"))
         "integrations.oredict.tungstenEnabled" -> listOf(LegacyKey("dictionary", "tungsten"))

--- a/src/main/kotlin/mods/eln/config/JsonConfig.kt
+++ b/src/main/kotlin/mods/eln/config/JsonConfig.kt
@@ -5,6 +5,7 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import mods.eln.Eln
+import mods.eln.metrics.MetricsSubsystem
 import mods.eln.Other
 import mods.eln.item.TurbineBladeLists
 import mods.eln.item.lampitem.BoilerplateLampData
@@ -257,6 +258,7 @@ class JsonConfig @JvmOverloads constructor(
         Eln.simMetricsId = getStringOrElse("integrations.mqtt.simMetrics.id", "server")
         Eln.simMetricsPublishIntervalTicks = max(1, getIntOrElse("integrations.mqtt.simMetrics.publishIntervalTicks", 20))
         Eln.debugEnabled = getBooleanOrElse("debug.logging.enabled", false)
+        MetricsSubsystem.refreshFromConfig()
 
         setRuntimeValue(
             "runtime.items.batteries.standardHalfLifeTicks",

--- a/src/main/kotlin/mods/eln/config/JsonConfig.kt
+++ b/src/main/kotlin/mods/eln/config/JsonConfig.kt
@@ -4,6 +4,7 @@ import com.google.gson.GsonBuilder
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import mods.eln.Eln
 import mods.eln.Other
 import mods.eln.item.LampLists
 import mods.eln.item.TurbineBladeLists
@@ -78,6 +79,10 @@ class JsonConfig @JvmOverloads constructor(
         spec(path = "integrations.modbus.enabled", defaultValue = false, comment = "Enable Modbus RTU."),
         spec(path = "integrations.modbus.port", defaultValue = 1502, comment = "TCP port for Modbus RTU."),
         spec(path = "integrations.mqtt.enabled", defaultValue = false, comment = "Enable MQTT devices. Server endpoints live in config/eln/mqtt.json."),
+        spec(path = "integrations.mqtt.simMetrics.enabled", defaultValue = false, comment = "Publish simulator MNA metrics to MQTT."),
+        spec(path = "integrations.mqtt.simMetrics.server", defaultValue = "", comment = "MQTT server name in config/eln/mqtt.json used for simulator metrics."),
+        spec(path = "integrations.mqtt.simMetrics.id", defaultValue = "server", comment = "Topic ID used under eln/sim/<id>/... for simulator metrics."),
+        spec(path = "integrations.mqtt.simMetrics.publishIntervalTicks", defaultValue = 20, comment = "Simulator ticks to aggregate before MQTT publish. Higher values reduce overhead."),
         spec(path = "integrations.computerProbe.enabled", defaultValue = true, comment = "Enable the OC/CC to Eln computer probe."),
         spec(path = "integrations.energyExporter.enabled", defaultValue = true, comment = "Enable the Eln energy exporter."),
         spec(path = "integrations.oredict.tungstenEnabled", defaultValue = false, comment = "Use shared ore dictionary entries for tungsten."),
@@ -225,6 +230,12 @@ class JsonConfig @JvmOverloads constructor(
         Other.wattsToEu = getDoubleOrElse("balance.integrationConversion.wattsToEu", 1.0 / 3.0)
         Other.wattsToOC = getDoubleOrElse("balance.integrationConversion.wattsToOc", 1.0 / 3.0 / 2.5)
         Other.wattsToRf = getDoubleOrElse("balance.integrationConversion.wattsToRf", 1.0 / 3.0 * 4)
+        Eln.mqttEnabled = getBooleanOrElse("integrations.mqtt.enabled", false)
+        Eln.simMetricsEnabled = getBooleanOrElse("integrations.mqtt.simMetrics.enabled", false)
+        Eln.simMetricsMqttServer = getStringOrElse("integrations.mqtt.simMetrics.server", "")
+        Eln.simMetricsId = getStringOrElse("integrations.mqtt.simMetrics.id", "server")
+        Eln.simMetricsPublishIntervalTicks = max(1, getIntOrElse("integrations.mqtt.simMetrics.publishIntervalTicks", 20))
+        Eln.debugEnabled = getBooleanOrElse("debug.logging.enabled", false)
 
         setRuntimeValue(
             "runtime.items.batteries.standardHalfLifeTicks",
@@ -781,6 +792,10 @@ class JsonConfig @JvmOverloads constructor(
         "integrations.modbus.enabled" -> listOf(LegacyKey("modbus", "enable"))
         "integrations.modbus.port" -> listOf(LegacyKey("modbus", "port"))
         "integrations.mqtt.enabled" -> listOf(LegacyKey("mqtt", "enable"))
+        "integrations.mqtt.simMetrics.enabled" -> listOf(LegacyKey("mqtt", "simMetricsEnable"))
+        "integrations.mqtt.simMetrics.server" -> listOf(LegacyKey("mqtt", "simMetricsServer"))
+        "integrations.mqtt.simMetrics.id" -> listOf(LegacyKey("mqtt", "simMetricsId"))
+        "integrations.mqtt.simMetrics.publishIntervalTicks" -> listOf(LegacyKey("mqtt", "simMetricsPublishIntervalTicks"))
         "integrations.computerProbe.enabled" -> listOf(LegacyKey("compatibility", "ComputerProbeEnable"))
         "integrations.energyExporter.enabled" -> listOf(LegacyKey("compatibility", "ElnToOtherEnergyConverterEnable"))
         "integrations.oredict.tungstenEnabled" -> listOf(LegacyKey("dictionary", "tungsten"))

--- a/src/main/kotlin/mods/eln/metrics/MetricsSubsystem.kt
+++ b/src/main/kotlin/mods/eln/metrics/MetricsSubsystem.kt
@@ -1,0 +1,289 @@
+package mods.eln.metrics
+
+import mods.eln.Eln
+import mods.eln.mqtt.MqttManager
+import mods.eln.mqtt.SimpleMqttClient
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+private data class SimMnaMetricsPayload(
+    val subSystemCount: Int,
+    val inversionCount: Int,
+    val singularMatrixCount: Int,
+    val inversionAverageNanoseconds: Double,
+    val inversionMaximumNanoseconds: Long
+)
+
+private data class SimRuntimeMetricsPayload(
+    val avgTickMicroseconds: Double,
+    val electricalMicroseconds: Double,
+    val thermalFastMicroseconds: Double,
+    val thermalSlowMicroseconds: Double,
+    val slowMicroseconds: Double,
+    val subSystemCount: Int,
+    val electricalProcessCount: Int,
+    val thermalFastLoadCount: Int,
+    val thermalFastConnectionCount: Int,
+    val thermalFastProcessCount: Int,
+    val thermalSlowLoadCount: Int,
+    val thermalSlowConnectionCount: Int,
+    val thermalSlowProcessCount: Int,
+    val slowProcessCount: Int
+)
+
+private sealed interface MetricsPayload
+private data class MnaPayload(val payload: SimMnaMetricsPayload) : MetricsPayload
+private data class RuntimePayload(val payload: SimRuntimeMetricsPayload) : MetricsPayload
+
+private interface MetricsSink {
+    fun publishMna(payload: SimMnaMetricsPayload)
+    fun publishRuntime(payload: SimRuntimeMetricsPayload)
+}
+
+private class MqttSimMetricsSink(
+    private val serverName: String,
+    private val streamId: String
+) : MetricsSink {
+    private var sourceInfoPublished = false
+
+    override fun publishMna(payload: SimMnaMetricsPayload) {
+        val server = MqttManager.getServerByName(serverName) ?: return
+        val client = MqttManager.getClient(server.name) ?: return
+        val baseTopic = topicFor(server.prefix.orEmpty(), streamId)
+        publishText(client, "$baseTopic/stat/subsystems", payload.subSystemCount)
+        publishText(client, "$baseTopic/stat/inversions", payload.inversionCount)
+        publishText(client, "$baseTopic/stat/singular_matrices", payload.singularMatrixCount)
+        publishText(client, "$baseTopic/stat/inversion_avg_ns", payload.inversionAverageNanoseconds)
+        publishText(client, "$baseTopic/stat/inversion_max_ns", payload.inversionMaximumNanoseconds)
+        if (!sourceInfoPublished) {
+            sourceInfoPublished = true
+            publishText(client, "$baseTopic/info/source", "simulator", retain = true)
+            publishText(client, "$baseTopic/info/id", streamId, retain = true)
+        }
+    }
+
+    override fun publishRuntime(payload: SimRuntimeMetricsPayload) {
+        val server = MqttManager.getServerByName(serverName) ?: return
+        val client = MqttManager.getClient(server.name) ?: return
+        val baseTopic = topicFor(server.prefix.orEmpty(), streamId)
+        publishText(client, "$baseTopic/stat/tick_us", payload.avgTickMicroseconds)
+        publishText(client, "$baseTopic/stat/electrical_us", payload.electricalMicroseconds)
+        publishText(client, "$baseTopic/stat/thermal_fast_us", payload.thermalFastMicroseconds)
+        publishText(client, "$baseTopic/stat/thermal_slow_us", payload.thermalSlowMicroseconds)
+        publishText(client, "$baseTopic/stat/slow_us", payload.slowMicroseconds)
+
+        publishText(client, "$baseTopic/stat/electrical_processes", payload.electricalProcessCount)
+        publishText(client, "$baseTopic/stat/thermal_fast_loads", payload.thermalFastLoadCount)
+        publishText(client, "$baseTopic/stat/thermal_fast_connections", payload.thermalFastConnectionCount)
+        publishText(client, "$baseTopic/stat/thermal_fast_processes", payload.thermalFastProcessCount)
+        publishText(client, "$baseTopic/stat/thermal_slow_loads", payload.thermalSlowLoadCount)
+        publishText(client, "$baseTopic/stat/thermal_slow_connections", payload.thermalSlowConnectionCount)
+        publishText(client, "$baseTopic/stat/thermal_slow_processes", payload.thermalSlowProcessCount)
+        publishText(client, "$baseTopic/stat/slow_processes", payload.slowProcessCount)
+        publishText(client, "$baseTopic/stat/subsystems_current", payload.subSystemCount)
+    }
+
+    private fun publishText(client: SimpleMqttClient, topic: String, value: Any, retain: Boolean = false) {
+        client.publish(topic, value.toString().toByteArray(), retain)
+    }
+
+    private fun topicFor(prefix: String, streamId: String): String {
+        val builder = StringBuilder()
+        if (prefix.isNotBlank()) {
+            builder.append(prefix.trimEnd('/'))
+            builder.append('/')
+        }
+        builder.append("eln/sim/")
+        builder.append(streamId)
+        return builder.toString()
+    }
+}
+
+object MetricsSubsystem {
+    private const val DUMMY_SERVER_NAME = "dummy"
+    private val running = AtomicBoolean(false)
+    private val queue = ConcurrentLinkedQueue<MetricsPayload>()
+    private val sinks = mutableListOf<MetricsSink>()
+    private val dummyPublishCount = AtomicInteger(0)
+    private val dummyInversionCount = AtomicInteger(0)
+    private val dummySingularCount = AtomicInteger(0)
+
+    @Volatile
+    private var worker: Thread? = null
+
+    @JvmStatic
+    @Synchronized
+    fun refreshFromConfig() {
+        sinks.clear()
+        dummyPublishCount.set(0)
+        dummyInversionCount.set(0)
+        dummySingularCount.set(0)
+        val serverName = Eln.simMetricsMqttServer
+        val streamId = Eln.simMetricsId.ifBlank { "server" }
+        if (!Eln.mqttEnabled || !Eln.simMetricsEnabled) {
+            stopWorker()
+            return
+        }
+        if (serverName.equals(DUMMY_SERVER_NAME, ignoreCase = true)) {
+            sinks.add(
+                object : MetricsSink {
+                    override fun publishMna(payload: SimMnaMetricsPayload) {
+                        dummyPublishCount.incrementAndGet()
+                        dummyInversionCount.addAndGet(payload.inversionCount)
+                        dummySingularCount.addAndGet(payload.singularMatrixCount)
+                    }
+
+                    override fun publishRuntime(payload: SimRuntimeMetricsPayload) {
+                        dummyPublishCount.incrementAndGet()
+                    }
+                }
+            )
+            startWorkerIfNeeded()
+            return
+        }
+        if (serverName.isBlank()) {
+            Eln.logger.warn("[Metrics] integrations.mqtt.simMetrics.enabled is true but integrations.mqtt.simMetrics.server is blank")
+            stopWorker()
+            return
+        }
+        sinks.add(MqttSimMetricsSink(serverName, streamId))
+        startWorkerIfNeeded()
+    }
+
+    @JvmStatic
+    fun publishMnaMetrics(
+        subSystemCount: Int,
+        inversionCount: Int,
+        singularMatrixCount: Int,
+        inversionAverageNanoseconds: Double,
+        inversionMaximumNanoseconds: Long
+    ) {
+        if (!Eln.simMetricsEnabled || sinks.isEmpty()) {
+            return
+        }
+        queue.offer(
+            MnaPayload(
+                SimMnaMetricsPayload(
+                subSystemCount = subSystemCount,
+                inversionCount = inversionCount,
+                singularMatrixCount = singularMatrixCount,
+                inversionAverageNanoseconds = inversionAverageNanoseconds,
+                inversionMaximumNanoseconds = inversionMaximumNanoseconds
+                )
+            )
+        )
+        startWorkerIfNeeded()
+    }
+
+    @JvmStatic
+    fun publishSimulatorRuntimeMetrics(
+        avgTickMicroseconds: Double,
+        electricalMicroseconds: Double,
+        thermalFastMicroseconds: Double,
+        thermalSlowMicroseconds: Double,
+        slowMicroseconds: Double,
+        subSystemCount: Int,
+        electricalProcessCount: Int,
+        thermalFastLoadCount: Int,
+        thermalFastConnectionCount: Int,
+        thermalFastProcessCount: Int,
+        thermalSlowLoadCount: Int,
+        thermalSlowConnectionCount: Int,
+        thermalSlowProcessCount: Int,
+        slowProcessCount: Int
+    ) {
+        if (!Eln.simMetricsEnabled || sinks.isEmpty()) {
+            return
+        }
+        queue.offer(
+            RuntimePayload(
+                SimRuntimeMetricsPayload(
+                    avgTickMicroseconds = avgTickMicroseconds,
+                    electricalMicroseconds = electricalMicroseconds,
+                    thermalFastMicroseconds = thermalFastMicroseconds,
+                    thermalSlowMicroseconds = thermalSlowMicroseconds,
+                    slowMicroseconds = slowMicroseconds,
+                    subSystemCount = subSystemCount,
+                    electricalProcessCount = electricalProcessCount,
+                    thermalFastLoadCount = thermalFastLoadCount,
+                    thermalFastConnectionCount = thermalFastConnectionCount,
+                    thermalFastProcessCount = thermalFastProcessCount,
+                    thermalSlowLoadCount = thermalSlowLoadCount,
+                    thermalSlowConnectionCount = thermalSlowConnectionCount,
+                    thermalSlowProcessCount = thermalSlowProcessCount,
+                    slowProcessCount = slowProcessCount
+                )
+            )
+        )
+        startWorkerIfNeeded()
+    }
+
+    @JvmStatic
+    @Synchronized
+    fun shutdown() {
+        stopWorker()
+        queue.clear()
+        sinks.clear()
+    }
+
+    @JvmStatic
+    fun getDummyPublishCountForTests(): Int {
+        return dummyPublishCount.get()
+    }
+
+    @JvmStatic
+    fun getDummyInversionCountForTests(): Int {
+        return dummyInversionCount.get()
+    }
+
+    @JvmStatic
+    fun getDummySingularCountForTests(): Int {
+        return dummySingularCount.get()
+    }
+
+    @Synchronized
+    private fun stopWorker() {
+        running.set(false)
+        worker?.interrupt()
+        worker = null
+    }
+
+    @Synchronized
+    private fun startWorkerIfNeeded() {
+        if (running.get()) {
+            return
+        }
+        running.set(true)
+        worker = Thread(
+            {
+                while (running.get()) {
+                    val payload = queue.poll()
+                    if (payload == null) {
+                        try {
+                            Thread.sleep(50)
+                        } catch (_: InterruptedException) {
+                            Thread.currentThread().interrupt()
+                            break
+                        }
+                        continue
+                    }
+                    sinks.forEach { sink ->
+                        try {
+                            when (payload) {
+                                is MnaPayload -> sink.publishMna(payload.payload)
+                                is RuntimePayload -> sink.publishRuntime(payload.payload)
+                            }
+                        } catch (e: Exception) {
+                            Eln.logger.warn("[Metrics] Sink publish failed: ${e.message}")
+                        }
+                    }
+                }
+            },
+            "eln-sim-metrics"
+        ).apply {
+            isDaemon = true
+            start()
+        }
+    }
+}

--- a/src/main/kotlin/mods/eln/metrics/MetricsSubsystem.kt
+++ b/src/main/kotlin/mods/eln/metrics/MetricsSubsystem.kt
@@ -103,6 +103,7 @@ private class MqttSimMetricsSink(
 object MetricsSubsystem {
     private const val DUMMY_SERVER_NAME = "dummy"
     private val running = AtomicBoolean(false)
+    private val simulatorMetricsActive = AtomicBoolean(false)
     private val queue = ConcurrentLinkedQueue<MetricsPayload>()
     private val sinks = mutableListOf<MetricsSink>()
     private val dummyPublishCount = AtomicInteger(0)
@@ -115,6 +116,7 @@ object MetricsSubsystem {
     @JvmStatic
     @Synchronized
     fun refreshFromConfig() {
+        simulatorMetricsActive.set(false)
         sinks.clear()
         dummyPublishCount.set(0)
         dummyInversionCount.set(0)
@@ -139,6 +141,7 @@ object MetricsSubsystem {
                     }
                 }
             )
+            simulatorMetricsActive.set(true)
             startWorkerIfNeeded()
             return
         }
@@ -148,7 +151,13 @@ object MetricsSubsystem {
             return
         }
         sinks.add(MqttSimMetricsSink(serverName, streamId))
+        simulatorMetricsActive.set(true)
         startWorkerIfNeeded()
+    }
+
+    @JvmStatic
+    fun isSimulatorMetricsActive(): Boolean {
+        return simulatorMetricsActive.get()
     }
 
     @JvmStatic
@@ -222,6 +231,7 @@ object MetricsSubsystem {
     @JvmStatic
     @Synchronized
     fun shutdown() {
+        simulatorMetricsActive.set(false)
         stopWorker()
         queue.clear()
         sinks.clear()

--- a/src/test/kotlin/mods/eln/sim/mna/RootSystemSimMetricsProfilingTest.kt
+++ b/src/test/kotlin/mods/eln/sim/mna/RootSystemSimMetricsProfilingTest.kt
@@ -1,0 +1,259 @@
+package mods.eln.sim.mna
+
+import mods.eln.Eln
+import mods.eln.disableLog4jJmx
+import mods.eln.metrics.MetricsSubsystem
+import mods.eln.sim.mna.component.CurrentSource
+import mods.eln.sim.mna.component.Resistor
+import mods.eln.sim.mna.component.VoltageSource
+import mods.eln.sim.mna.state.VoltageState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RootSystemSimMetricsProfilingTest {
+    data class ScenarioResult(
+        val elapsedRunsNanos: List<Long>,
+        val matrixRows: Int,
+        val matrixCols: Int,
+        val dummyPublishes: Int
+    )
+
+    @Test
+    fun profilesMnaWithAndWithoutDummyMqttMetrics() {
+        disableLog4jJmx()
+        Eln.debugEnabled = false
+
+        val withoutMetrics = runScenario(
+            enableMetrics = false,
+            matrixSize = 100,
+            repetitions = 3,
+            warmupSteps = 30,
+            measuredSteps = 250
+        )
+        val withMetrics = runScenario(
+            enableMetrics = true,
+            matrixSize = 100,
+            repetitions = 3,
+            warmupSteps = 30,
+            measuredSteps = 250
+        )
+
+        assertEquals(100, withoutMetrics.matrixRows)
+        assertEquals(100, withoutMetrics.matrixCols)
+        assertEquals(100, withMetrics.matrixRows)
+        assertEquals(100, withMetrics.matrixCols)
+        assertEquals(0, withoutMetrics.dummyPublishes)
+        assertTrue(withMetrics.dummyPublishes > 0, "Expected dummy MQTT metrics sink to receive publishes")
+
+        val ratio = bestNanos(withMetrics).toDouble() / bestNanos(withoutMetrics).toDouble()
+        assertTrue(
+            ratio <= 2.25,
+            "Sim metrics overhead is too high. ratio=$ratio without=${bestNanos(withoutMetrics)}ns with=${bestNanos(withMetrics)}ns"
+        )
+    }
+
+    @Test
+    fun profilesLargeMatrixWithMultiIterationSummary() {
+        disableLog4jJmx()
+        Eln.debugEnabled = false
+
+        val matrixSize = 220
+        val withoutMetrics = runScenario(
+            enableMetrics = false,
+            matrixSize = matrixSize,
+            repetitions = 12,
+            warmupSteps = 50,
+            measuredSteps = 750
+        )
+        val withMetrics = runScenario(
+            enableMetrics = true,
+            matrixSize = matrixSize,
+            repetitions = 12,
+            warmupSteps = 50,
+            measuredSteps = 750
+        )
+
+        assertEquals(matrixSize, withoutMetrics.matrixRows)
+        assertEquals(matrixSize, withoutMetrics.matrixCols)
+        assertEquals(matrixSize, withMetrics.matrixRows)
+        assertEquals(matrixSize, withMetrics.matrixCols)
+        assertEquals(0, withoutMetrics.dummyPublishes)
+        assertTrue(withMetrics.dummyPublishes > 0, "Expected dummy MQTT metrics sink to receive publishes")
+
+        val ratios = pairedRatios(withoutMetrics.elapsedRunsNanos, withMetrics.elapsedRunsNanos)
+        val ratioMean = mean(ratios)
+        val ratioMedian = percentile(ratios, 0.5)
+        val ratioP95 = percentile(ratios, 0.95)
+        println(
+            "SIM_METRICS_BENCH matrix=${matrixSize}x${matrixSize} runs=${ratios.size} " +
+                "ratio_mean=$ratioMean ratio_median=$ratioMedian ratio_p95=$ratioP95 " +
+                "dummyPublishes=${withMetrics.dummyPublishes}"
+        )
+
+        assertTrue(ratios.isNotEmpty(), "Expected ratio measurements")
+        assertTrue(ratioP95 <= 2.50, "P95 simulator overhead too high: p95=$ratioP95 ratios=$ratios")
+    }
+
+    @Test
+    fun comparesSmallAndLargeMatrixOverhead() {
+        disableLog4jJmx()
+        Eln.debugEnabled = false
+
+        val sizes = listOf(4, 10, 40, 220)
+        val summaries = ArrayList<Pair<Int, Triple<Double, Double, Double>>>()
+
+        sizes.forEach { size ->
+            val withoutMetrics = runScenario(
+                enableMetrics = false,
+                matrixSize = size,
+                repetitions = 12,
+                warmupSteps = 50,
+                measuredSteps = 750
+            )
+            val withMetrics = runScenario(
+                enableMetrics = true,
+                matrixSize = size,
+                repetitions = 12,
+                warmupSteps = 50,
+                measuredSteps = 750
+            )
+
+            assertEquals(size, withoutMetrics.matrixRows)
+            assertEquals(size, withoutMetrics.matrixCols)
+            assertEquals(size, withMetrics.matrixRows)
+            assertEquals(size, withMetrics.matrixCols)
+            assertEquals(0, withoutMetrics.dummyPublishes)
+            assertTrue(withMetrics.dummyPublishes > 0)
+
+            val ratios = pairedRatios(withoutMetrics.elapsedRunsNanos, withMetrics.elapsedRunsNanos)
+            val ratioMean = mean(ratios)
+            val ratioMedian = percentile(ratios, 0.5)
+            val ratioP95 = percentile(ratios, 0.95)
+            summaries += size to Triple(ratioMean, ratioMedian, ratioP95)
+            println(
+                "SIM_METRICS_SWEEP matrix=${size}x${size} runs=${ratios.size} " +
+                    "ratio_mean=$ratioMean ratio_median=$ratioMedian ratio_p95=$ratioP95 " +
+                    "dummyPublishes=${withMetrics.dummyPublishes}"
+            )
+        }
+
+        val tinyP95 = summaries.first { it.first == 4 }.second.third
+        val smallP95 = summaries.first { it.first == 10 }.second.third
+        val mediumP95 = summaries.first { it.first == 40 }.second.third
+        val largeP95 = summaries.first { it.first == 220 }.second.third
+        println("SIM_METRICS_SWEEP_COMPARE tiny_p95=$tinyP95 small_p95=$smallP95 medium_p95=$mediumP95 large_p95=$largeP95")
+    }
+
+    private fun runScenario(
+        enableMetrics: Boolean,
+        matrixSize: Int,
+        repetitions: Int,
+        warmupSteps: Int,
+        measuredSteps: Int
+    ): ScenarioResult {
+        Eln.mqttEnabled = enableMetrics
+        Eln.simMetricsEnabled = enableMetrics
+        Eln.simMetricsMqttServer = "dummy"
+        Eln.simMetricsId = if (enableMetrics) "perf-on-$matrixSize" else "perf-off-$matrixSize"
+        Eln.simMetricsPublishIntervalTicks = 1
+        MetricsSubsystem.shutdown()
+        MetricsSubsystem.refreshFromConfig()
+
+        val elapsedRuns = ArrayList<Long>(repetitions)
+        var matrixRows = 0
+        var matrixCols = 0
+
+        repeat(repetitions) {
+            val root = buildComplexRootSystem(matrixSize)
+            root.generate()
+            assertTrue(root.systems.isNotEmpty())
+
+            val snapshot = root.systems[0].captureDebugSnapshot()
+            assertFalse(snapshot.isSingular)
+            val matrix = snapshot.conductanceMatrix
+            matrixRows = matrix.size
+            matrixCols = if (matrix.isNotEmpty()) matrix[0].size else 0
+
+            repeat(warmupSteps) { root.step() }
+            val start = System.nanoTime()
+            repeat(measuredSteps) { root.step() }
+            elapsedRuns.add(System.nanoTime() - start)
+        }
+
+        if (enableMetrics) {
+            Thread.sleep(150)
+        }
+        val publishes = MetricsSubsystem.getDummyPublishCountForTests()
+        MetricsSubsystem.shutdown()
+        return ScenarioResult(elapsedRuns, matrixRows, matrixCols, publishes)
+    }
+
+    private fun buildComplexRootSystem(matrixSize: Int): RootSystem {
+        require(matrixSize >= 4)
+        val root = RootSystem(0.1, 1)
+        val nodeCount = matrixSize - 1
+        val nodes = List(nodeCount) { VoltageState() }
+        nodes.forEach { root.addState(it) }
+
+        for (i in 0 until nodeCount) {
+            val next = (i + 1) % nodeCount
+            root.addComponent(Resistor(nodes[i], nodes[next]).setResistance(8.0 + (i % 9)))
+
+            if (i % 3 == 0) {
+                val cross = (i + 13) % nodeCount
+                root.addComponent(Resistor(nodes[i], nodes[cross]).setResistance(20.0 + (i % 11)))
+            }
+
+            if (i % 2 == 0) {
+                root.addComponent(Resistor(nodes[i], null).setResistance(900.0 + i))
+            }
+        }
+
+        root.addComponent(VoltageSource("v-main", nodes[0], null).setVoltage(120.0))
+
+        var i = 1
+        while (i < nodeCount) {
+            val b = (i + 17) % nodeCount
+            root.addComponent(CurrentSource("i-$i", nodes[i], nodes[b]).setCurrent(0.3 + (i % 5) * 0.05))
+            i += 4
+        }
+        i = 2
+        while (i < nodeCount) {
+            root.addComponent(CurrentSource("ig-$i", nodes[i], null).setCurrent(0.1 + i * 0.01))
+            i += 3
+        }
+
+        return root
+    }
+
+    private fun bestNanos(result: ScenarioResult): Long {
+        return result.elapsedRunsNanos.minOrNull() ?: Long.MAX_VALUE
+    }
+
+    private fun pairedRatios(baseline: List<Long>, instrumented: List<Long>): List<Double> {
+        val size = minOf(baseline.size, instrumented.size)
+        val ratios = ArrayList<Double>(size)
+        for (idx in 0 until size) {
+            val b = baseline[idx]
+            val i = instrumented[idx]
+            if (b <= 0L) continue
+            ratios.add(i.toDouble() / b.toDouble())
+        }
+        return ratios
+    }
+
+    private fun mean(values: List<Double>): Double {
+        if (values.isEmpty()) return Double.NaN
+        return values.sum() / values.size.toDouble()
+    }
+
+    private fun percentile(values: List<Double>, p: Double): Double {
+        if (values.isEmpty()) return Double.NaN
+        val sorted = values.sorted()
+        val clamped = p.coerceIn(0.0, 1.0)
+        val index = ((sorted.size - 1) * clamped).toInt()
+        return sorted[index]
+    }
+}

--- a/src/test/kotlin/mods/eln/sim/mna/RootSystemSimMetricsProfilingTest.kt
+++ b/src/test/kotlin/mods/eln/sim/mna/RootSystemSimMetricsProfilingTest.kt
@@ -13,12 +13,44 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class RootSystemSimMetricsProfilingTest {
+    private enum class ScenarioShape {
+        SINGLE_SYSTEM,
+        MANY_SUBSYSTEMS
+    }
+
     data class ScenarioResult(
         val elapsedRunsNanos: List<Long>,
         val matrixRows: Int,
         val matrixCols: Int,
+        val subsystemCount: Int,
         val dummyPublishes: Int
     )
+
+    @Test
+    fun keepsSimulatorMetricsInactiveWhenMqttIsDisabled() {
+        disableLog4jJmx()
+        Eln.debugEnabled = false
+        Eln.mqttEnabled = false
+        Eln.simMetricsEnabled = true
+        Eln.simMetricsMqttServer = "dummy"
+        Eln.simMetricsId = "disabled-mqtt"
+        Eln.simMetricsPublishIntervalTicks = 1
+        MetricsSubsystem.shutdown()
+        MetricsSubsystem.refreshFromConfig()
+
+        assertFalse(MetricsSubsystem.isSimulatorMetricsActive())
+
+        val root = buildComplexRootSystem(40)
+        root.generate()
+        repeat(50) { root.step() }
+        Thread.sleep(50)
+
+        assertEquals(0, MetricsSubsystem.getDummyPublishCountForTests())
+        assertEquals(0, MetricsSubsystem.getDummyInversionCountForTests())
+        assertEquals(0, MetricsSubsystem.getDummySingularCountForTests())
+
+        MetricsSubsystem.shutdown()
+    }
 
     @Test
     fun profilesMnaWithAndWithoutDummyMqttMetrics() {
@@ -27,6 +59,7 @@ class RootSystemSimMetricsProfilingTest {
 
         val withoutMetrics = runScenario(
             enableMetrics = false,
+            shape = ScenarioShape.SINGLE_SYSTEM,
             matrixSize = 100,
             repetitions = 3,
             warmupSteps = 30,
@@ -34,6 +67,7 @@ class RootSystemSimMetricsProfilingTest {
         )
         val withMetrics = runScenario(
             enableMetrics = true,
+            shape = ScenarioShape.SINGLE_SYSTEM,
             matrixSize = 100,
             repetitions = 3,
             warmupSteps = 30,
@@ -42,8 +76,10 @@ class RootSystemSimMetricsProfilingTest {
 
         assertEquals(100, withoutMetrics.matrixRows)
         assertEquals(100, withoutMetrics.matrixCols)
+        assertEquals(1, withoutMetrics.subsystemCount)
         assertEquals(100, withMetrics.matrixRows)
         assertEquals(100, withMetrics.matrixCols)
+        assertEquals(1, withMetrics.subsystemCount)
         assertEquals(0, withoutMetrics.dummyPublishes)
         assertTrue(withMetrics.dummyPublishes > 0, "Expected dummy MQTT metrics sink to receive publishes")
 
@@ -62,6 +98,7 @@ class RootSystemSimMetricsProfilingTest {
         val matrixSize = 220
         val withoutMetrics = runScenario(
             enableMetrics = false,
+            shape = ScenarioShape.SINGLE_SYSTEM,
             matrixSize = matrixSize,
             repetitions = 12,
             warmupSteps = 50,
@@ -69,6 +106,7 @@ class RootSystemSimMetricsProfilingTest {
         )
         val withMetrics = runScenario(
             enableMetrics = true,
+            shape = ScenarioShape.SINGLE_SYSTEM,
             matrixSize = matrixSize,
             repetitions = 12,
             warmupSteps = 50,
@@ -77,8 +115,10 @@ class RootSystemSimMetricsProfilingTest {
 
         assertEquals(matrixSize, withoutMetrics.matrixRows)
         assertEquals(matrixSize, withoutMetrics.matrixCols)
+        assertEquals(1, withoutMetrics.subsystemCount)
         assertEquals(matrixSize, withMetrics.matrixRows)
         assertEquals(matrixSize, withMetrics.matrixCols)
+        assertEquals(1, withMetrics.subsystemCount)
         assertEquals(0, withoutMetrics.dummyPublishes)
         assertTrue(withMetrics.dummyPublishes > 0, "Expected dummy MQTT metrics sink to receive publishes")
 
@@ -88,6 +128,8 @@ class RootSystemSimMetricsProfilingTest {
         val ratioP95 = percentile(ratios, 0.95)
         println(
             "SIM_METRICS_BENCH matrix=${matrixSize}x${matrixSize} runs=${ratios.size} " +
+                "baseline_mean_ns=${meanLong(withoutMetrics.elapsedRunsNanos)} baseline_median_ns=${percentileLong(withoutMetrics.elapsedRunsNanos, 0.5)} " +
+                "instrumented_mean_ns=${meanLong(withMetrics.elapsedRunsNanos)} instrumented_median_ns=${percentileLong(withMetrics.elapsedRunsNanos, 0.5)} " +
                 "ratio_mean=$ratioMean ratio_median=$ratioMedian ratio_p95=$ratioP95 " +
                 "dummyPublishes=${withMetrics.dummyPublishes}"
         )
@@ -107,6 +149,7 @@ class RootSystemSimMetricsProfilingTest {
         sizes.forEach { size ->
             val withoutMetrics = runScenario(
                 enableMetrics = false,
+                shape = ScenarioShape.SINGLE_SYSTEM,
                 matrixSize = size,
                 repetitions = 12,
                 warmupSteps = 50,
@@ -114,6 +157,7 @@ class RootSystemSimMetricsProfilingTest {
             )
             val withMetrics = runScenario(
                 enableMetrics = true,
+                shape = ScenarioShape.SINGLE_SYSTEM,
                 matrixSize = size,
                 repetitions = 12,
                 warmupSteps = 50,
@@ -122,8 +166,10 @@ class RootSystemSimMetricsProfilingTest {
 
             assertEquals(size, withoutMetrics.matrixRows)
             assertEquals(size, withoutMetrics.matrixCols)
+            assertEquals(1, withoutMetrics.subsystemCount)
             assertEquals(size, withMetrics.matrixRows)
             assertEquals(size, withMetrics.matrixCols)
+            assertEquals(1, withMetrics.subsystemCount)
             assertEquals(0, withoutMetrics.dummyPublishes)
             assertTrue(withMetrics.dummyPublishes > 0)
 
@@ -146,8 +192,54 @@ class RootSystemSimMetricsProfilingTest {
         println("SIM_METRICS_SWEEP_COMPARE tiny_p95=$tinyP95 small_p95=$smallP95 medium_p95=$mediumP95 large_p95=$largeP95")
     }
 
+    @Test
+    fun profilesManySubsystemWorldOverhead() {
+        disableLog4jJmx()
+        Eln.debugEnabled = false
+
+        val withoutMetrics = runScenario(
+            enableMetrics = false,
+            shape = ScenarioShape.MANY_SUBSYSTEMS,
+            matrixSize = 10,
+            repetitions = 10,
+            warmupSteps = 40,
+            measuredSteps = 600
+        )
+        val withMetrics = runScenario(
+            enableMetrics = true,
+            shape = ScenarioShape.MANY_SUBSYSTEMS,
+            matrixSize = 10,
+            repetitions = 10,
+            warmupSteps = 40,
+            measuredSteps = 600
+        )
+
+        assertEquals(10, withoutMetrics.matrixRows)
+        assertEquals(10, withoutMetrics.matrixCols)
+        assertTrue(withoutMetrics.subsystemCount >= 24, "Expected fragmented subsystem scenario")
+        assertEquals(withoutMetrics.subsystemCount, withMetrics.subsystemCount)
+        assertEquals(0, withoutMetrics.dummyPublishes)
+        assertTrue(withMetrics.dummyPublishes > 0)
+
+        val ratios = pairedRatios(withoutMetrics.elapsedRunsNanos, withMetrics.elapsedRunsNanos)
+        val ratioMean = mean(ratios)
+        val ratioMedian = percentile(ratios, 0.5)
+        val ratioP95 = percentile(ratios, 0.95)
+        println(
+            "SIM_METRICS_FRAGMENTED subsystems=${withMetrics.subsystemCount} matrix=10x10 runs=${ratios.size} " +
+                "baseline_mean_ns=${meanLong(withoutMetrics.elapsedRunsNanos)} baseline_median_ns=${percentileLong(withoutMetrics.elapsedRunsNanos, 0.5)} " +
+                "instrumented_mean_ns=${meanLong(withMetrics.elapsedRunsNanos)} instrumented_median_ns=${percentileLong(withMetrics.elapsedRunsNanos, 0.5)} " +
+                "ratio_mean=$ratioMean ratio_median=$ratioMedian ratio_p95=$ratioP95 " +
+                "dummyPublishes=${withMetrics.dummyPublishes}"
+        )
+
+        assertTrue(ratios.isNotEmpty(), "Expected ratio measurements")
+        assertTrue(ratioP95 <= 1.75, "Fragmented-world simulator overhead too high: p95=$ratioP95 ratios=$ratios")
+    }
+
     private fun runScenario(
         enableMetrics: Boolean,
+        shape: ScenarioShape,
         matrixSize: Int,
         repetitions: Int,
         warmupSteps: Int,
@@ -164,11 +256,16 @@ class RootSystemSimMetricsProfilingTest {
         val elapsedRuns = ArrayList<Long>(repetitions)
         var matrixRows = 0
         var matrixCols = 0
+        var subsystemCount = 0
 
         repeat(repetitions) {
-            val root = buildComplexRootSystem(matrixSize)
+            val root = when (shape) {
+                ScenarioShape.SINGLE_SYSTEM -> buildComplexRootSystem(matrixSize)
+                ScenarioShape.MANY_SUBSYSTEMS -> buildFragmentedRootSystem(matrixSize, subsystemCount = 24)
+            }
             root.generate()
             assertTrue(root.systems.isNotEmpty())
+            subsystemCount = root.systems.size
 
             val snapshot = root.systems[0].captureDebugSnapshot()
             assertFalse(snapshot.isSingular)
@@ -187,7 +284,7 @@ class RootSystemSimMetricsProfilingTest {
         }
         val publishes = MetricsSubsystem.getDummyPublishCountForTests()
         MetricsSubsystem.shutdown()
-        return ScenarioResult(elapsedRuns, matrixRows, matrixCols, publishes)
+        return ScenarioResult(elapsedRuns, matrixRows, matrixCols, subsystemCount, publishes)
     }
 
     private fun buildComplexRootSystem(matrixSize: Int): RootSystem {
@@ -228,6 +325,18 @@ class RootSystemSimMetricsProfilingTest {
         return root
     }
 
+    private fun buildFragmentedRootSystem(matrixSize: Int, subsystemCount: Int): RootSystem {
+        require(matrixSize >= 4)
+        require(subsystemCount >= 2)
+        val root = RootSystem(0.1, 1)
+        repeat(subsystemCount) {
+            val subsystem = buildComplexRootSystem(matrixSize)
+            subsystem.addStates.forEach { root.addState(it) }
+            subsystem.addComponents.forEach { root.addComponent(it) }
+        }
+        return root
+    }
+
     private fun bestNanos(result: ScenarioResult): Long {
         return result.elapsedRunsNanos.minOrNull() ?: Long.MAX_VALUE
     }
@@ -249,8 +358,21 @@ class RootSystemSimMetricsProfilingTest {
         return values.sum() / values.size.toDouble()
     }
 
+    private fun meanLong(values: List<Long>): Double {
+        if (values.isEmpty()) return Double.NaN
+        return values.sum().toDouble() / values.size.toDouble()
+    }
+
     private fun percentile(values: List<Double>, p: Double): Double {
         if (values.isEmpty()) return Double.NaN
+        val sorted = values.sorted()
+        val clamped = p.coerceIn(0.0, 1.0)
+        val index = ((sorted.size - 1) * clamped).toInt()
+        return sorted[index]
+    }
+
+    private fun percentileLong(values: List<Long>, p: Double): Long {
+        if (values.isEmpty()) return Long.MIN_VALUE
         val sorted = values.sorted()
         val clamped = p.coerceIn(0.0, 1.0)
         val index = ((sorted.size - 1) * clamped).toInt()


### PR DESCRIPTION
- Introduced `MetricsSubsystem` for collecting and publishing simulator MNA and runtime metrics.
- Integrated MQTT metrics publishing with configurable server name, topic ID, and publish interval.
- Added metrics tracking for subsystem count, matrix inversions, singular matrix detections, and runtime performance.
- Enhanced `RootSystem` and `SubSystem` with metrics collection and aggregation logic.
- Updated configuration to include `simMetricsEnabled` and related settings.
- Included unit tests to validate the overhead and correctness of metrics publishing.