### PR TITLE
Revamp lamp aging command

### DIFF
--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -239,8 +239,14 @@ public class Eln {
     public static int wirelessTxRange = 32;
     public static int roomMaxAxisSpanBlocks = 24;
     public static int roomMaxVolumeBlocks = 4096;
+
+    /* ---- Lightbulb life --------------------------------- */
+    public static boolean incandescentLampInfiniteLife = false;
+    public static boolean ecoLampInfiniteLife = false;
     public static boolean ledLampInfiniteLife = false;
     public static boolean halogenLampInfiniteLife = false;
+    /* ----------------------------------------------------- */
+
     static public GenericItemUsingDamageDescriptor multiMeterElement, thermometerElement, allMeterElement;
     static public GenericItemUsingDamageDescriptor configCopyToolElement;
     public static TreeResin treeResin;

--- a/src/main/kotlin/mods/eln/config/ConfigHandler.kt
+++ b/src/main/kotlin/mods/eln/config/ConfigHandler.kt
@@ -144,14 +144,20 @@ object ConfigHandler {
             Eln.dictAdvancedChip = "circuitElnAdvanced"
         }
 
+        /* ---- Lamp config ----------------------------------------------------------------------- */
         eln.incandescentLampLife = Eln.config["lamp", "incandescentLifeInHours", 16.0].getDouble(16.0)
         eln.economicLampLife = Eln.config["lamp", "economicLifeInHours", 64.0].getDouble(64.0)
         eln.carbonLampLife = Eln.config["lamp", "carbonLifeInHours", 6.0].getDouble(6.0)
         eln.ledLampLife = Eln.config["lamp", "ledLifeInHours", 512.0].getDouble(512.0)
         eln.halogenLampLife = Eln.config["lamp", "halogenLifeInHours", 128.0].getDouble(128.0)
+
+        Eln.incandescentLampInfiniteLife = Eln.config["lamp", "infiniteIncandescentLife", false].boolean
+        Eln.ecoLampInfiniteLife = Eln.config["lamp", "infiniteEcoLife", false].boolean
         Eln.ledLampInfiniteLife = Eln.config["lamp", "infiniteLedLife", false].boolean
         Eln.halogenLampInfiniteLife = Eln.config["lamp", "infiniteHalogenLife", false].boolean
+
         Eln.allowSwingingLamps = Eln.config["lamp", "swingingLamps", true].boolean
+        /* ---------------------------------------------------------------------------------------- */
 
         eln.fuelGeneratorTankCapacity =
             Eln.config["fuelGenerator", "tankCapacityInSecondsAtNominalPower", 20 * 60].getDouble((20 * 60).toDouble())

--- a/src/main/kotlin/mods/eln/misc/HybridNodeDirection.kt
+++ b/src/main/kotlin/mods/eln/misc/HybridNodeDirection.kt
@@ -6,7 +6,7 @@ enum class HybridNodeDirection(val int: Int) {
 
     companion object {
         fun fromInt(idx: Int): HybridNodeDirection? {
-            for (direction in HybridNodeDirection.values()) {
+            for (direction in entries) {
                 if (direction.int == idx) return direction
             }
             return null

--- a/src/main/kotlin/mods/eln/server/SaveConfig.kt
+++ b/src/main/kotlin/mods/eln/server/SaveConfig.kt
@@ -7,7 +7,12 @@ import net.minecraft.world.WorldSavedData
 class SaveConfig(par1Str: String) : WorldSavedData(par1Str) {
     @JvmField
     var heatFurnaceFuel = true
-    var electricalLampAging = true
+
+    var infiniteIncandescentLife = Eln.incandescentLampInfiniteLife
+    var infiniteEcoBulbLife = Eln.ecoLampInfiniteLife
+    var infiniteLedBulbLife = Eln.ledLampInfiniteLife
+    var infiniteHalogenBulbLife = Eln.halogenLampInfiniteLife
+
     var batteryAging = true
     @JvmField
     var infinitePortableBattery = false
@@ -15,7 +20,12 @@ class SaveConfig(par1Str: String) : WorldSavedData(par1Str) {
     var cableRsFactor_lastUsed = 1.0
     override fun readFromNBT(nbt: NBTTagCompound) {
         heatFurnaceFuel = nbt.getBoolean("heatFurnaceFuel")
-        electricalLampAging = nbt.getBoolean("electricalLampAging")
+
+        infiniteIncandescentLife = nbt.getBoolean("infiniteIncandescentBulbLife")
+        infiniteEcoBulbLife = nbt.getBoolean("infiniteEcoBulbLife")
+        infiniteLedBulbLife = nbt.getBoolean("infiniteLedBulbLife")
+        infiniteHalogenBulbLife = nbt.getBoolean("infiniteHalogenBulbLife")
+
         batteryAging = nbt.getBoolean("batteryAging")
         infinitePortableBattery = nbt.getBoolean("infinitPortableBattery")
         reGenOre = nbt.getBoolean("reGenOre")
@@ -25,7 +35,12 @@ class SaveConfig(par1Str: String) : WorldSavedData(par1Str) {
 
     override fun writeToNBT(nbt: NBTTagCompound) {
         nbt.setBoolean("heatFurnaceFuel", heatFurnaceFuel)
-        nbt.setBoolean("electricalLampAging", electricalLampAging)
+
+        nbt.setBoolean("infiniteIncandescentBulbLife", infiniteIncandescentLife)
+        nbt.setBoolean("infiniteEcoBulbLife", infiniteEcoBulbLife)
+        nbt.setBoolean("infiniteLedBulbLife", infiniteLedBulbLife)
+        nbt.setBoolean("infiniteHalogenBulbLife", infiniteHalogenBulbLife)
+
         nbt.setBoolean("batteryAging", batteryAging)
         nbt.setBoolean("infinitPortableBattery", infinitePortableBattery)
         nbt.setBoolean("reGenOre", reGenOre)

--- a/src/main/kotlin/mods/eln/server/console/ElnConsoleCommands.kt
+++ b/src/main/kotlin/mods/eln/server/console/ElnConsoleCommands.kt
@@ -142,10 +142,17 @@ class ElnAgingCommand: IConsoleCommand {
     override fun runCommand(ics: ICommandSender, args: List<String>) {
         if (args.size == 1) {
             val aging = getArgBool(ics, args[0])?: return
+
             SaveConfig.instance?.batteryAging = aging
-            SaveConfig.instance?.electricalLampAging = aging
-            SaveConfig.instance?.heatFurnaceFuel = aging
             SaveConfig.instance?.infinitePortableBattery = !aging
+
+            SaveConfig.instance?.infiniteIncandescentLife = !aging
+            SaveConfig.instance?.infiniteEcoBulbLife = !aging
+            SaveConfig.instance?.infiniteLedBulbLife = !aging
+            SaveConfig.instance?.infiniteHalogenBulbLife = !aging
+
+            SaveConfig.instance?.heatFurnaceFuel = aging
+
             cprint(ics, "Batteries / Furnace Fuel / Lamp aging: ${FC.DARK_GREEN}${boolToStr(aging)}", indent = 1)
             cprint(ics, "Parameter saved in the map.", indent = 1)
         } else {
@@ -206,33 +213,105 @@ class ElnLampAgingCommand: IConsoleCommand {
     override val name = "lampAging"
 
     override fun runCommand(ics: ICommandSender, args: List<String>) {
-        if (args.size == 1) {
-            val lampAging = getArgBool(ics, args[0])?: return
-            SaveConfig.instance?.electricalLampAging = lampAging
-            cprint(ics, "Lamp aging: ${FC.DARK_GREEN}${boolToStr(lampAging)}", indent = 1)
-            cprint(ics, "Parameter saved in the map.", indent = 1)
-        } else {
-            cprint(ics, "This command only takes one argument - true or false")
+        var printError = false
+
+        if (args.size == 3) {
+            val domain = args[0]
+            val bulbType = args[1]
+            val aging = getArgBool(ics, args[2])?: return
+
+            var updateIncandescent = false
+            var updateEco = false
+            var updateLed = false
+            var updateHalogen = false
+
+            when (bulbType) {
+                "incandescent" -> updateIncandescent = true
+                "eco" -> updateEco = true
+                "led" -> updateLed = true
+                "halogen" -> updateHalogen = true
+                "all" -> {
+                    updateIncandescent = true
+                    updateEco = true
+                    updateLed = true
+                    updateHalogen = true
+                }
+                else -> printError = true
+            }
+
+            if (!printError) when (domain) {
+                "local" -> {
+                    if (updateIncandescent) SaveConfig.instance?.infiniteIncandescentLife = !aging
+                    if (updateEco) SaveConfig.instance?.infiniteEcoBulbLife = !aging
+                    if (updateLed) SaveConfig.instance?.infiniteLedBulbLife = !aging
+                    if (updateHalogen) SaveConfig.instance?.infiniteHalogenBulbLife = !aging
+
+                    cprint(ics, "Lamp aging: ${FC.DARK_GREEN}${bulbType}, ${FC.DARK_GREEN}${boolToStr(aging)}", indent = 1)
+                    cprint(ics, "Parameter saved in the map.", indent = 1)
+                }
+                "global" -> {
+                    if (updateIncandescent) {
+                        Eln.incandescentLampInfiniteLife = !aging
+                        Eln.config.get("lamp", "infiniteIncandescentLife", false).set(Eln.incandescentLampInfiniteLife)
+                    }
+                    if (updateEco) {
+                        Eln.ecoLampInfiniteLife = !aging
+                        Eln.config.get("lamp", "infiniteEcoLife", false).set(Eln.ecoLampInfiniteLife)
+                    }
+                    if (updateLed) {
+                        Eln.ledLampInfiniteLife = !aging
+                        Eln.config.get("lamp", "infiniteLedLife", false).set(Eln.ledLampInfiniteLife)
+                    }
+                    if (updateHalogen) {
+                        Eln.halogenLampInfiniteLife = !aging
+                        Eln.config.get("lamp", "infiniteHalogenLife", false).set(Eln.halogenLampInfiniteLife)
+                    }
+                    Eln.config.save()
+
+                    cprint(ics, "Lamp aging: ${FC.DARK_GREEN}${bulbType}, ${FC.DARK_GREEN}${boolToStr(aging)}", indent = 1)
+                    cprint(ics, "Parameter saved in the config file.", indent = 1)
+                }
+                else -> printError = true
+            }
         }
+        else printError = true
+
+        if (printError) cprint(ics, "This command takes three arguments - domain, bulb type, aging")
     }
 
     override fun getManPage(ics: ICommandSender, args: List<String>) {
         cprint(ics, "Enables/disables aging on lamps.", indent = 1)
-        cprint(ics, "Changes stored into the map.", indent = 1)
+        cprint(ics, "Changes stored into the map (local) or config file (global).", indent = 1)
         cprint(ics, "")
         cprint(ics, "Parameters :", indent = 1)
-        cprint(ics, "@0:bool : Lamp aging (enabled/disabled).", indent = 2)
+        cprint(ics, "@0:string : Domain (local/global).", indent = 2)
+        cprint(ics, "@1:string : Bulb Type (incandescent/eco/led/halogen/all).", indent = 2)
+        cprint(ics, "@2:bool : Aging (true/false).", indent = 2)
         cprint(ics, "")
     }
 
     override fun requiredPermission() = listOf(UserPermission.IS_OPERATOR)
 
     override fun getTabCompletion(args: List<String>): List<String> {
-        val options = listOf("true", "false")
-        return if (args.isEmpty() || args[0] == "") {
-            options
-        } else {
-            return options.filter {it.startsWith(args[0], ignoreCase = true)}
+        val arg0Options = listOf("local", "global")
+        val arg1Options = listOf("incandescent", "eco", "led", "halogen", "all")
+        val arg2Options = listOf("true", "false")
+
+        return when (args.size) {
+            0 -> arg0Options
+            1 -> {
+                if (args[0] == "") arg0Options
+                else arg0Options.filter {it.startsWith(args[0], ignoreCase = true)}
+            }
+            2 -> {
+                if (args[1] == "") arg1Options
+                else arg1Options.filter {it.startsWith(args[1], ignoreCase = true)}
+            }
+            3 -> {
+                if (args[2] == "") arg2Options
+                else arg2Options.filter {it.startsWith(args[2], ignoreCase = true)}
+            }
+            else -> listOf()
         }
     }
 }

--- a/src/main/kotlin/mods/eln/sixnode/lampsocket/LampSocketProcess.kt
+++ b/src/main/kotlin/mods/eln/sixnode/lampsocket/LampSocketProcess.kt
@@ -165,7 +165,12 @@ class LampSocketProcess(var lamp: LampSocketElement) : IProcess, INBTTReady /*,L
         if (newLight < 0) newLight = 0
 
         if (lampDescriptor != null) {
-            val bulbCanAge = !(lampDescriptor.type == LampDescriptor.Type.LED && Eln.ledLampInfiniteLife) && SaveConfig.instance!!.electricalLampAging
+            val bulbCanAge = when(lampDescriptor.type) {
+                LampDescriptor.Type.INCANDESCENT -> !Eln.incandescentLampInfiniteLife && !SaveConfig.instance!!.infiniteIncandescentLife
+                LampDescriptor.Type.ECO -> !Eln.ecoLampInfiniteLife && !SaveConfig.instance!!.infiniteEcoBulbLife
+                LampDescriptor.Type.LED -> !Eln.ledLampInfiniteLife && !SaveConfig.instance!!.infiniteLedBulbLife
+                LampDescriptor.Type.HALOGEN -> !Eln.halogenLampInfiniteLife && !SaveConfig.instance!!.infiniteHalogenBulbLife
+            }
 
             if (bulbCanAge) {
                 val currentLife = lampDescriptor.ageLamp(lampStack, lamp.lampResistor.voltage, time)

--- a/src/main/kotlin/mods/eln/transparentnode/floodlight/FloodlightProcess.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/floodlight/FloodlightProcess.kt
@@ -52,14 +52,14 @@ class FloodlightProcess(var element: FloodlightElement) : IProcess {
 
                 lampLightRanges.add(lampDescriptor.range)
 
-                val bulbCanAge = !Eln.halogenLampInfiniteLife && SaveConfig.instance!!.electricalLampAging
+                val bulbCanAge = !Eln.halogenLampInfiniteLife && !SaveConfig.instance!!.infiniteHalogenBulbLife
 
                 if (bulbCanAge) {
                     val currentLife = lampDescriptor.ageLamp(lampStacks[idx]!!, lampVoltage, time)
 
                     if (currentLife <= 0.0) {
                         element.inventory.setInventorySlotContents(idx, null)
-                        element.inventoryChange(element.inventory)
+                        element.inventory.markDirty()
                     }
                 }
             }


### PR DESCRIPTION
Update the `lampAging` command to handle the aging of each bulb type individually, as well as provide the option to update the global config file or save to the local world.

New syntax: `/eln lampAging [local/global] [incandescent/eco/led/halogen/all] [true/false]`. Should be pretty self-explanatory.

Note: There is an issue where the `man` command can't find the `lampAging` command for some reason. See issue #412.