### PR TITLE
Add `findConsoleCommand` utility and tests for case-insensitive comma…

### DIFF
--- a/src/main/kotlin/mods/eln/server/console/ElnConsoleCommands.kt
+++ b/src/main/kotlin/mods/eln/server/console/ElnConsoleCommands.kt
@@ -430,7 +430,6 @@ class ElnManCommand: IConsoleCommand {
     override val name = "man"
 
     override fun runCommand(ics: ICommandSender, args: List<String>) {
-        println("man command args: $args")
         when (args.size) {
             0 -> {
                 cprint(ics, "Returns help for a given command.", indent = 1)
@@ -440,7 +439,7 @@ class ElnManCommand: IConsoleCommand {
                 cprint(ics, "")
             }
             else -> {
-                val command = ElnConsoleCommandList.mapNotNull { if (it.name.lowercase() == args[0]) it else null }.firstOrNull()
+                val command = findConsoleCommand(args[0])
                 if (command == null) {
                     cprint(ics, "Sorry, but no man page was found for ${args[0]}", indent = 1)
                 } else {

--- a/src/main/kotlin/mods/eln/server/console/ElnConsoleHandler.kt
+++ b/src/main/kotlin/mods/eln/server/console/ElnConsoleHandler.kt
@@ -11,6 +11,13 @@ import java.util.*
 
 val ElnConsoleCommandList = mutableListOf<IConsoleCommand>()
 
+internal fun findConsoleCommand(
+    name: String,
+    commands: Iterable<IConsoleCommand> = ElnConsoleCommandList
+): IConsoleCommand? {
+    return commands.firstOrNull { it.name.equals(name, ignoreCase = true) }
+}
+
 class ElnConsoleCommands: ICommand {
 
     init {
@@ -128,18 +135,18 @@ class ElnConsoleCommands: ICommand {
             return
         }
         val permissions = determinePermissionsList(ics)
-        val command = ElnConsoleCommandList.filter { it.name.equals(args[0], ignoreCase = true) }
-        if (command.isEmpty()) {
+        val command = findConsoleCommand(args[0])
+        if (command == null) {
             cprint(ics,"${FC.DARK_CYAN}Command not found, run /eln ls for commands${FC.BRIGHT_GREY }")
             return
         }
         cprint(ics, "${FC.DARK_CYAN}${ics.commandSenderName} $${FC.DARK_YELLOW} /eln ${args.joinToString(" ")}")
-        val canRun = permissions.any { command[0].requiredPermission().contains(it) }
+        val canRun = permissions.any { command.requiredPermission().contains(it) }
         if (canRun) {
-            command[0].runCommand(ics, args.toList().drop(1))
+            command.runCommand(ics, args.toList().drop(1))
         } else {
             cprint(ics, "${FC.DARK_CYAN}You do not have permission to run that command. " +
-                "You need to have one of the following: ${command[0].requiredPermission()}${FC.BRIGHT_GREY }")
+                "You need to have one of the following: ${command.requiredPermission()}${FC.BRIGHT_GREY }")
         }
     }
 
@@ -175,11 +182,11 @@ class ElnConsoleCommands: ICommand {
         if (args.toList().isEmpty() || args[0] == "") {
             return ElnConsoleCommandList.map {it.name}.toMutableList()
         }
-        val command = ElnConsoleCommandList.filter { it.name.equals(args[0], ignoreCase = true) }
-        if (command.isEmpty()) {
+        val command = findConsoleCommand(args[0])
+        if (command == null) {
             return ElnConsoleCommandList.filter {it.name.startsWith(args[0], ignoreCase = true)}.map{it.name}.toMutableList()
         }
-        return command.first().getTabCompletion(args.drop(1)).toMutableList()
+        return command.getTabCompletion(args.drop(1)).toMutableList()
     }
 
     override fun isUsernameIndex(args: Array<out String>, index: Int): Boolean {

--- a/src/test/kotlin/mods/eln/server/console/ElnConsoleCommandLookupTest.kt
+++ b/src/test/kotlin/mods/eln/server/console/ElnConsoleCommandLookupTest.kt
@@ -1,0 +1,28 @@
+package mods.eln.server.console
+
+import net.minecraft.command.ICommandSender
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ElnConsoleCommandLookupTest {
+    private class TestCommand(override val name: String) : IConsoleCommand {
+        override fun runCommand(ics: ICommandSender, args: List<String>) {
+            error("Not used in lookup tests.")
+        }
+    }
+
+    @Test
+    fun findsMixedCaseCommandNamesIgnoringInputCase() {
+        val command = findConsoleCommand("polemap", listOf(TestCommand("poleMap"), TestCommand("debug")))
+
+        assertEquals("poleMap", command?.name)
+    }
+
+    @Test
+    fun returnsNullWhenCommandDoesNotExist() {
+        val command = findConsoleCommand("missing", listOf(TestCommand("poleMap"), TestCommand("debug")))
+
+        assertNull(command)
+    }
+}


### PR DESCRIPTION
…nd lookup

- Added `findConsoleCommand` to simplify case-insensitive console command retrieval.
- Replaced redundant lookup logic across `ElnConsoleCommands` and `ElnConsoleHandler` with `findConsoleCommand`.
- Removed unused debug print from `man` command implementation.
- Introduced unit tests in `ElnConsoleCommandLookupTest` to verify correct and null return cases.

I think this fixes #412