### PR TITLE
Add Y height temperature ramps to thermals

### DIFF
--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -142,6 +142,7 @@ public class Eln {
     public static double cableThermalSpikeLimitFactor = 20;
     public static boolean cableThermalSpikeLimiterEnabled = true;
     public static boolean lavaAmbientRampEnabled = true;
+    public static double undergroundBiomeTemperatureMultiplier = 0.2;
     public static final ThermalLoadInitializer cableThermalLoadInitializer =
      new ThermalLoadInitializer(cableWarmLimit, -100, cableHeatingTime, cableThermalConductionTao);
     public static final ThermalLoadInitializer sixNodeThermalLoadInitializer =

--- a/src/main/kotlin/mods/eln/config/ConfigHandler.kt
+++ b/src/main/kotlin/mods/eln/config/ConfigHandler.kt
@@ -194,6 +194,9 @@ object ConfigHandler {
         Eln.lavaAmbientRampEnabled =
             Eln.config["simulation", "lavaAmbientRampEnabled", true, "Blend ambient temperature toward 40C between Y20 and Y12, then clamp to 40C below Y12."]
                 .getBoolean(true)
+        Eln.undergroundBiomeTemperatureMultiplier =
+            Eln.config["simulation", "undergroundBiomeTemperatureMultiplier", 0.2, "Multiplier applied to biome ambient temperature when calculating the Y50 underground baseline: 12C + biomeTemp * multiplier."]
+                .getDouble(0.2)
 
         Eln.fuelHeatValueFactor = Eln.config["balancing", "fuelHeatValueFactor", 0.0000675, "Factor to apply when " +
                 "converting real word heat values to Minecraft heat values (1mB = 1l)."].double

--- a/src/main/kotlin/mods/eln/environment/BiomeClimateService.kt
+++ b/src/main/kotlin/mods/eln/environment/BiomeClimateService.kt
@@ -25,7 +25,6 @@ object BiomeClimateService {
     private const val LAVA_TRANSITION_START_Y = 20
     private const val LAVA_TRANSITION_END_Y = 12
     private const val UNDERGROUND_BASELINE_C = 12.0
-    private const val UNDERGROUND_BIOME_MULTIPLIER = 1.2
     private const val DEEP_UNDERGROUND_AMBIENT_C = 40.0
 
     private val profilesByBiomeName = HashMap<String, BiomeClimateProfile>()
@@ -320,7 +319,7 @@ object BiomeClimateService {
 
     @JvmStatic
     fun undergroundTemperatureCelsius(surfaceTemperatureCelsius: Double): Double {
-        return UNDERGROUND_BASELINE_C + surfaceTemperatureCelsius * UNDERGROUND_BIOME_MULTIPLIER
+        return UNDERGROUND_BASELINE_C + surfaceTemperatureCelsius * Eln.undergroundBiomeTemperatureMultiplier
     }
 
     private fun ensureLoaded() {

--- a/src/test/kotlin/mods/eln/environment/BiomeClimateServiceTest.kt
+++ b/src/test/kotlin/mods/eln/environment/BiomeClimateServiceTest.kt
@@ -77,13 +77,18 @@ class BiomeClimateServiceTest {
     @Test
     fun undergroundProfileTransitionsFromSurfaceToBiomeWeightedUnderground() {
         val surface = -10.0
+        val previous = Eln.undergroundBiomeTemperatureMultiplier
+        Eln.undergroundBiomeTemperatureMultiplier = 0.2
         val underground = BiomeClimateService.undergroundTemperatureCelsius(surface)
-
-        assertEquals(0.0, underground, 1.0e-9)
-        assertEquals(surface, BiomeClimateService.applyDepthTemperatureProfile(surface, 63), 1.0e-9)
-        assertEquals(underground, BiomeClimateService.applyDepthTemperatureProfile(surface, 50), 1.0e-9)
-        assertEquals(-80.0 / 13.0, BiomeClimateService.applyDepthTemperatureProfile(surface, 58), 1.0e-9)
-        assertEquals(underground, BiomeClimateService.applyDepthTemperatureProfile(surface, 30), 1.0e-9)
+        try {
+            assertEquals(10.0, underground, 1.0e-9)
+            assertEquals(surface, BiomeClimateService.applyDepthTemperatureProfile(surface, 63), 1.0e-9)
+            assertEquals(underground, BiomeClimateService.applyDepthTemperatureProfile(surface, 50), 1.0e-9)
+            assertEquals(-30.0 / 13.0, BiomeClimateService.applyDepthTemperatureProfile(surface, 58), 1.0e-9)
+            assertEquals(underground, BiomeClimateService.applyDepthTemperatureProfile(surface, 30), 1.0e-9)
+        } finally {
+            Eln.undergroundBiomeTemperatureMultiplier = previous
+        }
     }
 
     @Test
@@ -92,11 +97,11 @@ class BiomeClimateServiceTest {
         try {
             Eln.lavaAmbientRampEnabled = true
             assertEquals(40.0, BiomeClimateService.applyDepthTemperatureProfile(20.0, 12), 1.0e-9)
-            assertEquals(38.0, BiomeClimateService.applyDepthTemperatureProfile(20.0, 16), 1.0e-9)
+            assertEquals(28.0, BiomeClimateService.applyDepthTemperatureProfile(20.0, 16), 1.0e-9)
 
             Eln.lavaAmbientRampEnabled = false
-            assertEquals(36.0, BiomeClimateService.applyDepthTemperatureProfile(20.0, 16), 1.0e-9)
-            assertEquals(36.0, BiomeClimateService.applyDepthTemperatureProfile(20.0, 8), 1.0e-9)
+            assertEquals(16.0, BiomeClimateService.applyDepthTemperatureProfile(20.0, 16), 1.0e-9)
+            assertEquals(16.0, BiomeClimateService.applyDepthTemperatureProfile(20.0, 8), 1.0e-9)
         } finally {
             Eln.lavaAmbientRampEnabled = previous
         }


### PR DESCRIPTION
- Introduced `lavaAmbientRampEnabled` to control ambient temperature blending near lava layers.
- Added depth-based ambient temperature profile logic in `BiomeClimateService`.
- Updated configuration to include `lavaAmbientRampEnabled` toggle.
- Implemented unit tests verifying transitions from surface to underground biome temperatures and lava ramp behavior.