### PR TITLE
Adjust thermal limits for `CurrentRelay` and `CurrentCable`

### DIFF
--- a/src/main/kotlin/mods/eln/sixnode/currentcable/CurrentCable.kt
+++ b/src/main/kotlin/mods/eln/sixnode/currentcable/CurrentCable.kt
@@ -57,10 +57,8 @@ class CurrentCableDescriptor(
         thermalC = 1.0
         this.description = description
         this.render = render
-        thermalWarmLimit = 100.0
-        thermalCoolLimit = -100.0
         thermalWarmLimit = Eln.cableWarmLimit
-        thermalCoolLimit = -10.0
+        thermalCoolLimit = -40.0
         Eln.simulator.checkThermalLoad(thermalRs, thermalRp, thermalC)
     }
 

--- a/src/main/kotlin/mods/eln/sixnode/currentrelay/CurrentRelay.kt
+++ b/src/main/kotlin/mods/eln/sixnode/currentrelay/CurrentRelay.kt
@@ -196,7 +196,7 @@ class CurrentRelayElement(sixNode: SixNode, side: Direction, descriptor: SixNode
 
         slowProcessList.add(thermalWatchdog)
         thermalWatchdog
-            .setTemperatureLimits(Eln.cableWarmLimit, -10.0)
+            .setTemperatureLimits(Eln.cableWarmLimit, cableDescriptor.thermalCoolLimit)
             .setDestroys(WorldExplosion(this).cableExplosion())
         thermalWatchdog.dumpMatrixOnTrip("CurrentRelayElement thermal trip") { this }
     }


### PR DESCRIPTION
- Updated `thermalCoolLimit` in `CurrentCable` to -40.0 for improved cooling behavior.
- Modified `CurrentRelay` to use `cableDescriptor.thermalCoolLimit` instead of a hardcoded value.