### PR TITLE
Fix clutches not ever allowing a shaft to rotate ever again

### DIFF
--- a/src/main/kotlin/mods/eln/mechanical/Clutch.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Clutch.kt
@@ -78,6 +78,10 @@ class ClutchPlateItem(
 
 class ClutchPinItem(name: String) : GenericItemUsingDamageDescriptorWithComment(name, tr("Prevents clutches from slipping\nagain after they stop.").split("\n").toTypedArray())
 
+internal fun canClutchStopSlipping(leftShaft: ShaftNetwork, rightShaft: ShaftNetwork): Boolean {
+    return leftShaft !is StaticShaftNetwork && rightShaft !is StaticShaftNetwork
+}
+
 class ClutchDescriptor(name: String, override val obj: Obj3D) : SimpleShaftDescriptor(name, ClutchElement::class, ClutchRender::class, EntityMetaTag.Basic) {
     companion object {
         val degToRad = 360.0 / (2 * Math.PI)
@@ -285,6 +289,10 @@ class ClutchElement(node: TransparentNode, desc_: TransparentNodeDescriptor) : S
                 //if (slower.rads >= faster.rads - margin)
                 if (Math.signum(rightShaft.rads - leftShaft.rads) != Math.signum(preRads[RIGHT] - preRads[LEFT]))
                 {
+                    if (!canClutchStopSlipping(leftShaft, rightShaft)) {
+                        clutchPlateDescriptor!!.setWear(clutchPlateStack!!, wear + clutching * slipWearF.getValue(Math.abs(deltaR)))
+                        return
+                    }
                     // Sign change
                     //Utils.println("CPP.p: Sign change")
                     val dWFast = faster.rads - preRads[fasterIdx]

--- a/src/test/kotlin/mods/eln/mechanical/ClutchLogicTest.kt
+++ b/src/test/kotlin/mods/eln/mechanical/ClutchLogicTest.kt
@@ -1,0 +1,22 @@
+package mods.eln.mechanical
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClutchLogicTest {
+    @Test
+    fun clutchCannotStopSlippingWhenLeftSideIsStatic() {
+        assertFalse(canClutchStopSlipping(StaticShaftNetwork(), ShaftNetwork()))
+    }
+
+    @Test
+    fun clutchCannotStopSlippingWhenRightSideIsStatic() {
+        assertFalse(canClutchStopSlipping(ShaftNetwork(), StaticShaftNetwork()))
+    }
+
+    @Test
+    fun clutchCanStopSlippingWhenBothSidesRotateFreely() {
+        assertTrue(canClutchStopSlipping(ShaftNetwork(), ShaftNetwork()))
+    }
+}


### PR DESCRIPTION
- Introduced `canClutchStopSlipping` method to determine clutch slip behavior based on shaft networks.
- Integrated the method into clutch mechanics to handle static and rotating shaft conditions.
- Added `ClutchLogicTest` to validate various clutch slip scenarios.