### PR TITLE
Fix clutch acting like a normal shaft

### DIFF
--- a/src/main/kotlin/mods/eln/mechanical/Clutch.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Clutch.kt
@@ -291,6 +291,7 @@ class ClutchElement(node: TransparentNode, desc_: TransparentNodeDescriptor) : S
                 {
                     if (!canClutchStopSlipping(leftShaft, rightShaft)) {
                         clutchPlateDescriptor!!.setWear(clutchPlateStack!!, wear + clutching * slipWearF.getValue(Math.abs(deltaR)))
+                        slipping = false
                         return
                     }
                     // Sign change


### PR DESCRIPTION
As mentioned in my Issue #431 regarding that clutches are acting like normal shafts I noticed that the fix introduced by commit 46ab422 which was supposed to fix the issue #421 of "Fix clutches not ever allowing a shaft to rotate ever again" also made an error.

It returns from the process function inside the kotlin code for the clutch early which causes it to be unable to ever set slipping to false, therefore causing it to act as an shaft, normalizing both rad values of both sides as if the input signal was always true.

I merely added an slipping assignment to false which fixed the issue in my playtests, tho there may need to be more testing to make sure that this does not cause yet another problem.
