### PR TITLE
Solar panels can be placed in any direction

### DIFF
--- a/src/main/java/mods/eln/transparentnode/solarpanel/SolarPanelDescriptor.java
+++ b/src/main/java/mods/eln/transparentnode/solarpanel/SolarPanelDescriptor.java
@@ -7,7 +7,6 @@ import mods.eln.misc.Obj3D.Obj3DPart;
 import mods.eln.node.transparent.TransparentNodeDescriptor;
 import mods.eln.sim.ElectricalLoad;
 import mods.eln.wiki.Data;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -90,16 +89,6 @@ public class SolarPanelDescriptor extends TransparentNodeDescriptor {
         if (alpha > alphaMax) return alphaMax;
         if (alpha < alphaMin) return alphaMin;
         return alpha;
-    }
-
-    @Override
-    public Direction getFrontFromPlace(Direction side, EntityLivingBase entityLiving) {
-        if (canRotate && groundCoordinate != null) {
-            // That is, if this isn't a 1x1 panel.
-            return Direction.ZN;
-        } else {
-            return super.getFrontFromPlace(side, entityLiving);
-        }
     }
 
     void draw(float alpha, Direction front) {


### PR DESCRIPTION
Title. All solar panels can be oriented in any direction in the world, with rotatable panels still able to track the sun.

<img width="854" height="480" alt="2026-03-27_18 51 58" src="https://github.com/user-attachments/assets/36e0ae51-49a5-4139-93ab-4358fa0d7563" />