### PR TITLE
Add regex-based config path read/write support

### DIFF
--- a/src/main/kotlin/mods/eln/config/JsonConfig.kt
+++ b/src/main/kotlin/mods/eln/config/JsonConfig.kt
@@ -4,7 +4,6 @@ import com.google.gson.GsonBuilder
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
-import mods.eln.Eln
 import mods.eln.Other
 import mods.eln.item.LampLists
 import mods.eln.misc.Utils
@@ -15,6 +14,7 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.util.Locale
 import java.util.UUID
+import java.util.regex.PatternSyntaxException
 import kotlin.math.max
 import kotlin.math.min
 
@@ -265,6 +265,30 @@ class JsonConfig(private val legacyCfgFile: File) {
     }
 
     /**
+     * Reads every persisted config path whose full dotted path matches [pathPattern].
+     * Each dot-delimited path segment is treated as a regex segment, except `*` which expands to `.*`.
+     */
+    @Suppress("unused")
+    fun readPathsMatching(pathPattern: String): LinkedHashMap<String, Any> {
+        populateDefaults()
+        val canonicalPattern = pathPattern.trim()
+        val compiledPattern = try {
+            compilePathPattern(canonicalPattern)
+        } catch (e: PatternSyntaxException) {
+            throw IllegalArgumentException("Invalid config path regex '$canonicalPattern': ${e.message}")
+        }
+        val result = linkedMapOf<String, Any>()
+        values.keys
+            .filter { it.matches(compiledPattern) }
+            .sorted()
+            .forEach { path -> result[path] = values.getValue(path) }
+        if (result.isEmpty()) {
+            throw IllegalArgumentException("No config paths matched '$canonicalPattern'")
+        }
+        return result
+    }
+
+    /**
      * Registers an additional persisted config entry owned by another subsystem.
      */
     @Suppress("unused")
@@ -298,7 +322,7 @@ class JsonConfig(private val legacyCfgFile: File) {
      * Parses and writes a string value to a persisted config path, then reloads derived runtime caches.
      */
     @Suppress("unused")
-    fun writePath(path: String, rawValue: String, eln: Eln): String {
+    fun writePath(path: String, rawValue: String): String {
         populateDefaults()
         val canonicalPath = path.trim()
         val existing = values[canonicalPath] ?: throw IllegalArgumentException("Unknown config path '$canonicalPath'")
@@ -306,6 +330,34 @@ class JsonConfig(private val legacyCfgFile: File) {
         save()
         loadConfig()
         return formatValue(values.getValue(canonicalPath))
+    }
+
+    /**
+     * Writes a value to every persisted config path whose full dotted path matches [pathPattern].
+     * Each dot-delimited path segment is treated as a regex segment, except `*` which expands to `.*`.
+     */
+    @Suppress("unused")
+    fun writePathsMatching(pathPattern: String, rawValue: String): List<String> {
+        populateDefaults()
+        val canonicalPattern = pathPattern.trim()
+        val compiledPattern = try {
+            compilePathPattern(canonicalPattern)
+        } catch (e: PatternSyntaxException) {
+            throw IllegalArgumentException("Invalid config path regex '$canonicalPattern': ${e.message}")
+        }
+        val matchedPaths = values.keys
+            .filter { it.matches(compiledPattern) }
+            .sorted()
+        if (matchedPaths.isEmpty()) {
+            throw IllegalArgumentException("No config paths matched '$canonicalPattern'")
+        }
+        matchedPaths.forEach { path ->
+            val existing = values.getValue(path)
+            values[path] = parseRawValue(rawValue, existing)
+        }
+        save()
+        loadConfig()
+        return matchedPaths
     }
 
     /**
@@ -628,6 +680,18 @@ class JsonConfig(private val legacyCfgFile: File) {
     }
 
     private fun joinPath(parts: List<String>): String = parts.joinToString(".")
+
+    private fun compilePathPattern(pathPattern: String): Regex {
+        val regex = pathPattern
+            .split('.')
+            .joinToString("\\.") { segment ->
+                when (segment) {
+                    "*" -> ".*"
+                    else -> segment
+                }
+            }
+        return Regex("^$regex$")
+    }
 
     private fun registerSpecComments() {
         for (spec in specs) {

--- a/src/main/kotlin/mods/eln/server/console/ElnConsoleCommands.kt
+++ b/src/main/kotlin/mods/eln/server/console/ElnConsoleCommands.kt
@@ -97,7 +97,10 @@ private fun clearElnBlock(world: World, x: Int, y: Int, z: Int): Boolean {
 }
 
 private fun saveConfigPath(path: String, value: Any): String =
-    Eln.config.writePath(path, value.toString(), Eln.instance)
+    Eln.config.writePath(path, value.toString())
+
+private fun isConfigPathPattern(path: String): Boolean =
+    path.any { it in "*+?[](){}|^$\\" }
 
 class ElnLsCommand: IConsoleCommand {
     override val name = "ls"
@@ -126,12 +129,23 @@ class ElnConfigCommand : IConsoleCommand {
                     cprint(ics, "Usage: /eln config get <path>", indent = 1)
                     return
                 }
-                val value = Eln.config.readPath(path)
-                if (value == null) {
-                    cprint(ics, "${FC.BRIGHT_RED}Unknown config path '$path'.", indent = 1)
-                    return
+                try {
+                    if (isConfigPathPattern(path)) {
+                        val values = Eln.config.readPathsMatching(path)
+                        values.forEach { (matchedPath, value) ->
+                            cprint(ics, "${FC.BRIGHT_GREEN}$matchedPath = $value", indent = 1)
+                        }
+                    } else {
+                        val value = Eln.config.readPath(path)
+                        if (value == null) {
+                            cprint(ics, "${FC.BRIGHT_RED}Unknown config path '$path'.", indent = 1)
+                            return
+                        }
+                        cprint(ics, "${FC.BRIGHT_GREEN}$path = $value", indent = 1)
+                    }
+                } catch (e: IllegalArgumentException) {
+                    cprint(ics, "${FC.BRIGHT_RED}${e.message}", indent = 1)
                 }
-                cprint(ics, "${FC.BRIGHT_GREEN}$path = $value", indent = 1)
             }
             "set" -> {
                 val path = args.getOrNull(1)
@@ -141,8 +155,16 @@ class ElnConfigCommand : IConsoleCommand {
                 }
                 val rawValue = args.drop(2).joinToString(" ")
                 try {
-                    val writtenValue = Eln.config.writePath(path, rawValue, Eln.instance)
-                    cprint(ics, "${FC.BRIGHT_GREEN}$path = $writtenValue", indent = 1)
+                    if (isConfigPathPattern(path)) {
+                        val matchedPaths = Eln.config.writePathsMatching(path, rawValue)
+                        cprint(ics, "${FC.BRIGHT_GREEN}Updated ${matchedPaths.size} config paths.", indent = 1)
+                        matchedPaths.forEach { matchedPath ->
+                            cprint(ics, "$matchedPath = ${Eln.config.readPath(matchedPath)}", indent = 2)
+                        }
+                    } else {
+                        val writtenValue = Eln.config.writePath(path, rawValue)
+                        cprint(ics, "${FC.BRIGHT_GREEN}$path = $writtenValue", indent = 1)
+                    }
                     cprint(ics, "Changes saved to config/eln/eln.json.", indent = 1)
                 } catch (e: IllegalArgumentException) {
                     cprint(ics, "${FC.BRIGHT_RED}${e.message}", indent = 1)
@@ -175,7 +197,9 @@ class ElnConfigCommand : IConsoleCommand {
         cprint(ics, "This command updates the cache and writes back to config/eln/eln.json.", indent = 1)
         cprint(ics, "", indent = 1)
         cprint(ics, "Usage: /eln config get <path>", indent = 1)
+        cprint(ics, "Usage: /eln config get <path-regex>", indent = 1)
         cprint(ics, "Usage: /eln config set <path> <value>", indent = 1)
+        cprint(ics, "Usage: /eln config set <path-regex> <value>", indent = 1)
         cprint(ics, "Usage: /eln config list [prefix]", indent = 1)
     }
 

--- a/src/test/kotlin/mods/eln/config/JsonConfigTest.kt
+++ b/src/test/kotlin/mods/eln/config/JsonConfigTest.kt
@@ -113,4 +113,23 @@ class JsonConfigTest {
             FuelRegistry.heatEnergyPerMilliBucket("creosote")
         )
     }
+
+    @Test
+    fun regexReadAndWriteWorkForConfigPaths() {
+        val dir = Files.createTempDirectory("eln-json-regex-test").toFile()
+        val config = JsonConfig(dir.resolve("Eln.cfg"))
+        Eln.config = config
+        config.load()
+
+        val lampPaths = config.readPathsMatching("lighting.lamps.*.infiniteLifeEnabled")
+        assertTrue(lampPaths.isNotEmpty())
+        assertTrue(lampPaths.values.all { it is Boolean })
+
+        val updatedPaths = config.writePathsMatching(
+            "lighting.lamps.*.infiniteLifeEnabled",
+            "true"
+        )
+        assertEquals(lampPaths.keys.toSet(), updatedPaths.toSet())
+        assertTrue(updatedPaths.all { config.getBooleanOrElse(it, false) })
+    }
 }


### PR DESCRIPTION
- Introduced `readPathsMatching` and `writePathsMatching` methods in `JsonConfig` to allow reading and updating multiple config paths using regex patterns.
- Added `isConfigPathPattern` helper to detect regex-based paths.
- Enhanced `/eln config` command to handle regex-based get/set operations.
- Updated unit tests to verify regex-based config path functionality.