### PR TITLE
Increase the maximum expression length in the Signal Processor to 600 characters. 

### DIFF
--- a/src/main/java/mods/eln/gui/GuiContainerEln.java
+++ b/src/main/java/mods/eln/gui/GuiContainerEln.java
@@ -55,6 +55,12 @@ public abstract class GuiContainerEln extends GuiContainer implements IGuiObject
         return o;
     }
 
+    public GuiTextFieldEln newGuiTextField(int x, int y, int width, int maxLength) {
+        GuiTextFieldEln o = helper.newGuiTextField(x, y, width, maxLength);
+        o.setObserver(this);
+        return o;
+    }
+
     public GuiButtonEln newGuiButton(int x, int y, int width, String name) {
         GuiButtonEln o = helper.newGuiButton(x, y, width, name);
         o.setObserver(this);

--- a/src/main/java/mods/eln/gui/GuiHelper.java
+++ b/src/main/java/mods/eln/gui/GuiHelper.java
@@ -39,9 +39,13 @@ public class GuiHelper {
     }
 
     GuiTextFieldEln newGuiTextField(int x, int y, int width) {
+        return newGuiTextField(x, y, width, 150);
+    }
+
+    GuiTextFieldEln newGuiTextField(int x, int y, int width, int maxLength) {
         GuiTextFieldEln o;
         o = new GuiTextFieldEln(Minecraft.getMinecraft().fontRenderer,
-            screen.width / 2 - xSize / 2 + x, screen.height / 2 - ySize / 2 + y, width, 12, this);
+            screen.width / 2 - xSize / 2 + x, screen.height / 2 - ySize / 2 + y, width, 12, this, maxLength);
         objectList.add(o);
         return o;
     }

--- a/src/main/java/mods/eln/gui/GuiTextFieldEln.java
+++ b/src/main/java/mods/eln/gui/GuiTextFieldEln.java
@@ -17,11 +17,15 @@ public class GuiTextFieldEln extends GuiTextField implements IGuiObject {
     IGuiObjectObserver iGuiObjectObserver;
 
     public GuiTextFieldEln(FontRenderer par1FontRenderer, int x, int y, int w, int h, GuiHelper helper) {
+        this(par1FontRenderer, x, y, w, h, helper, 150);
+    }
+
+    public GuiTextFieldEln(FontRenderer par1FontRenderer, int x, int y, int w, int h, GuiHelper helper, int maxLength) {
         super(par1FontRenderer, x, y, w, h);
         setTextColor(-1);
         setDisabledTextColour(-1);
         setEnableBackgroundDrawing(true);
-        setMaxStringLength(150);
+        setMaxStringLength(maxLength);
         xPos = x;
         yPos = y;
         width = w;

--- a/src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathGui.java
+++ b/src/main/java/mods/eln/sixnode/electricalmath/ElectricalMathGui.java
@@ -30,7 +30,7 @@ public class ElectricalMathGui extends GuiContainerEln {
     public void initGui() {
         super.initGui();
 
-        expression = newGuiTextField(8, 8, 176 - 16 + 44);
+        expression = newGuiTextField(8, 8, 176 - 16 + 44, 600);
         expression.setText(render.expression);
         expression.setObserver(this);
         expression.setComment(new String[]{tr("Output voltage formula"),


### PR DESCRIPTION
This is my first PR - I'm not a Java developer, and it pains me to see no way to specify optional parameters without creating overloads...

The goal is to increase the character limit in the expression input field of the signal handler to 600, without affecting the UI of other state machines.