### PR TITLE
Added CoFHCore as a required dependency

### DIFF
--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -110,8 +110,11 @@ import java.util.*;
 import static mods.eln.i18n.I18N.TR;
 import static mods.eln.i18n.I18N.tr;
 
-@Mod(modid = Eln.MODID, name = Eln.NAME, version = Tags.VERSION, dependencies = "after:CoFHCore;after:CoFHAPI;" +
-        "after:CoFHAPI|energy")
+@Mod(
+        modid = Eln.MODID,
+        name = Eln.NAME,
+        version = Tags.VERSION,
+        dependencies = "required-after:CoFHCore")
 public class Eln {
     @Instance("Eln")
     public static Eln instance;

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -13,8 +13,8 @@
 		"logoFile": "assets/eln/logo.png",
 		"screenshots": [],
 		"parent": "",
-		"requiredMods": [],
-		"dependencies": [],
+		"requiredMods": ["CoFHCore"],
+		"dependencies": ["CoFHCore"],
 		"dependants": [],
 		"useDependencyInformation": false
 	}]


### PR DESCRIPTION
This change has been long overdue.

## What changed
Fixes the crash that occurred when CoFHCore was not installed. Now, if a user tries to launch without it, Forge stops the initialization and notifies them to install the missing dependency.