### PR TITLE
Added infinite clutch plate life config option

### DIFF
--- a/src/main/kotlin/mods/eln/config/JsonConfig.kt
+++ b/src/main/kotlin/mods/eln/config/JsonConfig.kt
@@ -10,6 +10,7 @@ import mods.eln.Other
 import mods.eln.item.TurbineBladeLists
 import mods.eln.item.lampitem.BoilerplateLampData
 import mods.eln.item.lampitem.LampLists
+import mods.eln.mechanical.ClutchPlateItem
 import mods.eln.misc.Utils
 import java.io.File
 import java.io.FileReader
@@ -240,6 +241,7 @@ class JsonConfig @JvmOverloads constructor(
 
         LampLists.loadAllLampConfigs()
         for (bladeData in TurbineBladeLists.bladeConfigList) bladeData.loadConfig()
+        ClutchPlateItem.infiniteLifeEnabled = getBooleanOrElse("items.clutchPlates.infiniteLifeEnabled", false)
 
         val analyticsEnabled = getBooleanOrElse("analytics.enabled", true)
         if (analyticsEnabled) {
@@ -843,6 +845,7 @@ class JsonConfig @JvmOverloads constructor(
                 defaults["items.turbineBlades.${blade.tierName}.nominalLifeHours"] = blade.nominalLifeInHours
                 defaults["items.turbineBlades.${blade.tierName}.infiniteLifeEnabled"] = blade.infiniteLifeEnabled
             }
+            defaults["items.clutchPlates.infiniteLifeEnabled"] = ClutchPlateItem.infiniteLifeEnabled
         }
         return defaults
     }
@@ -913,6 +916,7 @@ class JsonConfig @JvmOverloads constructor(
             pathComments["items.turbineBlades.${blade.tierName}.nominalLifeHours"] = "Nominal turbine blade lifetime in hours for the ${blade.tierName} tier."
             pathComments["items.turbineBlades.${blade.tierName}.infiniteLifeEnabled"] = "Disable wear-out for ${blade.tierName} turbine blades."
         }
+        pathComments["items.clutchPlates.infiniteLifeEnabled"] = "Disable clutch plate wear-out."
     }
 
     private fun legacyKeysFor(spec: ConfigSpec): List<LegacyKey> = when (joinPath(spec.path)) {

--- a/src/main/kotlin/mods/eln/mechanical/Clutch.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Clutch.kt
@@ -36,6 +36,10 @@ class ClutchPlateItem(
     val maxDTF: Float, val minDTF: Float,
     val wearSpeed: Float, public val explodes: Boolean
 ) : GenericItemUsingDamageDescriptor(name) {
+    companion object {
+        var infiniteLifeEnabled: Boolean = false
+    }
+
     override fun getDefaultNBT() = NBTTagCompound()
 
     fun setWear(stack: ItemStack, wear: Double) {
@@ -290,7 +294,7 @@ class ClutchElement(node: TransparentNode, desc_: TransparentNodeDescriptor) : S
                 if (Math.signum(rightShaft.rads - leftShaft.rads) != Math.signum(preRads[RIGHT] - preRads[LEFT]))
                 {
                     if (!canClutchStopSlipping(leftShaft, rightShaft)) {
-                        clutchPlateDescriptor!!.setWear(clutchPlateStack!!, wear + clutching * slipWearF.getValue(Math.abs(deltaR)))
+                        if (!ClutchPlateItem.infiniteLifeEnabled) clutchPlateDescriptor!!.setWear(clutchPlateStack!!, wear + clutching * slipWearF.getValue(Math.abs(deltaR)))
                         slipping = false
                         return
                     }
@@ -314,7 +318,7 @@ class ClutchElement(node: TransparentNode, desc_: TransparentNodeDescriptor) : S
                         slower.rads = finalW
                     }
                 } else {
-                    clutchPlateDescriptor!!.setWear(clutchPlateStack!!, wear + clutching * slipWearF.getValue(Math.abs(deltaR)))
+                    if (!ClutchPlateItem.infiniteLifeEnabled) clutchPlateDescriptor!!.setWear(clutchPlateStack!!, wear + clutching * slipWearF.getValue(Math.abs(deltaR)))
                 }
             } else {
                 val maxE = clutching * maxStaticEnergyF.getValue(wear)


### PR DESCRIPTION
"f-f-f-friction" ~Martincitopants

## What changed

Adds a config option to disable clutch plate wear, similar to the
existing options for lamps and turbine blades.

## Notes

I wanted the change to be as minimal as possible, but I figure the clutch plate code structure should be rewritten to follow the same pattern as the Lamp and Turbine Blade descriptors in the future, eh?