### PR TITLE
Fixed relay rendering crash

### DIFF
--- a/src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayRender.java
+++ b/src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayRender.java
@@ -82,7 +82,10 @@ public class ElectricalRelayRender extends SixNodeElementRender {
     @Override
     public CableRenderDescriptor getCableRender(LRDU lrdu) {
         if (lrdu == front) return Eln.instance.signalCableDescriptor.render;
-        if (lrdu == front.left() || lrdu == front.right()) return descriptor.cable.render;
+        if (lrdu == front.left() || lrdu == front.right()) {
+            if (descriptor.cable == null) return null;
+            return descriptor.cable.render;
+        }
         return null;
     }
 }


### PR DESCRIPTION
## What changed

- Placing a visible relay causes a client crash because ElectricalRelayRender.getCableRender dereferences descriptor.cable.render when cable is null. This happens for all visible relay variants since they use the alternate descriptor constructor that intentionally sets cable to null. The fix adds a null guard matching the base class default behavior.