### PR TITLE
Rename mod ID: integration mods

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ modName = Electrical Age - jrddunbr's build
 
 # Case-sensitive identifier string, available for mcmod.info population and used for automatic mixin JSON generation.
 # Conventionally lowercase.
-modId = Eln
+modId = eln
 
 # Root package of the mod, used to find various classes in other properties,
 # mcmod.info substitution, enabling assertions in run tasks, etc.

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -120,11 +120,11 @@ import static mods.eln.i18n.I18N.tr;
         version = Tags.VERSION,
         dependencies = "required-after:CoFHCore")
 public class Eln {
-    @Instance("Eln")
+    @Instance("eln")
     public static Eln instance;
     @SidedProxy(clientSide = "mods.eln.client.ClientProxy", serverSide = "mods.eln.CommonProxy")
     public static CommonProxy proxy;
-    public final static String MODID = "Eln";
+    public final static String MODID = "eln";
     public final static Logger LOGGER = LogManager.getLogger(MODID);
     public final static String NAME = "Electrical Age - jrddunbr's build";
     public final static String UPDATE_URL = "https://github.com/age-series/ElectricalAge/releases";
@@ -294,7 +294,7 @@ public class Eln {
     }
 
     public static ItemStack findItemStack(String name, int stackSize) {
-        ItemStack stack = GameRegistry.findItemStack("Eln", name, stackSize);
+        ItemStack stack = GameRegistry.findItemStack("eln", name, stackSize);
         if (stack == null) {
             stack = dictionnaryOreFromMod.get(name);
             stack = Utils.newItemStack(Item.getIdFromItem(stack.getItem()), stackSize, stack.getItemDamage());

--- a/src/main/java/mods/eln/Other.java
+++ b/src/main/java/mods/eln/Other.java
@@ -15,7 +15,7 @@ public class Other {
 
     public static final String modIdIc2 = "IC2";
     public static final String modIdOc = "OpenComputers";
-    public static final String modIdTe = "Eln";
+    public static final String modIdTe = "eln";
     public static final String modIdCc = "ComputerCraft";
 
     public static void check() {

--- a/src/main/kotlin/mods/eln/registration/ItemRegistration.kt
+++ b/src/main/kotlin/mods/eln/registration/ItemRegistration.kt
@@ -1886,7 +1886,7 @@ object ItemRegistration {
                 ArmorMaterial.IRON, 2, ArmourType.Helmet, "eln:textures" +
                         "/armor/copper_layer_1.png", "eln:textures/armor/copper_layer_2.png"
             ).setUnlocalizedName(name).setTextureName("eln:copper_helmet").setCreativeTab(Eln.creativeTabToolsArmor) as ItemArmor
-            GameRegistry.registerItem(Eln.helmetCopper, "Eln.$name")
+            GameRegistry.registerItem(Eln.helmetCopper, "eln.$name")
             GameRegistry.registerCustomItemStack(name, ItemStack(Eln.helmetCopper))
         }
         run {
@@ -1896,7 +1896,7 @@ object ItemRegistration {
                         ":textures/armor/copper_layer_1.png", "eln:textures/armor/copper_layer_2.png"
             ).setUnlocalizedName(name).setTextureName("eln:copper_chestplate")
                 .setCreativeTab(Eln.creativeTabToolsArmor) as ItemArmor
-            GameRegistry.registerItem(Eln.chestplateCopper, "Eln.$name")
+            GameRegistry.registerItem(Eln.chestplateCopper, "eln.$name")
             GameRegistry.registerCustomItemStack(name, ItemStack(Eln.chestplateCopper))
         }
         run {
@@ -1906,7 +1906,7 @@ object ItemRegistration {
                         "/armor/copper_layer_1.png", "eln:textures/armor/copper_layer_2.png"
             ).setUnlocalizedName(name).setTextureName("eln:copper_leggings")
                 .setCreativeTab(Eln.creativeTabToolsArmor) as ItemArmor
-            GameRegistry.registerItem(Eln.legsCopper, "Eln.$name")
+            GameRegistry.registerItem(Eln.legsCopper, "eln.$name")
             GameRegistry.registerCustomItemStack(name, ItemStack(Eln.legsCopper))
         }
         run {
@@ -1915,7 +1915,7 @@ object ItemRegistration {
                 ArmorMaterial.IRON, 2, ArmourType.Boots, "eln:textures" +
                         "/armor/copper_layer_1.png", "eln:textures/armor/copper_layer_2.png"
             ).setUnlocalizedName(name).setTextureName("eln:copper_boots").setCreativeTab(Eln.creativeTabToolsArmor) as ItemArmor
-            GameRegistry.registerItem(Eln.bootsCopper, "Eln.$name")
+            GameRegistry.registerItem(Eln.bootsCopper, "eln.$name")
             GameRegistry.registerCustomItemStack(name, ItemStack(Eln.bootsCopper))
         }
         val t1 = "eln:textures/armor/ecoal_layer_1.png"
@@ -1936,7 +1936,7 @@ object ItemRegistration {
                 "eln" +
                         ":ecoal_helmet"
             ).setCreativeTab(Eln.creativeTabToolsArmor) as ItemArmor
-            GameRegistry.registerItem(Eln.helmetECoal, "Eln.$name")
+            GameRegistry.registerItem(Eln.helmetECoal, "eln.$name")
             GameRegistry.registerCustomItemStack(name, ItemStack(Eln.helmetECoal))
         }
         run {
@@ -1947,7 +1947,7 @@ object ItemRegistration {
                 2000.0, armor / 20.0, armor * energyPerDamage, energyPerDamage
             ).setUnlocalizedName(name).setTextureName("eln:ecoal_chestplate")
                 .setCreativeTab(Eln.creativeTabToolsArmor) as ItemArmor
-            GameRegistry.registerItem(Eln.plateECoal, "Eln.$name")
+            GameRegistry.registerItem(Eln.plateECoal, "eln.$name")
             GameRegistry.registerCustomItemStack(name, ItemStack(Eln.plateECoal))
         }
         run {
@@ -1960,7 +1960,7 @@ object ItemRegistration {
                 "eln" +
                         ":ecoal_leggings"
             ).setCreativeTab(Eln.creativeTabToolsArmor) as ItemArmor
-            GameRegistry.registerItem(Eln.legsECoal, "Eln.$name")
+            GameRegistry.registerItem(Eln.legsECoal, "eln.$name")
             GameRegistry.registerCustomItemStack(name, ItemStack(Eln.legsECoal))
         }
         run {
@@ -1973,7 +1973,7 @@ object ItemRegistration {
                 "eln" +
                         ":ecoal_boots"
             ).setCreativeTab(Eln.creativeTabToolsArmor) as ItemArmor
-            GameRegistry.registerItem(Eln.bootsECoal, "Eln.$name")
+            GameRegistry.registerItem(Eln.bootsECoal, "eln.$name")
             GameRegistry.registerCustomItemStack(name, ItemStack(Eln.bootsECoal))
         }
     }
@@ -1986,7 +1986,7 @@ object ItemRegistration {
                 "eln" +
                         ":copper_sword"
             ).setCreativeTab(Eln.creativeTabToolsArmor)
-            GameRegistry.registerItem(Eln.swordCopper, "Eln.$name")
+            GameRegistry.registerItem(Eln.swordCopper, "eln.$name")
             GameRegistry.registerCustomItemStack(name, ItemStack(Eln.swordCopper))
         }
         run {
@@ -1994,7 +1994,7 @@ object ItemRegistration {
             Eln.hoeCopper =
                 ItemHoe(ToolMaterial.IRON).setUnlocalizedName(name).setTextureName("eln:copper_hoe")
                     .setCreativeTab(Eln.creativeTabToolsArmor)
-            GameRegistry.registerItem(Eln.hoeCopper, "Eln.$name")
+            GameRegistry.registerItem(Eln.hoeCopper, "eln.$name")
             GameRegistry.registerCustomItemStack(name, ItemStack(Eln.hoeCopper))
         }
         run {
@@ -2003,7 +2003,7 @@ object ItemRegistration {
                 "eln" +
                         ":copper_shovel"
             ).setCreativeTab(Eln.creativeTabToolsArmor)
-            GameRegistry.registerItem(Eln.shovelCopper, "Eln.$name")
+            GameRegistry.registerItem(Eln.shovelCopper, "eln.$name")
             GameRegistry.registerCustomItemStack(name, ItemStack(Eln.shovelCopper))
         }
         run {
@@ -2012,7 +2012,7 @@ object ItemRegistration {
                 "eln" +
                         ":copper_pickaxe"
             ).setCreativeTab(Eln.creativeTabToolsArmor)
-            GameRegistry.registerItem(Eln.pickaxeCopper, "Eln.$name")
+            GameRegistry.registerItem(Eln.pickaxeCopper, "eln.$name")
             GameRegistry.registerCustomItemStack(name, ItemStack(Eln.pickaxeCopper))
         }
         run {
@@ -2020,7 +2020,7 @@ object ItemRegistration {
             Eln.axeCopper =
                 ItemAxeEln(ToolMaterial.IRON).setUnlocalizedName(name).setTextureName("eln:copper_axe")
                     .setCreativeTab(Eln.creativeTabToolsArmor)
-            GameRegistry.registerItem(Eln.axeCopper, "Eln.$name")
+            GameRegistry.registerItem(Eln.axeCopper, "eln.$name")
             GameRegistry.registerCustomItemStack(name, ItemStack(Eln.axeCopper))
         }
     }


### PR DESCRIPTION
I have been working on an integration mod that uses classes from the mod directly (doesn't use the electrical API, but adds blocks into the mod directly, the electrical api is too basic for my use case), and for some reason I couldn't use Eln as a dependency, because forge normalizes it to lowercase (even if explicitly told not to in the mods info file!)

It kept bothering me, so I tried doing this..and it somehow worked.

I've discussed this problem in the Discord server earlier. My mod https://github.com/brambora69123/eln-to-hbm will not function without it properly.

if any other mod id is preferred let me know and ill change it in my mod too. (instead of eln perhaps electricalage could be a better mod id? but hbm nuclear tech mod as an example just has hbm)