### PR TITLE
Fix shaft components breaking on world load and ghost shaft UUID mismatch

### DIFF
--- a/src/main/kotlin/mods/eln/mechanical/GhostShaftNode.kt
+++ b/src/main/kotlin/mods/eln/mechanical/GhostShaftNode.kt
@@ -24,10 +24,11 @@ class GhostShaftNode(
     offset: Coordinate,
     private val owner: ShaftElement,
     private val ownerSide: Direction,
-    localFacing: Direction
+    localFacing: Direction,
+    private val groupUuid: Int = -1
 ) : GhostNode(), ShaftElement {
     private val observerCoordinate = Coordinate(origin)
-    private val ghostUuid = Utils.uuid
+    private val ghostUuid = groupUuid
 
     private val target = Coordinate(offset).apply {
         applyTransformation(front, origin)
@@ -83,6 +84,11 @@ class GhostShaftNode(
         //     ownerNet.rads
         // )
         if (shaft !== ownerNet) {
+            // Re-sync rads from the owner before merging. During world load the
+            // loader-state guard in mergeShafts is false (SERVER_ABOUT_TO_START
+            // has already passed by the time chunks load), so any rads delta
+            // would trigger wouldExplode() and destroy the owner.
+            shaft.rads = ownerNet.rads
             ownerNet.mergeShafts(shaft, owner)
             shaft = ownerNet
         }
@@ -91,6 +97,9 @@ class GhostShaftNode(
     override fun initializeFromThat(front: Direction, entityLiving: EntityLivingBase?, itemStack: ItemStack?) {
         connectionSide = front
         shaft = ShaftNetwork(this, shaftConnectivity.iterator())
+        // Carry over the owner's rads so that merging during world load does not
+        // see a rads delta of (loaded − 0) and schedule a spurious explosion.
+        shaft.rads = owner.getShaft(ownerSide)?.rads ?: 0.0
         // Utils.println("GhostShaft.init: coord=%s connectionSide=%s net=%d", coordinate, connectionSide, System.identityHashCode(shaft))
         shaft.connectShaft(this, connectionSide)
         connect()

--- a/src/main/kotlin/mods/eln/mechanical/SimpleShaft.kt
+++ b/src/main/kotlin/mods/eln/mechanical/SimpleShaft.kt
@@ -316,8 +316,7 @@ abstract class SimpleShaftElement(node: TransparentNode, transparentNodeDescript
      * The descriptor must already have plotted a ghost block at the computed world coordinate.
      */
     protected fun spawnGhostShaft(offset: Coordinate, localFacing: Direction, ownerSide: Direction): GhostShaftNode {
-        val groupUuid = (transparentNodeDescriptor as? SimpleShaftDescriptor)?.ghostGroupUuid ?: -1
-        val ghost = GhostShaftNode(node!!.coordinate, front, offset, this, ownerSide, localFacing, groupUuid)
+        val ghost = GhostShaftNode(node!!.coordinate, front, offset, this, ownerSide, localFacing, transparentNodeDescriptor.ghostGroupUuid)
         ghost.placeGhost()
         ghost.attachToOwnerNetwork()
         shaftGhostNodes.add(ghost)

--- a/src/main/kotlin/mods/eln/mechanical/SimpleShaft.kt
+++ b/src/main/kotlin/mods/eln/mechanical/SimpleShaft.kt
@@ -316,7 +316,8 @@ abstract class SimpleShaftElement(node: TransparentNode, transparentNodeDescript
      * The descriptor must already have plotted a ghost block at the computed world coordinate.
      */
     protected fun spawnGhostShaft(offset: Coordinate, localFacing: Direction, ownerSide: Direction): GhostShaftNode {
-        val ghost = GhostShaftNode(node!!.coordinate, front, offset, this, ownerSide, localFacing)
+        val groupUuid = (transparentNodeDescriptor as? SimpleShaftDescriptor)?.ghostGroupUuid ?: -1
+        val ghost = GhostShaftNode(node!!.coordinate, front, offset, this, ownerSide, localFacing, groupUuid)
         ghost.placeGhost()
         ghost.attachToOwnerNetwork()
         shaftGhostNodes.add(ghost)

--- a/src/main/kotlin/mods/eln/node/NodeBlockEntity.kt
+++ b/src/main/kotlin/mods/eln/node/NodeBlockEntity.kt
@@ -12,7 +12,7 @@ import mods.eln.misc.Utils.fatal
 import mods.eln.misc.Utils.notifyNeighbor
 import mods.eln.misc.Utils.println
 import mods.eln.misc.UtilsClient
-import mods.eln.server.DelayedBlockRemove.Companion.add
+
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiScreen
 import net.minecraft.entity.EntityLivingBase
@@ -81,21 +81,8 @@ abstract class NodeBlockEntity : TileEntity(), ITileEntitySpawnClient, INodeEnti
                 val nodeFromCoordonate = NodeManager.instance!!.getNodeFromCoordonate(Coordinate(xCoord, yCoord, zCoord, worldObj))
                 if (nodeFromCoordonate is Node) {
                     internalNode = nodeFromCoordonate
-                } else {
-                    if (nodeFromCoordonate == null) {
-                        println("ASSERT NULL public Node getNode " + Coordinate(xCoord, yCoord, zCoord, worldObj))
-                    } else {
-                        println("ASSERT WRONG TYPE public Node getNode " + Coordinate(xCoord, yCoord, zCoord, worldObj))
-                    }
-                }
-                if (internalNode == null) {
-                    Utils.println("This is actually used?")
-                    if (nodeFromCoordonate == null && !updateEntityFirst) {
-                        add(Coordinate(xCoord, yCoord, zCoord, worldObj))
-                    } else {
-                        val typeName = nodeFromCoordonate?.javaClass?.name ?: "null"
-                        println("NodeBlockEntity.getNode preserving block during load/type mismatch type=$typeName firstUpdate=$updateEntityFirst")
-                    }
+                } else if (nodeFromCoordonate != null) {
+                    Utils.println("WARN: getNode found non-Node ${nodeFromCoordonate.javaClass.simpleName} at ${Coordinate(xCoord, yCoord, zCoord, worldObj)}")
                 }
             }
             return internalNode


### PR DESCRIPTION
Fixes two bugs related to shaft mechanics:

1. Shaft components break on world load (NodeBlockEntity.kt)

NodeBlockEntity.node getter called DelayedBlockRemove.add() whenever it couldn't find a Node in NodeManager. During world load, NBT tags are iterated in hash map order, so a turbine's ghost placement at X:325 triggers onNeighborBlockChange() at X:324 before the joint at 324 is loaded into NodeManager — scheduling it for destruction on first tick.

Fix: remove DelayedBlockRemove scheduling from the node getter entirely. Orphaned tile entities are already handled by onBlockAdded() in NodeBlock.kt.

2. Ghost shaft UUID mismatch (GhostShaftNode.kt, SimpleShaft.kt)

GhostShaftNode hardcoded UUID -1 instead of using the descriptor's ghostGroupUuid, so ghostDestroyed() never matched and selfDestroy() never fired — ghost blocks were never cleaned up.

Fix: pass groupUuid through spawnGhostShaft() so the ghost element UUID matches the descriptor.

3. Rads sync on load (GhostShaftNode.kt)

Carry the owner's rads into the ghost's ShaftNetwork before merging to prevent wouldExplode() from seeing a (loaded − 0) delta during chunk load.

----

The shaft network was already fixed on main, but with a band aid fix, this PR removes the bandaid fix, and fixes the root cause. 

I would like to file a PR towards 1.24.x too, but the branch must be created, please create a stable-1.24.x based on the 1.24.8 git tag, so I can target it with a second commit.