### PR TITLE
Properly address NBT desync bug, improve keyhandler, and add server-to-client config sync

### DIFF
--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -19,6 +19,7 @@ import mods.eln.cable.CableRenderDescriptor;
 import mods.eln.client.ClientKeyHandler;
 import mods.eln.client.SoundLoader;
 import mods.eln.config.JsonConfig;
+import mods.eln.config.ServerConfigSyncHandler;
 import mods.eln.craft.CraftingRecipes;
 import mods.eln.entity.ReplicatorPopProcess;
 import mods.eln.environment.BiomeClimateService;
@@ -144,6 +145,7 @@ public class Eln {
     public static final byte packetClientToServerConnection = 21;
     public static final byte packetServerToClientInfo = 22;
     public static final byte packetFalstadImport = 23;
+    public static final byte packetServerConfigSync = 24;
     public static final Obj3DFolder obj = new Obj3DFolder();
     public static final double gateInputCurrent = 0.00005;
     public static final double gateOutputCurrent = 0.100;
@@ -522,6 +524,7 @@ public class Eln {
         MinecraftForge.EVENT_BUS.register(new RoomThermalBlockEventsHandler());
         MinecraftForge.EVENT_BUS.register(new ElectricMinecartChargeReporter());
         FMLCommonHandler.instance().bus().register(new ElnFMLEventsHandler());
+        FMLCommonHandler.instance().bus().register(ServerConfigSyncHandler.INSTANCE);
         MinecraftForge.EVENT_BUS.register(this);
         FMLInterModComms.sendMessage("Waila", "register", "mods.eln.integration.waila.WailaIntegration" +
                 ".callbackRegister");

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -16,7 +16,6 @@ import mods.eln.block.ArcClayItemBlock;
 import mods.eln.block.ArcMetalBlock;
 import mods.eln.block.ArcMetalItemBlock;
 import mods.eln.cable.CableRenderDescriptor;
-import mods.eln.client.ClientKeyHandler;
 import mods.eln.client.SoundLoader;
 import mods.eln.config.JsonConfig;
 import mods.eln.config.ServerConfigSyncHandler;
@@ -167,7 +166,6 @@ public class Eln {
     public static SimpleNetworkWrapper elnNetwork;
     public static PacketHandler packetHandler;
     public static LiveDataManager clientLiveDataManager;
-    public static ClientKeyHandler clientKeyHandler;
     public static SaveConfig saveConfig;
     public static GhostManager ghostManager;
     public static GhostManagerNbt ghostManagerNbt;

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -211,7 +211,6 @@ public class Eln {
     public static String simMetricsMqttServer = "";
     public static String simMetricsId = "server";
     public static int simMetricsPublishIntervalTicks = 20;
-    public static boolean debugEnabled = false;
     public static SiliconWafer siliconWafer;
     public static Transistor transistor;
     public static Thermistor thermistor;

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -516,7 +516,7 @@ public class Eln {
         TR_GROUP("ElnMachines", "Electrical Age - Machines");
         TR_GROUP("ElnCreative", "Electrical Age - Creative");
         TR_GROUP("ElnOther", "Electrical Age - Other");
-        /* if (isDevelopmentRun()) */ Achievements.init();
+        if (isDevelopmentRun()) Achievements.init();
         FluidRegistrationKt.registerElnFluids();
         MinecraftForge.EVENT_BUS.register(new ElnForgeEventsHandler());
         MinecraftForge.EVENT_BUS.register(new RoomThermalBlockEventsHandler());
@@ -661,8 +661,13 @@ public class Eln {
         }
     }
 
-    // "Temporarily" disabling all usages of this function to allow for proper multiplayer testing.
     public boolean isDevelopmentRun() {
-        return (Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment");
+        // This is used solely for testing purposes in multiplayer environments where it is necessary for an external
+        // client to join a server hosted by the IDE (i.e. at least two clients and one server are needed for testing).
+        // This flag should be temporarily set to TRUE before building the mod for a testing distribution.
+        boolean bypassDevEnvironmentCheck = false;
+
+        if (bypassDevEnvironmentCheck) return true;
+        else return (Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment");
     }
 }

--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -21,14 +21,14 @@ import mods.eln.client.SoundLoader;
 import mods.eln.config.JsonConfig;
 import mods.eln.craft.CraftingRecipes;
 import mods.eln.entity.ReplicatorPopProcess;
+import mods.eln.environment.BiomeClimateService;
 import mods.eln.eventhandlers.ElnFMLEventsHandler;
 import mods.eln.eventhandlers.ElnForgeEventsHandler;
 import mods.eln.eventhandlers.RoomThermalBlockEventsHandler;
 import mods.eln.fluid.ElnFluidRegistry;
+import mods.eln.fluid.FluidRegistrationKt;
 import mods.eln.fluid.FuelRegistry;
 import mods.eln.fluid.ThermalRegistry;
-import mods.eln.fluid.FluidRegistrationKt;
-import mods.eln.environment.BiomeClimateService;
 import mods.eln.generic.GenericCreativeTab;
 import mods.eln.generic.GenericItemUsingDamageDescriptor;
 import mods.eln.generic.GenericItemUsingDamageDescriptorWithComment;
@@ -41,9 +41,9 @@ import mods.eln.item.electricalinterface.ItemEnergyInventoryProcess;
 import mods.eln.item.lampitem.LampLists;
 import mods.eln.lightblock.LightBlock;
 import mods.eln.lightblock.LightBlockEntity;
+import mods.eln.metrics.MetricsSubsystem;
 import mods.eln.misc.*;
 import mods.eln.mqtt.MqttManager;
-import mods.eln.metrics.MetricsSubsystem;
 import mods.eln.node.NodeBlockEntity;
 import mods.eln.node.NodeManager;
 import mods.eln.node.NodeManagerNbt;
@@ -55,12 +55,15 @@ import mods.eln.ore.OreDescriptor;
 import mods.eln.ore.OreItem;
 import mods.eln.ore.OreScannerManager;
 import mods.eln.packets.*;
+import mods.eln.railroad.ElectricMinecartChargeReporter;
 import mods.eln.registration.ItemRegistration;
 import mods.eln.registration.SingleNodeRegistration;
 import mods.eln.registration.SixNodeRegistration;
 import mods.eln.registration.TransparentNodeRegistration;
-import mods.eln.railroad.ElectricMinecartChargeReporter;
-import mods.eln.server.*;
+import mods.eln.server.DelayedBlockRemove;
+import mods.eln.server.DelayedTaskManager;
+import mods.eln.server.SaveConfig;
+import mods.eln.server.ServerEventListener;
 import mods.eln.server.console.ElnConsoleCommands;
 import mods.eln.sim.Simulator;
 import mods.eln.sim.ThermalLoadInitializer;
@@ -98,9 +101,9 @@ import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.oredict.OreDictionary;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.config.Configuration;
@@ -110,7 +113,6 @@ import org.apache.logging.log4j.core.layout.PatternLayout;
 import java.io.File;
 import java.util.*;
 
-import static mods.eln.i18n.I18N.TR;
 import static mods.eln.i18n.I18N.TR_GROUP;
 import static mods.eln.i18n.I18N.tr;
 
@@ -514,9 +516,7 @@ public class Eln {
         TR_GROUP("ElnMachines", "Electrical Age - Machines");
         TR_GROUP("ElnCreative", "Electrical Age - Creative");
         TR_GROUP("ElnOther", "Electrical Age - Other");
-        if (isDevelopmentRun()) {
-            Achievements.init();
-        }
+        /* if (isDevelopmentRun()) */ Achievements.init();
         FluidRegistrationKt.registerElnFluids();
         MinecraftForge.EVENT_BUS.register(new ElnForgeEventsHandler());
         MinecraftForge.EVENT_BUS.register(new RoomThermalBlockEventsHandler());
@@ -661,6 +661,7 @@ public class Eln {
         }
     }
 
+    // "Temporarily" disabling all usages of this function to allow for proper multiplayer testing.
     public boolean isDevelopmentRun() {
         return (Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment");
     }

--- a/src/main/java/mods/eln/client/ClientProxy.java
+++ b/src/main/java/mods/eln/client/ClientProxy.java
@@ -36,7 +36,7 @@ public class ClientProxy extends CommonProxy {
 
         RenderingRegistry.registerEntityRenderingHandler(ReplicatorEntity.class, new ReplicatorRender(new ModelSilverfish(), (float) 0.3));
 
-        Eln.clientKeyHandler = new ClientKeyHandler();
+        Eln.clientKeyHandler = ClientKeyHandler.INSTANCE;
         FMLCommonHandler.instance().bus().register(Eln.clientKeyHandler);
         MinecraftForge.EVENT_BUS.register(new TutorialSignOverlay());
         uuidManager = new UuidManager();

--- a/src/main/java/mods/eln/client/ClientProxy.java
+++ b/src/main/java/mods/eln/client/ClientProxy.java
@@ -36,8 +36,7 @@ public class ClientProxy extends CommonProxy {
 
         RenderingRegistry.registerEntityRenderingHandler(ReplicatorEntity.class, new ReplicatorRender(new ModelSilverfish(), (float) 0.3));
 
-        Eln.clientKeyHandler = ClientKeyHandler.INSTANCE;
-        FMLCommonHandler.instance().bus().register(Eln.clientKeyHandler);
+        FMLCommonHandler.instance().bus().register(ClientKeyHandler.INSTANCE);
         MinecraftForge.EVENT_BUS.register(new TutorialSignOverlay());
         uuidManager = new UuidManager();
         soundClientEventListener = new SoundClientEventListener(uuidManager);

--- a/src/main/java/mods/eln/sim/Simulator.java
+++ b/src/main/java/mods/eln/sim/Simulator.java
@@ -4,7 +4,6 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent.Phase;
 import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
-import mods.eln.Eln;
 import mods.eln.environment.RoomThermalManager;
 import mods.eln.item.lampitem.LampLists;
 import mods.eln.metrics.MetricsSubsystem;
@@ -476,13 +475,13 @@ public class Simulator /* ,IPacketHandler */ {
             thermalFastNsStack = 0;
             slowNsStack = 0;
             thermalSlowNsStack = 0;
+        }
 
-            if (LampLists.INSTANCE.getResetLampLifeFlag()) {
-                if (++resetLampLifeTimeoutCounter == 2) { // Ensure that all lamp sockets have time to react to the flag by waiting between 1 and 2 seconds to reset the flag
-                    LampLists.INSTANCE.setResetLampLifeFlag(false);
-                    Utils.println("Reset all lamp lives to nominal.");
-                    resetLampLifeTimeoutCounter = 0;
-                }
+        if (LampLists.INSTANCE.getResetLampLifeFlag()) {
+            if (++resetLampLifeTimeoutCounter == 2) { // Keep the flag enabled for a minimum of one tick
+                LampLists.INSTANCE.setResetLampLifeFlag(false);
+                Utils.println("Reset all lamp lives to nominal.");
+                resetLampLifeTimeoutCounter = 0;
             }
         }
 

--- a/src/main/java/mods/eln/sim/mna/component/Resistor.java
+++ b/src/main/java/mods/eln/sim/mna/component/Resistor.java
@@ -36,7 +36,7 @@ public class Resistor extends Bipole {
             Utils.println("Error! Resistor cannot be set to " + resistance);
             // Call stack for debugging which node type it comes from;
             // this typically results in a cable going boom! somewhere
-            if (Eln.config.getBooleanOrElse("debug.logging.enabled", false))
+            if (Utils.isDebugEnabled())
                 Eln.LOGGER.error("Error! Resistor cannot be set to {}", resistance, new Throwable());
             return this;
         }

--- a/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerElement.java
+++ b/src/main/java/mods/eln/sixnode/batterycharger/BatteryChargerElement.java
@@ -1,6 +1,5 @@
 package mods.eln.sixnode.batterycharger;
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.item.MachineBoosterDescriptor;
 import mods.eln.item.electricalinterface.IItemEnergyBattery;
@@ -117,7 +116,7 @@ public class BatteryChargerElement extends SixNodeElement {
     public Map<String, String> getWaila() {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Charge Current"), Utils.plotAmpere("", powerLoad.getCurrent()));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Voltage"), Utils.plotVolt("", powerLoad.getVoltage()));
             info.put(I18N.tr("Power"), Utils.plotPower("", powerLoad.getCurrent() * powerLoad.getVoltage()));
         }

--- a/src/main/java/mods/eln/sixnode/diode/DiodeElement.java
+++ b/src/main/java/mods/eln/sixnode/diode/DiodeElement.java
@@ -1,6 +1,5 @@
 package mods.eln.sixnode.diode;
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -101,7 +100,7 @@ public class DiodeElement extends SixNodeElement {
     public Map<String, String> getWaila() {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Current"), Utils.plotAmpere("", anodeLoad.getCurrent()));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Forward Voltage"), Utils.plotVolt("", anodeLoad.getVoltage() - catodeLoad.getVoltage()));
             info.put(I18N.tr("Temperature"), plotAmbientCelsius("", thermalLoad.getTemperature()));
         }

--- a/src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalalarm/ElectricalAlarmElement.java
@@ -1,6 +1,5 @@
 package mods.eln.sixnode.electricalalarm;
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -89,7 +88,7 @@ public class ElectricalAlarmElement extends SixNodeElement {
     public Map<String, String> getWaila() {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Engaged"), inputGate.stateHigh() ? I18N.tr("Yes") : I18N.tr("No"));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Input Voltage"), Utils.plotVolt("", inputGate.getVoltage()));
         }
         return info;

--- a/src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalbreaker/ElectricalBreakerElement.java
@@ -2,20 +2,20 @@ package mods.eln.sixnode.electricalbreaker;
 
 import mods.eln.Eln;
 import mods.eln.i18n.I18N;
+import mods.eln.misc.Coordinate;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
 import mods.eln.misc.Utils;
 import mods.eln.node.Node;
-import mods.eln.node.NodeBlockEntity;
 import mods.eln.node.NodeBase;
+import mods.eln.node.NodeBlockEntity;
 import mods.eln.node.NodeConnection;
 import mods.eln.node.six.SixNode;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.node.six.SixNodeElement;
 import mods.eln.node.six.SixNodeElementInventory;
-import mods.eln.misc.Coordinate;
-import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ElectricalConnection;
+import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.Resistor;
 import mods.eln.sim.nbt.NbtElectricalLoad;
@@ -26,6 +26,7 @@ import mods.eln.sound.SoundCommand;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -34,7 +35,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import net.minecraft.tileentity.TileEntity;
 
 public class ElectricalBreakerElement extends SixNodeElement {
     private static final String BREAKER_CLOSE_SOUND = "eln:circuit_breaker_close";
@@ -163,7 +163,7 @@ public class ElectricalBreakerElement extends SixNodeElement {
         UtilityCableElement utilityCable = resolveWailaUtilityCable();
         if (utilityCable != null && !utilityCable.descriptor.getActsAsSingleConductor()) {
             putMultiConductorWaila(info, utilityCable);
-        } else if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        } else if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Voltages"), Utils.plotVolt("", aLoad.getVoltage()) + Utils.plotVolt(" ", bLoad.getVoltage()));
         }
         return info;

--- a/src/main/java/mods/eln/sixnode/electricalcable/ElectricalCableElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalcable/ElectricalCableElement.java
@@ -1,6 +1,5 @@
 package mods.eln.sixnode.electricalcable;
 
-import mods.eln.Eln;
 import mods.eln.generic.GenericItemUsingDamageDescriptor;
 import mods.eln.i18n.I18N;
 import mods.eln.item.BrushDescriptor;
@@ -123,7 +122,7 @@ public class ElectricalCableElement extends SixNodeElement {
         } else {
             info.put(I18N.tr("Current"), Utils.plotAmpere("", electricalLoad.getCurrent()));
             info.put(I18N.tr("Temperature"), plotAmbientCelsius("", thermalLoad.getTemperature()));
-            if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+            if (Utils.isWailaEasyModeEnabled()) {
                 info.put(I18N.tr("Voltage"), Utils.plotVolt("", electricalLoad.getVoltage()));
             }
         }

--- a/src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerElement.java
+++ b/src/main/java/mods/eln/sixnode/electricaldatalogger/ElectricalDataLoggerElement.java
@@ -1,6 +1,5 @@
 package mods.eln.sixnode.electricaldatalogger;
 
-import mods.eln.Eln;
 import mods.eln.generic.GenericItemUsingDamageDescriptor;
 import mods.eln.i18n.I18N;
 import mods.eln.item.BrushDescriptor;
@@ -146,7 +145,7 @@ public class ElectricalDataLoggerElement extends SixNodeElement implements IConf
     public Map<String, String> getWaila() {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Input"), Utils.plotVolt("", inputGate.getVoltage()));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false) && logs.size() > 0) {
+        if (Utils.isWailaEasyModeEnabled() && logs.size() > 0) {
             info.put(I18N.tr("Current value"), DataLogs.getValueString(
                 logs.read(0),
                 logs.maxValue,

--- a/src/main/java/mods/eln/sixnode/electricalentitysensor/ElectricalEntitySensorElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalentitysensor/ElectricalEntitySensorElement.java
@@ -1,6 +1,5 @@
 package mods.eln.sixnode.electricalentitysensor;
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.item.EntitySensorFilterDescriptor;
 import mods.eln.misc.Direction;
@@ -81,7 +80,7 @@ public class ElectricalEntitySensorElement extends SixNodeElement {
     public Map<String, String> getWaila() {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Entity present"), slowProcess.state ? I18N.tr("Yes") : I18N.tr("No"));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Output voltage"), Utils.plotVolt("", outputGate.getVoltage()));
         }
         return info;

--- a/src/main/java/mods/eln/sixnode/electricalfiredetector/ElectricalFireDetectorElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalfiredetector/ElectricalFireDetectorElement.java
@@ -1,6 +1,5 @@
 package mods.eln.sixnode.electricalfiredetector;
 
-import mods.eln.Eln;
 import mods.eln.item.electricalitem.BatteryItem;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -103,7 +102,7 @@ public class ElectricalFireDetectorElement extends SixNodeElement {
     public Map<String, String> getWaila() {
         Map<String, String> info = new HashMap<String, String>();
         info.put(tr("Fire present"), firePresent ? tr("Yes") : tr("No"));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false) && !descriptor.batteryPowered) {
+        if (Utils.isWailaEasyModeEnabled() && !descriptor.batteryPowered) {
             info.put(tr("Output voltage"), Utils.plotVolt("", outputGate.getVoltage()));
         }
         if (descriptor.batteryPowered) {

--- a/src/main/java/mods/eln/sixnode/electricallightsensor/ElectricalLightSensorElement.java
+++ b/src/main/java/mods/eln/sixnode/electricallightsensor/ElectricalLightSensorElement.java
@@ -1,6 +1,5 @@
 package mods.eln.sixnode.electricallightsensor;
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -68,7 +67,7 @@ public class ElectricalLightSensorElement extends SixNodeElement {
     public Map<String, String> getWaila() {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Light level"), Utils.plotValue(slowProcess.light));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Output voltage"), Utils.plotVolt("", outputGate.getVoltage()));
         }
         return info;

--- a/src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalrelay/ElectricalRelayElement.java
@@ -1,6 +1,5 @@
 package mods.eln.sixnode.electricalrelay;
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.item.IConfigurable;
 import mods.eln.misc.Direction;
@@ -145,7 +144,7 @@ public class ElectricalRelayElement extends SixNodeElement implements IConfigura
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Position"), switchState ? I18N.tr("Closed") : I18N.tr("Open"));
         info.put(I18N.tr("Current"), Utils.plotAmpere("", aLoad.getCurrent()));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Default position"), defaultOutput ? I18N.tr("Closed") : I18N.tr("Open"));
             info.put(I18N.tr("Voltages"), Utils.plotVolt("", aLoad.getVoltage()) + Utils.plotVolt(" ", bLoad.getVoltage()));
         }

--- a/src/main/java/mods/eln/sixnode/electricalsensor/ElectricalSensorElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalsensor/ElectricalSensorElement.java
@@ -184,7 +184,7 @@ public class ElectricalSensorElement extends SixNodeElement implements IConfigur
     public Map<String, String> getWaila() {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Output voltage"), Utils.plotVolt("", outputGate.getVoltage()));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             switch (typeOfSensor) {
                 case voltageType:
                     info.put(I18N.tr("Measured voltage"), Utils.plotVolt("", aLoad.getVoltage()));

--- a/src/main/java/mods/eln/sixnode/electricalsource/ElectricalSourceElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalsource/ElectricalSourceElement.java
@@ -3,20 +3,16 @@ package mods.eln.sixnode.electricalsource;
 import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.item.IConfigurable;
+import mods.eln.misc.Coordinate;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
 import mods.eln.misc.Utils;
-import mods.eln.misc.Coordinate;
-import mods.eln.node.Node;
-import mods.eln.node.NodeBase;
-import mods.eln.node.NodeBlockEntity;
-import mods.eln.node.NodeConnection;
-import mods.eln.node.NodeConnectionEndpoint;
+import mods.eln.node.*;
 import mods.eln.node.six.SixNode;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.node.six.SixNodeElement;
-import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ElectricalConnection;
+import mods.eln.sim.ElectricalLoad;
 import mods.eln.sim.ThermalLoad;
 import mods.eln.sim.mna.component.VoltageSource;
 import mods.eln.sim.nbt.NbtElectricalLoad;
@@ -117,7 +113,7 @@ public class ElectricalSourceElement extends SixNodeElement implements IConfigur
                 putConductorVoltage(info, "Ground", lrdu, utilityCable.activeGroundConductorColor());
             }
         }
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Power"), Utils.plotPower("", Math.max(Math.abs(electricalLoad.getVoltage() * voltageSource.getCurrent()), Math.abs(electricalLoadRed.getVoltage() * voltageSourceRed.getCurrent()))));
         }
         return info;

--- a/src/main/java/mods/eln/sixnode/electricalswitch/ElectricalSwitchElement.java
+++ b/src/main/java/mods/eln/sixnode/electricalswitch/ElectricalSwitchElement.java
@@ -125,7 +125,7 @@ public class ElectricalSwitchElement extends SixNodeElement {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Position"), switchState ? I18N.tr("Closed") : I18N.tr("Open"));
         info.put(I18N.tr("Current"), Utils.plotAmpere("", aLoad.getCurrent()));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Voltages"), Utils.plotVolt("", aLoad.getVoltage()) + Utils.plotVolt(" ", bLoad.getVoltage()));
         }
         info.put(I18N.tr("Subsystem Matrix Size"), Utils.renderSubSystemWaila(switchResistor.getSubSystem()));

--- a/src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutElement.java
+++ b/src/main/java/mods/eln/sixnode/electricaltimeout/ElectricalTimeoutElement.java
@@ -1,6 +1,5 @@
 package mods.eln.sixnode.electricaltimeout;
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -103,7 +102,7 @@ public class ElectricalTimeoutElement extends SixNodeElement {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Input"), inputGate.stateHigh() ? I18N.tr("ON") : I18N.tr("OFF"));
         info.put(I18N.tr("Output"), timeOutCounter > 0 ? I18N.tr("ON") : I18N.tr("OFF"));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Remaining"), Utils.plotValue(timeOutCounter, "s"));
         }
         return info;

--- a/src/main/java/mods/eln/sixnode/lampsupply/LampSupplyElement.java
+++ b/src/main/java/mods/eln/sixnode/lampsupply/LampSupplyElement.java
@@ -1,6 +1,6 @@
 package mods.eln.sixnode.lampsupply;
 
-import mods.eln.Eln;
+import mods.eln.generic.GenericItemBlockUsingDamageDescriptor;
 import mods.eln.i18n.I18N;
 import mods.eln.item.ConfigCopyToolDescriptor;
 import mods.eln.item.IConfigurable;
@@ -9,7 +9,6 @@ import mods.eln.misc.LRDU;
 import mods.eln.misc.Utils;
 import mods.eln.node.AutoAcceptInventoryProxy;
 import mods.eln.node.NodeBase;
-import mods.eln.generic.GenericItemBlockUsingDamageDescriptor;
 import mods.eln.node.six.SixNode;
 import mods.eln.node.six.SixNodeDescriptor;
 import mods.eln.node.six.SixNodeElement;
@@ -37,7 +36,9 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.*;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTTagString;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -244,7 +245,7 @@ public class LampSupplyElement extends SixNodeElement implements IConfigurable {
             }
         }
         info.put(I18N.tr("Total power"), Utils.plotPower("", powerLoad.getVoltage() * powerLoad.getCurrent()));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Voltage"), Utils.plotVolt("", powerLoad.getVoltage()));
         }
         return info;

--- a/src/main/java/mods/eln/sixnode/resistor/ResistorElement.java
+++ b/src/main/java/mods/eln/sixnode/resistor/ResistorElement.java
@@ -1,6 +1,5 @@
 package mods.eln.sixnode.resistor;
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -130,7 +129,7 @@ public class ResistorElement extends SixNodeElement {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Resistance"), Utils.plotValue(r.getResistance(), "\u2126"));
         info.put(I18N.tr("Voltage drop"), Utils.plotVolt("", Math.abs(r.getVoltage())));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Current"), Utils.plotAmpere("", Math.abs(r.getCurrent())));
 
         }

--- a/src/main/java/mods/eln/sixnode/thermalsensor/ThermalSensorElement.java
+++ b/src/main/java/mods/eln/sixnode/thermalsensor/ThermalSensorElement.java
@@ -158,7 +158,7 @@ public class ThermalSensorElement extends SixNodeElement implements IConfigurabl
     public Map<String, String> getWaila() {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Output voltage"), Utils.plotVolt("", outputGate.getVoltage()));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             switch (typeOfSensor) {
                 case temperatureType:
                     info.put(I18N.tr("Measured temperature"), plotAmbientCelsius("", thermalLoad.getTemperature()));

--- a/src/main/java/mods/eln/transparentnode/eggincubator/EggIncubatorElement.java
+++ b/src/main/java/mods/eln/transparentnode/eggincubator/EggIncubatorElement.java
@@ -1,6 +1,5 @@
 package mods.eln.transparentnode.eggincubator;
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.misc.Direction;
 import mods.eln.misc.INBTTReady;
@@ -197,7 +196,7 @@ public class EggIncubatorElement extends TransparentNodeElement {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Has egg"), inventory.getStackInSlot(EggIncubatorContainer.EggSlotId) != null ?
             I18N.tr("Yes") : I18N.tr("No"));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Power consumption"), Utils.plotPower("", powerResistor.getPower()));
         }
         return info;

--- a/src/main/java/mods/eln/transparentnode/electricalantennarx/ElectricalAntennaRxElement.java
+++ b/src/main/java/mods/eln/transparentnode/electricalantennarx/ElectricalAntennaRxElement.java
@@ -1,6 +1,5 @@
 package mods.eln.transparentnode.electricalantennarx;
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.misc.Coordinate;
 import mods.eln.misc.Direction;
@@ -155,7 +154,7 @@ public class ElectricalAntennaRxElement extends TransparentNodeElement {
     public Map<String, String> getWaila() {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Receiving"), powerSrc.getPower() != 0 ? "Yes" : "No");
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Power received"), Utils.plotPower("", powerSrc.getPower()));
             info.put(I18N.tr("Effective power"), Utils.plotPower("", powerSrc.getEffectivePower()));
         }

--- a/src/main/java/mods/eln/transparentnode/electricalantennatx/ElectricalAntennaTxElement.java
+++ b/src/main/java/mods/eln/transparentnode/electricalantennatx/ElectricalAntennaTxElement.java
@@ -1,6 +1,5 @@
 package mods.eln.transparentnode.electricalantennatx;
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.misc.Coordinate;
 import mods.eln.misc.Direction;
@@ -207,7 +206,7 @@ public class ElectricalAntennaTxElement extends TransparentNodeElement {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Transmitting"), commandIn.getNormalized() > 0 ? "Yes" : "No");
         info.put(I18N.tr("Efficiency"), Utils.plotPercent("", powerEfficency));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Power"), Utils.plotPower("", powerIn.getCurrent() * powerIn.getVoltage()));
         }
         return info;

--- a/src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineElement.java
+++ b/src/main/java/mods/eln/transparentnode/electricalmachine/ElectricalMachineElement.java
@@ -1,6 +1,5 @@
 package mods.eln.transparentnode.electricalmachine;
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.item.ConfigCopyToolDescriptor;
 import mods.eln.item.IConfigurable;
@@ -203,7 +202,7 @@ public class ElectricalMachineElement extends TransparentNodeElement implements 
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Power consumption"), Utils.plotPower("", slowRefreshProcess.getPower()));
         info.put(I18N.tr("Voltage"), Utils.plotVolt("", electricalLoad.getVoltage()));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Power provided"), Utils.plotPower("", electricalLoad.getCurrent() * electricalLoad.getVoltage()));
         }
         return info;

--- a/src/main/java/mods/eln/transparentnode/solarpanel/SolarPanelElement.java
+++ b/src/main/java/mods/eln/transparentnode/solarpanel/SolarPanelElement.java
@@ -255,7 +255,7 @@ public class SolarPanelElement extends TransparentNodeElement {
         info.put(I18N.tr("Sun angle"), Utils.plotValue(((slowProcess.getSolarAlpha()) * (180 / Math.PI)) - 90, "\u00B0"));
         info.put(I18N.tr("Panel angle"), Utils.plotValue((panelAlpha * (180 / Math.PI)) - 90, "\u00B0"));
         info.put(I18N.tr("Producing energy"), (slowProcess.getSolarLight() != 0 ? "Yes" : "No"));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Produced power"), Utils.plotPower("", powerSource.getPower()));
         }
         return info;

--- a/src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveElement.java
+++ b/src/main/java/mods/eln/transparentnode/thermaldissipatoractive/ThermalDissipatorActiveElement.java
@@ -1,6 +1,5 @@
 package mods.eln.transparentnode.thermaldissipatoractive;
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -132,7 +131,7 @@ public class ThermalDissipatorActiveElement extends TransparentNodeElement {
     public Map<String, String> getWaila() {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Temperature"), plotAmbientCelsius("", thermalLoad.temperatureCelsius));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Thermal power"), Utils.plotPower("", thermalLoad.getPower()));
         }
         return info;

--- a/src/main/java/mods/eln/transparentnode/thermaldissipatorpassive/ThermalDissipatorPassiveElement.java
+++ b/src/main/java/mods/eln/transparentnode/thermaldissipatorpassive/ThermalDissipatorPassiveElement.java
@@ -1,7 +1,6 @@
 package mods.eln.transparentnode.thermaldissipatorpassive;
 
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.misc.Direction;
 import mods.eln.misc.LRDU;
@@ -116,7 +115,7 @@ public class ThermalDissipatorPassiveElement extends TransparentNodeElement {
     public Map<String, String> getWaila() {
         Map<String, String> info = new HashMap<String, String>();
         info.put(I18N.tr("Temperature"), plotAmbientCelsius("", thermalLoad.temperatureCelsius));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Thermal power"), Utils.plotPower("", thermalLoad.getPower()));
         }
         return info;

--- a/src/main/java/mods/eln/transparentnode/turbine/TurbineElement.java
+++ b/src/main/java/mods/eln/transparentnode/turbine/TurbineElement.java
@@ -179,7 +179,7 @@ public class TurbineElement extends TransparentNodeElement {
         info.put(I18N.tr("Nominal") + " \u0394T",
             (warmLoad.temperatureCelsius - coolLoad.temperatureCelsius == descriptor.nominalDeltaT ? I18N.tr("Yes") : I18N.tr("No")));
         info.put(I18N.tr("Generated power"), Utils.plotPower("", electricalPowerSourceProcess.getPower()));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put("\u0394T", Utils.plotCelsius("", warmLoad.temperatureCelsius - coolLoad.temperatureCelsius));
             info.put(I18N.tr("Voltage"), Utils.plotVolt("", electricalPowerSourceProcess.getVoltage()));
         }

--- a/src/main/java/mods/eln/transparentnode/turret/TurretElement.java
+++ b/src/main/java/mods/eln/transparentnode/turret/TurretElement.java
@@ -276,7 +276,7 @@ public class TurretElement extends TransparentNodeElement implements IConfigurab
             }
         }
 
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info.put(I18N.tr("Charge level"),
                 Utils.plotPercent("", energyBuffer / descriptor.getProperties().impulseEnergy));
         }

--- a/src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineElement.java
+++ b/src/main/java/mods/eln/transparentnode/waterturbine/WaterTurbineElement.java
@@ -1,6 +1,5 @@
 package mods.eln.transparentnode.waterturbine;
 
-import mods.eln.Eln;
 import mods.eln.i18n.I18N;
 import mods.eln.misc.Coordinate;
 import mods.eln.misc.Direction;
@@ -155,7 +154,7 @@ public class WaterTurbineElement extends TransparentNodeElement {
         Map<String, String> wailaList = new HashMap<String, String>();
         wailaList.put(I18N.tr("Generating"), slowProcess.getWaterFactor() > 0 ? I18N.tr("Yes") : I18N.tr("No"));
         wailaList.put(I18N.tr("Produced power"), Utils.plotPower("", powerSource.getEffectivePower()));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             wailaList.put(I18N.tr("Voltage"), Utils.plotVolt("", powerSource.getVoltage()));
         }
         return wailaList;

--- a/src/main/java/mods/eln/transparentnode/windturbine/WindTurbineElement.java
+++ b/src/main/java/mods/eln/transparentnode/windturbine/WindTurbineElement.java
@@ -153,7 +153,7 @@ public class WindTurbineElement extends TransparentNodeElement {
         wailaList.put(I18N.tr("Wind"), Utils.plotValue(slowProcess.getWind(), "m/s"));
         wailaList.put(I18N.tr("Rotor speed"), Utils.plotRads("", slowProcess.getRotorRads()));
         wailaList.put(I18N.tr("Produced power"), Utils.plotPower("", Math.max(0.0, powerSource.getPower())));
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             wailaList.put(I18N.tr("Voltage"), Utils.plotVolt("", powerSource.getVoltage()));
             wailaList.put(I18N.tr("Current"), Utils.plotAmpere("", powerSource.getCurrent()));
             wailaList.put(I18N.tr("Current limit"), Utils.plotAmpere("", regulatorCurrentLimitRequest));

--- a/src/main/kotlin/mods/eln/PacketHandler.kt
+++ b/src/main/kotlin/mods/eln/PacketHandler.kt
@@ -3,7 +3,6 @@ package mods.eln
 import cpw.mods.fml.common.eventhandler.SubscribeEvent
 import cpw.mods.fml.common.network.FMLNetworkEvent.ServerCustomPacketEvent
 import io.netty.channel.ChannelHandler.Sharable
-import mods.eln.client.ClientKeyHandler
 import mods.eln.client.ClientProxy
 import mods.eln.item.FalstadImportPacketHandler
 import mods.eln.misc.Coordinate
@@ -17,11 +16,7 @@ import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.entity.player.EntityPlayerMP
 import net.minecraft.network.NetHandlerPlayServer
 import net.minecraft.network.NetworkManager
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.io.DataInputStream
-import java.io.DataOutputStream
-import java.io.IOException
+import java.io.*
 
 @Sharable
 class PacketHandler {

--- a/src/main/kotlin/mods/eln/PacketHandler.kt
+++ b/src/main/kotlin/mods/eln/PacketHandler.kt
@@ -4,6 +4,7 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent
 import cpw.mods.fml.common.network.FMLNetworkEvent.ServerCustomPacketEvent
 import io.netty.channel.ChannelHandler.Sharable
 import mods.eln.client.ClientProxy
+import mods.eln.config.ClientConfigSyncHandler
 import mods.eln.item.FalstadImportPacketHandler
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Utils
@@ -43,6 +44,7 @@ class PacketHandler {
                 Eln.packetClientToServerConnection -> packetNewClient(manager, player)
                 Eln.packetServerToClientInfo -> packetServerInfo(stream, manager, player)
                 Eln.packetFalstadImport -> packetFalstadImport(stream, manager, player)
+                Eln.packetServerConfigSync -> packetServerConfigSync(stream, manager, player)
             }
         } catch (e: IOException) {
             e.printStackTrace()
@@ -189,6 +191,23 @@ class PacketHandler {
             val bytes = ByteArray(length)
             stream.readFully(bytes)
             FalstadImportPacketHandler.handle(player as EntityPlayerMP, bytes)
+        } catch (e: IOException) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun packetServerConfigSync(stream: DataInputStream, @Suppress("UNUSED_PARAMETER") manager: NetworkManager, @Suppress("UNUSED_PARAMETER") player: EntityPlayer) {
+        try {
+            val configName = stream.readUTF()
+            val configValue: Any? = when (stream.readChar()) {
+                'b' -> stream.readBoolean()
+                'i' -> stream.readInt()
+                'd' -> stream.readDouble()
+                's' -> stream.readUTF()
+                else -> null // This should not happen unless the wrong char is mistakenly sent
+            }
+            ClientConfigSyncHandler.setSyncedConfigEntry(configName, configValue)
+            Utils.println("Successfully received a config entry ($configName, $configValue) from the server.")
         } catch (e: IOException) {
             e.printStackTrace()
         }

--- a/src/main/kotlin/mods/eln/PacketHandler.kt
+++ b/src/main/kotlin/mods/eln/PacketHandler.kt
@@ -6,6 +6,7 @@ import io.netty.channel.ChannelHandler.Sharable
 import mods.eln.client.ClientProxy
 import mods.eln.item.FalstadImportPacketHandler
 import mods.eln.misc.Coordinate
+import mods.eln.misc.Utils
 import mods.eln.misc.Utils.println
 import mods.eln.misc.Utils.sendPacketToClient
 import mods.eln.node.INodeEntity
@@ -171,11 +172,12 @@ class PacketHandler {
         }
     }
 
-    private fun packetPlayerKey(stream: DataInputStream, @Suppress("UNUSED_PARAMETER") manager: NetworkManager, @Suppress("UNUSED_PARAMETER") player: EntityPlayer?) {
+    private fun packetPlayerKey(stream: DataInputStream, @Suppress("UNUSED_PARAMETER") manager: NetworkManager, player: EntityPlayer) {
         try {
             val name = stream.readUTF()
             val state = stream.readBoolean()
-            ServerKeyHandler.set(name, state)
+            ServerKeyHandler.set(name, state, player)
+            Utils.println("Server received a client key event from player $player: $name is $state")
         } catch (e: IOException) {
             e.printStackTrace()
         }

--- a/src/main/kotlin/mods/eln/ServerKeyHandler.kt
+++ b/src/main/kotlin/mods/eln/ServerKeyHandler.kt
@@ -26,7 +26,7 @@ object ServerKeyHandler {
     private val playerKeyStateList = mutableListOf<PlayerKeyState>()
 
     fun get(name: String, player: EntityPlayer): Boolean {
-        return playerKeyStateList.firstOrNull {it.player == player}?.keyStateList?.firstOrNull { it.name == name }?.state?: false
+        return playerKeyStateList.firstOrNull { it.player == player }?.keyStateList?.firstOrNull { it.name == name }?.state?: false
     }
 
     fun set(name: String, state: Boolean, player: EntityPlayer) {

--- a/src/main/kotlin/mods/eln/ServerKeyHandler.kt
+++ b/src/main/kotlin/mods/eln/ServerKeyHandler.kt
@@ -1,17 +1,41 @@
 package mods.eln
 
-data class KeyState(val name: String, var state: Boolean = false)
+import net.minecraft.entity.player.EntityPlayer
+
+data class KeyState(
+    val name: String,
+    var state: Boolean = false
+)
+
+data class PlayerKeyState(
+    var player: EntityPlayer,
+    val keyStateList: List<KeyState> = listOf(
+        KeyState(ServerKeyHandler.WRENCH),
+        KeyState(ServerKeyHandler.WIKI),
+        KeyState(ServerKeyHandler.LSHIFT),
+        KeyState(ServerKeyHandler.RSHIFT)
+    )
+)
 
 object ServerKeyHandler {
-    val WRENCH = "Wrench"
-    val WIKI = "Wiki"
-    private val keyState = listOf(KeyState(WRENCH))
+    const val WRENCH = "Wrench"
+    const val WIKI = "Wiki"
+    const val LSHIFT = "LeftShift"
+    const val RSHIFT = "RightShift"
 
-    fun get(name: String): Boolean {
-        return keyState.firstOrNull {it.name == name}?.state?: false
+    private val playerKeyStateList = mutableListOf<PlayerKeyState>()
+
+    fun get(name: String, player: EntityPlayer): Boolean {
+        return playerKeyStateList.firstOrNull {it.player == player}?.keyStateList?.firstOrNull { it.name == name }?.state?: false
     }
 
-    fun set(name: String, state: Boolean) {
-        keyState.firstOrNull { it.name == name }?.state = state
+    fun set(name: String, state: Boolean, player: EntityPlayer) {
+        addPlayerToList(player)
+        playerKeyStateList.firstOrNull { it.player == player }?.keyStateList?.firstOrNull { it.name == name }?.state = state
+    }
+
+    private fun addPlayerToList(player: EntityPlayer) {
+        playerKeyStateList.forEach { if (it.player == player) return }
+        playerKeyStateList.add(PlayerKeyState(player))
     }
 }

--- a/src/main/kotlin/mods/eln/api/v1/electrical/ElectricalIntegration.kt
+++ b/src/main/kotlin/mods/eln/api/v1/electrical/ElectricalIntegration.kt
@@ -5,19 +5,17 @@ package mods.eln.api.v1.electrical
 import mods.eln.Eln
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Direction
-import mods.eln.misc.Utils
 import mods.eln.misc.LRDU
+import mods.eln.misc.Utils
 import mods.eln.node.GhostNode
-import mods.eln.node.NodeManager
 import mods.eln.node.NodeBase
+import mods.eln.node.NodeManager
 import mods.eln.sim.ElectricalConnection
-import mods.eln.sim.ElectricalLoad as SimElectricalLoad
 import mods.eln.sim.IProcess
 import mods.eln.sim.SignalLoadSupport
 import mods.eln.sim.Simulator
 import mods.eln.sim.mna.component.Component
 import mods.eln.sim.mna.component.Resistor
-import mods.eln.sim.mna.component.VoltageSource as InternalVoltageSource
 import mods.eln.sim.nbt.NbtElectricalGateOutputProcess
 import mods.eln.sim.nbt.NbtElectricalLoad
 import mods.eln.sim.process.destruct.IDestructible
@@ -26,7 +24,9 @@ import mods.eln.sim.process.destruct.VoltageStateWatchDog
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
-import java.util.Locale
+import java.util.*
+import mods.eln.sim.ElectricalLoad as SimElectricalLoad
+import mods.eln.sim.mna.component.VoltageSource as InternalVoltageSource
 
 /**
  * Stable versioned electrical integration API exposed for external mods.
@@ -1939,7 +1939,7 @@ object ElectricalIntegration {
     }
 
     private fun apiDebug(message: String, vararg args: Any?) {
-        if (!Eln.config.getBooleanOrElse("debug.logging.enabled", false)) return
+        if (!Utils.isDebugEnabled()) return
         Eln.LOGGER.info("[ElectricalApiV1] $message", *args)
     }
 

--- a/src/main/kotlin/mods/eln/client/ClientKeyHandler.kt
+++ b/src/main/kotlin/mods/eln/client/ClientKeyHandler.kt
@@ -5,7 +5,6 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent
 import cpw.mods.fml.common.gameevent.InputEvent.KeyInputEvent
 import mods.eln.Eln
 import mods.eln.ServerKeyHandler
-import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Utils
 import mods.eln.misc.UtilsClient.clientOpenGui
 import mods.eln.misc.UtilsClient.sendPacketToServer
@@ -19,17 +18,40 @@ import java.io.IOException
 
 data class ElectricalAgeKey(var defaultKeybind: Int, val name: String, var lastState: Boolean = false, var binding: KeyBinding? = null)
 
-class ClientKeyHandler {
-    // Note: C is the default wrench key, but it can be changed with the GUI in-game. This is override with the value stored in options.txt
+object ClientKeyHandler {
+    // These are the defaults, but they can be changed by the player after launching the game
+    const val DEFAULT_WRENCH_KEY = Keyboard.KEY_C
+    const val DEFAULT_WIKI_KEY = Keyboard.KEY_P
+
     private val keyboardKeys = listOf(
-        ElectricalAgeKey(Keyboard.KEY_C, ServerKeyHandler.WRENCH),
-        ElectricalAgeKey(Keyboard.KEY_P, ServerKeyHandler.WIKI)
+        ElectricalAgeKey(DEFAULT_WRENCH_KEY, ServerKeyHandler.WRENCH),
+        ElectricalAgeKey(DEFAULT_WIKI_KEY, ServerKeyHandler.WIKI)
     )
 
     init {
         keyboardKeys.forEach {
             it.binding = KeyBinding(it.name, it.defaultKeybind, StatCollector.translateToLocal("ElectricalAge"))
             ClientRegistry.registerKeyBinding(it.binding)
+        }
+    }
+
+    /**
+     * Returns either the numeric value of the keyboard key associated with the specified keybind or -1 if the keybind
+     * is not found.
+     */
+    fun getKeybindValue(keybindName: String): Int {
+        return keyboardKeys.firstOrNull { it.name == keybindName }?.binding?.keyCode ?: -1
+    }
+
+    /**
+     * Returns either the human-readable name of the keyboard key associated with the specified keybind or an empty
+     * string if the keybind is not found.
+     */
+    fun getKeybindKey(keybindName: String): String {
+        return try {
+            Keyboard.getKeyName(getKeybindValue(keybindName))
+        } catch (_: IndexOutOfBoundsException) { // This handles the case in which getKeybindValue() somehow returns -1
+            ""
         }
     }
 

--- a/src/main/kotlin/mods/eln/client/ClientKeyHandler.kt
+++ b/src/main/kotlin/mods/eln/client/ClientKeyHandler.kt
@@ -85,7 +85,7 @@ object ClientKeyHandler {
         }
     }
 
-    fun setState(name: String, state: Boolean) {
+    private fun setState(name: String, state: Boolean) {
         val entry = keyboardKeys.firstOrNull { it.name == name }?: return
         if (entry.lastState != state) {
             entry.lastState = state // Be sure to set the state so that it calls again when key released

--- a/src/main/kotlin/mods/eln/client/ClientKeyHandler.kt
+++ b/src/main/kotlin/mods/eln/client/ClientKeyHandler.kt
@@ -2,7 +2,7 @@ package mods.eln.client
 
 import cpw.mods.fml.client.registry.ClientRegistry
 import cpw.mods.fml.common.eventhandler.SubscribeEvent
-import cpw.mods.fml.common.gameevent.InputEvent.KeyInputEvent
+import cpw.mods.fml.common.gameevent.TickEvent.ClientTickEvent
 import mods.eln.Eln
 import mods.eln.ServerKeyHandler
 import mods.eln.misc.Utils
@@ -16,7 +16,14 @@ import java.io.ByteArrayOutputStream
 import java.io.DataOutputStream
 import java.io.IOException
 
-data class ElectricalAgeKey(var defaultKeybind: Int, val name: String, var lastState: Boolean = false, var binding: KeyBinding? = null)
+data class ElectricalAgeKey(
+    val defaultKeybind: Int,
+    val name: String,
+    var lastState: Boolean = false,
+    var binding: KeyBinding? = null,
+    val registerBinding: Boolean = true,
+    val activeOnGuiScreen: Boolean = false
+)
 
 object ClientKeyHandler {
     // These are the defaults, but they can be changed by the player after launching the game
@@ -25,13 +32,19 @@ object ClientKeyHandler {
 
     private val keyboardKeys = listOf(
         ElectricalAgeKey(DEFAULT_WRENCH_KEY, ServerKeyHandler.WRENCH),
-        ElectricalAgeKey(DEFAULT_WIKI_KEY, ServerKeyHandler.WIKI)
+        ElectricalAgeKey(DEFAULT_WIKI_KEY, ServerKeyHandler.WIKI),
+
+        // Shift keys do not need a keybind, since Minecraft hardcodes them for certain inventory operations
+        ElectricalAgeKey(Keyboard.KEY_LSHIFT, ServerKeyHandler.LSHIFT, registerBinding = false, activeOnGuiScreen = true),
+        ElectricalAgeKey(Keyboard.KEY_RSHIFT, ServerKeyHandler.RSHIFT, registerBinding = false, activeOnGuiScreen = true)
     )
 
     init {
         keyboardKeys.forEach {
-            it.binding = KeyBinding(it.name, it.defaultKeybind, StatCollector.translateToLocal("ElectricalAge"))
-            ClientRegistry.registerKeyBinding(it.binding)
+            if (it.registerBinding) {
+                it.binding = KeyBinding(it.name, it.defaultKeybind, StatCollector.translateToLocal("ElectricalAge"))
+                ClientRegistry.registerKeyBinding(it.binding)
+            }
         }
     }
 
@@ -55,10 +68,20 @@ object ClientKeyHandler {
         }
     }
 
+    /**
+     * This guarantees that client key events are fired even if a client has a GUI screen open (though this only works
+     * for GUI screens that do not pause the game).
+     */
     @SubscribeEvent
-    fun onKeyInput(@Suppress("UNUSED_PARAMETER") event: KeyInputEvent?) {
+    fun onClientTick(@Suppress("UNUSED_PARAMETER") event: ClientTickEvent) {
         keyboardKeys.forEach {
-            setState(it.name, it.binding?.isKeyPressed ?: return@forEach)
+            val state = if (it.registerBinding) {
+                if (it.activeOnGuiScreen) { Keyboard.isKeyDown(getKeybindValue(it.name)) }
+                else { it.binding?.isKeyPressed ?: return@forEach }
+            } else {
+                Keyboard.isKeyDown(it.defaultKeybind)
+            }
+            setState(it.name, state)
         }
     }
 

--- a/src/main/kotlin/mods/eln/config/ConfigSyncHandler.kt
+++ b/src/main/kotlin/mods/eln/config/ConfigSyncHandler.kt
@@ -1,0 +1,112 @@
+package mods.eln.config
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent
+import cpw.mods.fml.common.gameevent.PlayerEvent
+import mods.eln.Eln
+import mods.eln.misc.Utils
+import java.io.ByteArrayOutputStream
+import java.io.DataOutputStream
+import java.io.IOException
+
+data class ConfigEntry(
+    val name: String,
+    var value: Any?
+)
+
+object ClientConfigSyncHandler {
+
+    private val syncedConfigEntries = mutableListOf<ConfigEntry>()
+
+    @JvmStatic
+    fun getSyncedConfigEntry(name: String): Any? {
+        return syncedConfigEntries.firstOrNull { it.name == name }?.value
+    }
+
+    @JvmStatic
+    fun setSyncedConfigEntry(name: String, value: Any?) {
+        syncedConfigEntries.forEach { entry ->
+            if (entry.name == name) {
+                entry.value = value
+                return
+            }
+        }
+        syncedConfigEntries.add(ConfigEntry(name, value))
+    }
+
+}
+
+object ServerConfigSyncHandler {
+
+    private val serverConfigEntries = listOf(
+        ConfigEntry("debug.logging.enabled", false)
+    )
+
+    @SubscribeEvent
+    fun onClientJoinServer(@Suppress("UNUSED_PARAMETER") event: PlayerEvent.PlayerLoggedInEvent) {
+        syncClientConfig()
+    }
+
+    /**
+     * Reads the relevant config entries from the server config file, then sends them to all connected clients.
+     *
+     * This is called automatically whenever a client connects to the server (including singleplayer), as well as
+     * every time a client calls the console commands `/eln config` or `/eln debug`.
+     */
+    @JvmStatic
+    fun syncClientConfig() {
+        updateServerConfigEntries()
+        sendServerConfigToAllClients()
+    }
+
+    private fun updateServerConfigEntries() {
+        serverConfigEntries.forEach { entry ->
+            when (entry.value) {
+                is Boolean -> entry.value = Eln.config.getBooleanOrElse(entry.name, false)
+                is Int -> entry.value = Eln.config.getIntOrElse(entry.name, 0)
+                is Double -> entry.value = Eln.config.getDoubleOrElse(entry.name, 0.0)
+                is String -> entry.value = Eln.config.getStringOrElse(entry.name, "")
+                else -> entry.value = null // Only the above types are currently supported for config entries
+            }
+        }
+    }
+
+    private fun sendServerConfigToAllClients() {
+        Utils.println("Sending server config to all clients.")
+
+        serverConfigEntries.forEach { entry ->
+            val bos = ByteArrayOutputStream(64)
+            val stream = DataOutputStream(bos)
+
+            try {
+                stream.writeByte(Eln.packetServerConfigSync.toInt())
+                stream.writeUTF(entry.name)
+                when (entry.value) {
+                    is Boolean -> {
+                        stream.writeChar('b'.code)
+                        stream.writeBoolean(entry.value as Boolean)
+                    }
+                    is Int -> {
+                        stream.writeChar('i'.code)
+                        stream.writeInt(entry.value as Int)
+                    }
+                    is Double -> {
+                        stream.writeChar('d'.code)
+                        stream.writeDouble(entry.value as Double)
+                    }
+                    is String -> {
+                        stream.writeChar('s'.code)
+                        stream.writeUTF(entry.value as String)
+                    }
+                    else -> {
+                        return@forEach // Don't send config entries with null values
+                    }
+                }
+            } catch (e: IOException) {
+                e.printStackTrace()
+            }
+
+            Utils.sendPacketToAllClients(bos)
+        }
+    }
+
+}

--- a/src/main/kotlin/mods/eln/config/JsonConfig.kt
+++ b/src/main/kotlin/mods/eln/config/JsonConfig.kt
@@ -5,20 +5,19 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import mods.eln.Eln
-import mods.eln.metrics.MetricsSubsystem
 import mods.eln.Other
 import mods.eln.item.TurbineBladeLists
 import mods.eln.item.lampitem.BoilerplateLampData
 import mods.eln.item.lampitem.LampLists
 import mods.eln.mechanical.ClutchPlateItem
+import mods.eln.metrics.MetricsSubsystem
 import mods.eln.misc.Utils
 import java.io.File
 import java.io.FileReader
 import java.io.FileWriter
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
-import java.util.Locale
-import java.util.UUID
+import java.util.*
 import java.util.regex.PatternSyntaxException
 import kotlin.math.max
 import kotlin.math.min
@@ -263,7 +262,6 @@ class JsonConfig @JvmOverloads constructor(
         Eln.simMetricsMqttServer = getStringOrElse("integrations.mqtt.simMetrics.server", "")
         Eln.simMetricsId = getStringOrElse("integrations.mqtt.simMetrics.id", "server")
         Eln.simMetricsPublishIntervalTicks = max(1, getIntOrElse("integrations.mqtt.simMetrics.publishIntervalTicks", 20))
-        Eln.debugEnabled = getBooleanOrElse("debug.logging.enabled", false)
         MetricsSubsystem.refreshFromConfig()
 
         setRuntimeValue(

--- a/src/main/kotlin/mods/eln/gridnode/GridSwitch.kt
+++ b/src/main/kotlin/mods/eln/gridnode/GridSwitch.kt
@@ -3,7 +3,7 @@ package mods.eln.gridnode
 import mods.eln.Eln
 import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
-import mods.eln.misc.NominalVoltage
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.TransparentNode
 import mods.eln.node.transparent.TransparentNodeDescriptor
@@ -287,7 +287,7 @@ class GridSwitchElement(node: TransparentNode, descriptor: TransparentNodeDescri
 
     override fun getWaila(): Map<String, String> {
         val info = mutableMapOf<String, String>()
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Left")] = Utils.plotUIP(grida.voltage, grida.current)
             info[tr("Right")] = Utils.plotUIP(gridb.voltage, gridb.current)
             info[tr("Transfer")] = Utils.plotPower(transfer.power)

--- a/src/main/kotlin/mods/eln/item/lampitem/LampDescriptor.kt
+++ b/src/main/kotlin/mods/eln/item/lampitem/LampDescriptor.kt
@@ -1,9 +1,9 @@
 package mods.eln.item.lampitem
 
-import mods.eln.Eln
 import mods.eln.i18n.I18N
 import mods.eln.item.GenericItemUsingDamageDescriptorUpgrade
 import mods.eln.misc.Utils
+import mods.eln.misc.UtilsClient
 import mods.eln.misc.VoltageLevelColor
 import mods.eln.sim.mna.component.Resistor
 import mods.eln.wiki.Data
@@ -50,36 +50,39 @@ class LampDescriptor(name: String, iconName: String, val lampData: SpecificLampD
     }
 
     /**
-     * This function is currently set up to be called once per second (IRL). If the NBT update bug is ever fixed, this
-     * function should be updated to run once per tick by dividing the life lost by 20 before calculating the new life.
-     * See https://www.desmos.com/calculator/0uuzozsiuu for a plot of the lamp aging function.
+     * See https://www.desmos.com/calculator/0uuzozsiuu for a plot of the life lost vs. applied voltage curve.
      */
     fun decreaseLampLife(lampStack: ItemStack, appliedVoltage: Double): Double {
         val currentLife = getLifeInTag(lampStack)
 
-        // resetLampLifeFlag should be automatically set to false after 1-2 seconds (see usage in Simulator.java)
+        // resetLampLifeFlag should be automatically set to false after ~1 tick (see usage in Simulator.java)
         if (currentLife > lampData.technology.nominalLifeInHours || LampLists.resetLampLifeFlag) {
             setLifeInTag(lampStack, lampData.technology.nominalLifeInHours)
             return getLifeInTag(lampStack)
         }
 
-        if (!lampData.technology.infiniteLifeEnabled) {
-            // Division by 3600 converts seconds to hours (IRL)
-            val lifeLost = when {
-                // Life lost per second increases exponentially when voltage is above nominal (10x as fast at 1.25x nominal)
-                abs(appliedVoltage) > lampData.nominalU -> {
-                    10.0.pow(4.0 / lampData.nominalU).pow(abs(appliedVoltage) - lampData.nominalU) / 3600.0
-                }
-                // Life lost per second increases linearly when voltage is between nominal and minimal
-                abs(appliedVoltage) in (lampData.nominalU * lampData.technology.minimalUFactor)..lampData.nominalU -> {
-                    val slope = 1.0 / (lampData.nominalU * (1.0 - lampData.technology.minimalUFactor))
-                    val intercept = 1.0 - (slope * lampData.nominalU)
+        // Lamp aging only occurs when the shift key is not held. This prevents the infamous NBT mismatch/desync bug
+        // from occurring, where an item is duplicated when shift-clicked from an inventory if its NBT tags differ
+        // between the client and the server.
+        if (!lampData.technology.infiniteLifeEnabled && !UtilsClient.isShiftHeld()) {
+            var lifeLost: Double
 
-                    ((slope * abs(appliedVoltage)) + intercept) / 3600.0
-                }
+            if (abs(appliedVoltage) > lampData.nominalU) {
+                // Life lost per tick increases exponentially when voltage is above nominal (10x as fast at 1.25x nominal)
+                lifeLost = 10.0.pow(4.0 / lampData.nominalU).pow(abs(appliedVoltage) - lampData.nominalU)
+            } else if (abs(appliedVoltage) in (lampData.nominalU * lampData.technology.minimalUFactor)..lampData.nominalU) {
+                // Life lost per tick increases linearly when voltage is between nominal and minimal
+                val slope = 1.0 / (lampData.nominalU * (1.0 - lampData.technology.minimalUFactor))
+                val intercept = 1.0 - (slope * lampData.nominalU)
+                lifeLost = (slope * abs(appliedVoltage)) + intercept
+            } else {
                 // Lamp does not lose life when voltage is below minimal (no light produced)
-                else -> 0.0
+                lifeLost = 0.0
             }
+
+            // Division by 72,000 = 20 * 3600 converts ticks to hours (20 ticks/second, 3600 seconds/hour)
+            // Bulb lives are defined in hours, so this conversion is necessary for losing life at the proper rate
+            lifeLost /= (20.0 * 3600.0)
 
             var newLife = currentLife - lifeLost
             if (newLife < 0.0) newLife = 0.0
@@ -101,9 +104,7 @@ class LampDescriptor(name: String, iconName: String, val lampData: SpecificLampD
         list.add(I18N.tr($$"Nominal lifetime: %1$h", lampData.technology.nominalLifeInHours))
 
         if (itemStack != null) {
-            if (Eln.config.getBooleanOrElse("debug.logging.enabled", false)) {
-                list.add(I18N.tr($$"Current lifetime: %1$h", getLifeInTag(itemStack)))
-            }
+            if (Utils.isDebugEnabled()) list.add(I18N.tr($$"Current lifetime: %1$h", getLifeInTag(itemStack)))
             list.add(I18N.tr("Condition: %1$", getLampCondition(itemStack)))
         }
     }

--- a/src/main/kotlin/mods/eln/item/lampitem/LampDescriptor.kt
+++ b/src/main/kotlin/mods/eln/item/lampitem/LampDescriptor.kt
@@ -3,6 +3,7 @@ package mods.eln.item.lampitem
 import mods.eln.i18n.I18N
 import mods.eln.item.GenericItemUsingDamageDescriptorUpgrade
 import mods.eln.misc.Utils
+import mods.eln.misc.UtilsClient
 import mods.eln.misc.VoltageLevelColor
 import mods.eln.sim.mna.component.Resistor
 import mods.eln.sixnode.lampsocket.LampSocketContainer
@@ -126,7 +127,7 @@ class LampDescriptor(name: String, iconName: String, val lampData: SpecificLampD
         list.add(I18N.tr($$"Nominal lifetime: %1$h", lampData.technology.nominalLifeInHours))
 
         if (itemStack != null) {
-            if (Utils.isDebugEnabled()) list.add(I18N.tr($$"Current lifetime: %1$h", getLifeInTag(itemStack)))
+            if (UtilsClient.isServerDebugEnabled()) list.add(I18N.tr($$"Current lifetime: %1$h", getLifeInTag(itemStack)))
             list.add(I18N.tr("Condition: %1$", getLampCondition(itemStack)))
         }
     }

--- a/src/main/kotlin/mods/eln/item/lampitem/LampDescriptor.kt
+++ b/src/main/kotlin/mods/eln/item/lampitem/LampDescriptor.kt
@@ -3,9 +3,10 @@ package mods.eln.item.lampitem
 import mods.eln.i18n.I18N
 import mods.eln.item.GenericItemUsingDamageDescriptorUpgrade
 import mods.eln.misc.Utils
-import mods.eln.misc.UtilsClient
 import mods.eln.misc.VoltageLevelColor
 import mods.eln.sim.mna.component.Resistor
+import mods.eln.sixnode.lampsocket.LampSocketContainer
+import mods.eln.transparentnode.floodlight.FloodlightContainer
 import mods.eln.wiki.Data
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.Item
@@ -61,10 +62,11 @@ class LampDescriptor(name: String, iconName: String, val lampData: SpecificLampD
             return getLifeInTag(lampStack)
         }
 
-        // Lamp aging only occurs when the shift key is not held. This prevents the infamous NBT mismatch/desync bug
+        // If a player is holding shift while accessing the GUI of a lamp socket or floodlight, all light bulbs within
+        // that lamp socket/floodlight temporarily stop losing life. This prevents the infamous NBT mismatch/desync bug
         // from occurring, where an item is duplicated when shift-clicked from an inventory if its NBT tags differ
         // between the client and the server.
-        if (!lampData.technology.infiniteLifeEnabled && !UtilsClient.isShiftHeld()) {
+        if (!lampData.technology.infiniteLifeEnabled && !isContainerOpenAndPlayerHoldingShift()) {
             var lifeLost: Double
 
             if (abs(appliedVoltage) > lampData.nominalU) {
@@ -92,6 +94,26 @@ class LampDescriptor(name: String, iconName: String, val lampData: SpecificLampD
         } else {
             return currentLife
         }
+    }
+
+    /**
+     * Polls all players in a world and checks if this specific lamp item is within a lamp socket that a player is interacting with.
+     */
+    private fun isContainerOpenAndPlayerHoldingShift(): Boolean {
+        Utils.getServerPlayerList().forEach { player ->
+            val container = player.openContainer
+
+            if (container is LampSocketContainer || container is FloodlightContainer) {
+                for (idx in 0..<container.containerSize) {
+                    val lampStack = container.inventoryItemStacks[idx] as? ItemStack
+                    val lampDescriptor = Utils.getItemObject(lampStack) as? LampDescriptor
+
+                    if (this === lampDescriptor && Utils.isPlayerHoldingShift(player)) return true
+                }
+            }
+        }
+
+        return false
     }
 
     override fun addInformation(itemStack: ItemStack?, entityPlayer: EntityPlayer?, list: MutableList<String>, par4: Boolean) {

--- a/src/main/kotlin/mods/eln/mechanical/Clutch.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Clutch.kt
@@ -2,7 +2,6 @@ package mods.eln.mechanical
 
 import mods.eln.Eln
 import mods.eln.cable.CableRender
-import mods.eln.generic.GenericItemUsingDamage
 import mods.eln.generic.GenericItemUsingDamageDescriptor
 import mods.eln.generic.GenericItemUsingDamageDescriptorWithComment
 import mods.eln.generic.GenericItemUsingDamageSlot
@@ -11,6 +10,7 @@ import mods.eln.gui.HelperStdContainer
 import mods.eln.gui.ISlotSkin
 import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.*
 import mods.eln.sim.ElectricalLoad
@@ -428,7 +428,7 @@ class ClutchElement(node: TransparentNode, desc_: TransparentNodeDescriptor) : S
         info.put(tr("Energies"), entries.map {
             Utils.plotEnergy("", it.value.energy)
         }.joinToString(", "))
-        if(Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if(isWailaEasyModeEnabled()) {
             info.put("Masses", entries.map {
                 Utils.plotValue(it.value.mass * 1000, "g")
             }.joinToString(", "))
@@ -438,7 +438,7 @@ class ClutchElement(node: TransparentNode, desc_: TransparentNodeDescriptor) : S
                 info.put("Wear", String.format("%.6f", desc.getWear(stack)))
         }
         info.put(tr("Clutching"), Utils.plotVolt(inputGate.signalVoltage))
-        if(Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if(isWailaEasyModeEnabled()) {
             info.put("Slipping", if (slipping) {
                 "YES"
             } else {

--- a/src/main/kotlin/mods/eln/mechanical/Generator.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Generator.kt
@@ -4,6 +4,7 @@ import mods.eln.Eln
 import mods.eln.cable.CableRenderDescriptor
 import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.EntityMetaTag
 import mods.eln.node.transparent.TransparentNode
@@ -332,7 +333,7 @@ class GeneratorElement(node: TransparentNode, desc_: TransparentNodeDescriptor) 
         var info = mutableMapOf<String, String>()
         info.put(tr("Energy"), Utils.plotEnergy("", shaft.energy))
         info.put(tr("Speed"), Utils.plotRads("", shaft.rads))
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info.put(tr("Voltage"), Utils.plotVolt("", electricalPowerSource.getVoltage()))
             info.put(tr("Current"), Utils.plotAmpere("", electricalPowerSource.getCurrent()))
             info.put(tr("Regulator target"), Utils.plotVolt("", regulatorVoltageTarget))

--- a/src/main/kotlin/mods/eln/mechanical/Motor.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Motor.kt
@@ -4,6 +4,7 @@ import mods.eln.Eln
 import mods.eln.cable.CableRenderDescriptor
 import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.EntityMetaTag
 import mods.eln.node.transparent.TransparentNode
@@ -435,7 +436,7 @@ class MotorElement(node: TransparentNode, desc_: TransparentNodeDescriptor) :
         var info = mutableMapOf<String, String>()
         info.put(tr("Energy"), Utils.plotEnergy("", shaft.energy))
         info.put(tr("Speed"), Utils.plotRads("", shaft.rads))
-        if(Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if(isWailaEasyModeEnabled()) {
             info.put(tr("Voltage"), Utils.plotVolt("", powerSource.voltage))
             info.put(tr("Current"), Utils.plotAmpere("", powerSource.current))
             info.put(tr("Drive target"), Utils.plotRads("", driveSpeedTarget))

--- a/src/main/kotlin/mods/eln/mechanical/RadialMotor.kt
+++ b/src/main/kotlin/mods/eln/mechanical/RadialMotor.kt
@@ -4,13 +4,8 @@ import mods.eln.Eln
 import mods.eln.fluid.FuelRegistry
 import mods.eln.fluid.PreciseElementFluidHandler
 import mods.eln.i18n.I18N.tr
-import mods.eln.misc.Coordinate
-import mods.eln.misc.Direction
-import mods.eln.misc.INBTTReady
-import mods.eln.misc.LRDU
-import mods.eln.misc.Obj3D
-import mods.eln.misc.RcInterpolator
-import mods.eln.misc.Utils
+import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
 import mods.eln.node.published
 import mods.eln.node.transparent.EntityMetaTag
@@ -173,7 +168,7 @@ class RadialMotorElement(node: TransparentNode, transparentNodeDescriptor: Trans
         val info = mutableMapOf<String, String>()
         info[tr("Speed")] = Utils.plotRads("", shaft.rads)
         info[tr("Energy")] = Utils.plotEnergy("", shaft.energy)
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Efficiency")] = Utils.plotPercent("", efficiency.toDouble())
             info[tr("Fuel usage")] = Utils.plotBuckets("", fluidRate / 1000.0) + "/s"
         }

--- a/src/main/kotlin/mods/eln/mechanical/ShaftDebugLogger.kt
+++ b/src/main/kotlin/mods/eln/mechanical/ShaftDebugLogger.kt
@@ -3,17 +3,17 @@ package mods.eln.mechanical
 import mods.eln.Eln
 import mods.eln.misc.Coordinate
 import mods.eln.misc.Direction
+import mods.eln.misc.Utils
 import mods.eln.node.NodeManager
 import mods.eln.node.transparent.TransparentNode
-import java.util.Collections
-import java.util.IdentityHashMap
+import java.util.*
 
 object ShaftDebugLogger {
     private var lastSecond = Long.MIN_VALUE
     private val dumpedNetworks = Collections.newSetFromMap(IdentityHashMap<ShaftNetwork, Boolean>())
 
     fun logElement(element: ShaftElement) {
-        if (!Eln.config.getBooleanOrElse("debug.logging.enabled", false)) return
+        if (!Utils.isDebugEnabled()) return
 
         val coordinate = element.coordonate()
         if (!coordinate.worldExist) return

--- a/src/main/kotlin/mods/eln/mechanical/Turbines.kt
+++ b/src/main/kotlin/mods/eln/mechanical/Turbines.kt
@@ -9,18 +9,15 @@ import mods.eln.gui.GuiHelperContainer
 import mods.eln.gui.HelperStdContainer
 import mods.eln.gui.ISlotSkin.SlotSkin
 import mods.eln.i18n.I18N.tr
-import mods.eln.item.TurbineBladeLists
 import mods.eln.item.TurbineBladeDescriptor
+import mods.eln.item.TurbineBladeLists
 import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.INodeContainer
 import mods.eln.node.NodeBase
 import mods.eln.node.NodePeriodicPublishProcess
 import mods.eln.node.published
-import mods.eln.node.transparent.EntityMetaTag
-import mods.eln.node.transparent.TransparentNode
-import mods.eln.node.transparent.TransparentNodeDescriptor
-import mods.eln.node.transparent.TransparentNodeElementInventory
-import mods.eln.node.transparent.TransparentNodeEntity
+import mods.eln.node.transparent.*
 import mods.eln.sim.IProcess
 import mods.eln.sim.nbt.NbtElectricalGateInput
 import net.minecraft.entity.player.EntityPlayer
@@ -32,7 +29,6 @@ import net.minecraft.nbt.NBTTagCompound
 import org.lwjgl.opengl.GL11
 import java.io.DataInputStream
 import java.io.DataOutputStream
-import java.util.*
 
 abstract class TurbineDescriptor(baseName: String, obj: Obj3D) :
     SimpleShaftDescriptor(baseName, TurbineElement::class, TurbineRender::class, EntityMetaTag.Fluid) {
@@ -309,7 +305,7 @@ class TurbineElement(node: TransparentNode, desc_: TransparentNodeDescriptor) :
         } else {
             info[tr("Blade")] = tr("None")
         }
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Efficiency")] = Utils.plotPercent("", efficiency.toDouble())
             info[tr("Fuel usage")] = desc.formatFluidRate(fluidRate)
         }

--- a/src/main/kotlin/mods/eln/misc/BasicContainer.kt
+++ b/src/main/kotlin/mods/eln/misc/BasicContainer.kt
@@ -11,6 +11,9 @@ import net.minecraft.item.ItemStack
 import kotlin.math.min
 
 open class BasicContainer(player: EntityPlayer, protected var inventory: IInventory, slot: Array<Slot>) : Container() {
+    /** The number of slots specific to this container (i.e. not counting the player inventory) */
+    val containerSize = slot.size
+
     init {
         for (i in slot.indices) {
             addSlotToContainer(slot[i])

--- a/src/main/kotlin/mods/eln/misc/Utils.kt
+++ b/src/main/kotlin/mods/eln/misc/Utils.kt
@@ -1,63 +1,51 @@
 @file:Suppress("NAME_SHADOWING")
 package mods.eln.misc
 
-import mods.eln.Eln
-import net.minecraft.entity.EntityLivingBase
-import net.minecraft.util.MathHelper
-import net.minecraft.item.ItemStack
-import net.minecraft.tileentity.TileEntityFurnace
-import net.minecraft.nbt.NBTTagCompound
-import net.minecraft.inventory.IInventory
-import net.minecraft.nbt.NBTTagList
-import net.minecraft.entity.player.EntityPlayerMP
-import net.minecraft.network.play.server.S3FPacketCustomPayload
-import org.lwjgl.opengl.GL11
-import net.minecraft.world.World
 import cpw.mods.fml.common.FMLCommonHandler
 import cpw.mods.fml.relauncher.Side
+import mods.eln.Eln
 import mods.eln.ServerKeyHandler
-import net.minecraftforge.common.DimensionManager
-import net.minecraft.entity.item.EntityItem
-import java.io.IOException
-import net.minecraft.tileentity.TileEntity
-import net.minecraft.client.Minecraft
-import net.minecraft.world.EnumSkyBlock
-import mods.eln.node.ITileEntitySpawnClient
-import net.minecraft.entity.player.EntityPlayer
-import net.minecraft.util.AxisAlignedBB
-import mods.eln.generic.GenericItemUsingDamage
 import mods.eln.generic.GenericItemBlockUsingDamage
-import net.minecraft.creativetab.CreativeTabs
-import net.minecraftforge.oredict.OreDictionary
-import net.minecraft.util.Vec3
-import net.minecraft.client.entity.EntityOtherPlayerMP
-import net.minecraft.init.Blocks
-import java.lang.SecurityException
-import java.lang.IllegalAccessException
-import java.lang.NoSuchFieldException
-import net.minecraft.item.crafting.IRecipe
-import net.minecraft.item.crafting.ShapedRecipes
-import net.minecraftforge.oredict.ShapedOreRecipe
-import net.minecraft.item.crafting.ShapelessRecipes
-import net.minecraftforge.oredict.ShapelessOreRecipe
-import net.minecraft.util.ChatComponentText
-import net.minecraft.world.IBlockAccess
-import kotlin.jvm.JvmOverloads
-import net.minecraft.item.crafting.FurnaceRecipes
-import java.io.FileInputStream
+import mods.eln.generic.GenericItemUsingDamage
 import mods.eln.misc.Obj3D.Obj3DPart
+import mods.eln.node.ITileEntitySpawnClient
 import mods.eln.sim.mna.SubSystem
 import net.minecraft.block.Block
+import net.minecraft.client.Minecraft
+import net.minecraft.client.entity.EntityOtherPlayerMP
+import net.minecraft.creativetab.CreativeTabs
 import net.minecraft.entity.Entity
+import net.minecraft.entity.EntityLivingBase
+import net.minecraft.entity.item.EntityItem
+import net.minecraft.entity.player.EntityPlayer
+import net.minecraft.entity.player.EntityPlayerMP
+import net.minecraft.init.Blocks
+import net.minecraft.inventory.IInventory
 import net.minecraft.item.Item
+import net.minecraft.item.ItemStack
+import net.minecraft.item.crafting.FurnaceRecipes
+import net.minecraft.item.crafting.IRecipe
+import net.minecraft.item.crafting.ShapedRecipes
+import net.minecraft.item.crafting.ShapelessRecipes
+import net.minecraft.nbt.NBTTagCompound
+import net.minecraft.nbt.NBTTagList
+import net.minecraft.network.play.server.S3FPacketCustomPayload
+import net.minecraft.tileentity.TileEntity
+import net.minecraft.tileentity.TileEntityFurnace
+import net.minecraft.util.AxisAlignedBB
+import net.minecraft.util.ChatComponentText
+import net.minecraft.util.MathHelper
+import net.minecraft.util.Vec3
+import net.minecraft.world.EnumSkyBlock
+import net.minecraft.world.IBlockAccess
+import net.minecraft.world.World
 import net.minecraft.world.chunk.Chunk
-import java.io.ByteArrayOutputStream
-import java.io.DataInputStream
-import java.io.DataOutputStream
-import java.io.File
-import java.lang.ClassNotFoundException
-import java.lang.Exception
-import java.lang.IllegalArgumentException
+import net.minecraftforge.common.DimensionManager
+import net.minecraftforge.oredict.OreDictionary
+import net.minecraftforge.oredict.ShapedOreRecipe
+import net.minecraftforge.oredict.ShapelessOreRecipe
+import org.lwjgl.opengl.GL11
+import java.io.*
 import java.nio.charset.Charset
 import java.text.DecimalFormat
 import java.util.*
@@ -88,7 +76,7 @@ object Utils {
 
     @JvmStatic
     fun println(str: String?) {
-        if (Eln.config.getBooleanOrElse("debug.logging.enabled", false)) Eln.logger.info(str)
+        if (isDebugEnabled()) Eln.logger.info(str)
     }
 
     @JvmStatic
@@ -1361,5 +1349,15 @@ object Utils {
             else -> "§c"
         }
         return "$textColorLeft$leftSubSystemSize §r| $textColorRight$rightSubSystemSize"
+    }
+
+    @JvmStatic
+    fun isDebugEnabled(): Boolean {
+        return Eln.config.getBooleanOrElse("debug.logging.enabled", false)
+    }
+
+    @JvmStatic
+    fun isWailaEasyModeEnabled(): Boolean {
+        return Eln.config.getBooleanOrElse("ui.waila.easyMode", false)
     }
 }

--- a/src/main/kotlin/mods/eln/misc/Utils.kt
+++ b/src/main/kotlin/mods/eln/misc/Utils.kt
@@ -375,6 +375,13 @@ object Utils {
     }
 
     @JvmStatic
+    fun sendPacketToAllClients(bos: ByteArrayOutputStream) {
+        getServerPlayerList().forEach { player ->
+            sendPacketToClient(bos, player)
+        }
+    }
+
+    @JvmStatic
     fun setGlColorFromDye(damage: Int) {
         setGlColorFromDye(damage, 1.0f)
     }

--- a/src/main/kotlin/mods/eln/misc/Utils.kt
+++ b/src/main/kotlin/mods/eln/misc/Utils.kt
@@ -30,6 +30,7 @@ import net.minecraft.item.crafting.ShapelessRecipes
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.nbt.NBTTagList
 import net.minecraft.network.play.server.S3FPacketCustomPayload
+import net.minecraft.server.MinecraftServer
 import net.minecraft.tileentity.TileEntity
 import net.minecraft.tileentity.TileEntityFurnace
 import net.minecraft.util.AxisAlignedBB
@@ -1263,9 +1264,14 @@ object Utils {
     @JvmStatic
     fun isPlayerUsingWrench(player: EntityPlayer?): Boolean {
         if (player == null) return false
-        if (ServerKeyHandler.get(ServerKeyHandler.WRENCH)) return true
+        if (ServerKeyHandler.get(ServerKeyHandler.WRENCH, player)) return true
         val stack = player.inventory.getCurrentItem() ?: return false
         return isWrench(stack)
+    }
+
+    @JvmStatic
+    fun isPlayerHoldingShift(player: EntityPlayer): Boolean {
+        return ServerKeyHandler.get(ServerKeyHandler.LSHIFT, player) || ServerKeyHandler.get(ServerKeyHandler.RSHIFT, player)
     }
 
     fun isClassLoaded(@Suppress("UNUSED_PARAMETER") name: String?): Boolean {
@@ -1359,5 +1365,22 @@ object Utils {
     @JvmStatic
     fun isWailaEasyModeEnabled(): Boolean {
         return Eln.config.getBooleanOrElse("ui.waila.easyMode", false)
+    }
+
+    /**
+     * Returns a list of all players in a world. Inspired by
+     * https://forums.minecraftforge.net/topic/5782-getting-a-world-object-and-player-list/.
+     */
+    @JvmStatic
+    fun getServerPlayerList(): List<EntityPlayerMP> {
+        val playerList = mutableListOf<EntityPlayerMP>()
+
+        MinecraftServer.getServer().worldServers.forEach { server ->
+            server.playerEntities.forEach { player ->
+                playerList.add(player as EntityPlayerMP)
+            }
+        }
+
+        return playerList
     }
 }

--- a/src/main/kotlin/mods/eln/misc/UtilsClient.kt
+++ b/src/main/kotlin/mods/eln/misc/UtilsClient.kt
@@ -4,6 +4,8 @@ package mods.eln.misc
 import cpw.mods.fml.common.network.internal.FMLProxyPacket
 import mods.eln.Eln
 import mods.eln.GuiHandler
+import mods.eln.ServerKeyHandler
+import mods.eln.client.ClientKeyHandler
 import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Obj3D.Obj3DPart
 import mods.eln.node.six.SixNodeEntity
@@ -31,7 +33,6 @@ import org.lwjgl.input.Keyboard
 import org.lwjgl.opengl.GL11
 import java.awt.Color
 import java.io.ByteArrayOutputStream
-import java.util.*
 import kotlin.math.sqrt
 
 object UtilsClient {
@@ -619,18 +620,24 @@ object UtilsClient {
         if (realisticEnum != null)
             dst.add("§r${realisticEnum.color}${realisticEnum.name}§r")
         if (details.isNotEmpty()) {
-            if (isShiftHeld()) {
+            if (isShiftHeld() || (Utils.isDebugEnabled() && isWrenchKeyHeld())) {
                 dst.addAll(details)
             } else {
-                dst.add("§F§o${tr("Hold [shift] for details")}")
+                if (Utils.isDebugEnabled()) {
+                    dst.add("§F§o${tr("Hold [shift] or [%1$] for details", ClientKeyHandler.getKeybindKey(ServerKeyHandler.WRENCH))}")
+                } else {
+                    dst.add("§F§o${tr("Hold [shift] for details")}")
+                }
             }
         }
         if (realismDetails.isNotEmpty()) {
-            if (isControlHeld()) {
+            if (isControlHeld() || (Utils.isDebugEnabled() && isWrenchKeyHeld())) {
                 dst.addAll(realismDetails)
             } else {
-                if (realisticEnum != null) {
-                    if (realismDetails.isNotEmpty()) {
+                if (realisticEnum != null && realismDetails.isNotEmpty()) {
+                    if (Utils.isDebugEnabled()) {
+                        dst.add("§F§o${tr("Hold [ctrl] or [%1$] for realism details", ClientKeyHandler.getKeybindKey(ServerKeyHandler.WRENCH))}")
+                    } else {
                         dst.add("§F§o${tr("Hold [ctrl] for realism details")}")
                     }
                 }
@@ -641,12 +648,20 @@ object UtilsClient {
 
     private fun List<String>.listLengthFormatter(@Suppress("UNUSED_PARAMETER") length: Int) {}
 
-    private fun isShiftHeld(): Boolean {
+    fun isShiftHeld(): Boolean {
         return Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)
     }
 
     private fun isControlHeld(): Boolean {
         return Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL)
+    }
+
+    private fun isWrenchKeyHeld(): Boolean {
+        return try {
+            Keyboard.isKeyDown(ClientKeyHandler.getKeybindValue(ServerKeyHandler.WRENCH))
+        } catch (_: IndexOutOfBoundsException) { // This handles the case in which getKeybindValue() somehow returns -1
+            false
+        }
     }
 
     @JvmStatic

--- a/src/main/kotlin/mods/eln/misc/UtilsClient.kt
+++ b/src/main/kotlin/mods/eln/misc/UtilsClient.kt
@@ -648,7 +648,7 @@ object UtilsClient {
 
     private fun List<String>.listLengthFormatter(@Suppress("UNUSED_PARAMETER") length: Int) {}
 
-    fun isShiftHeld(): Boolean {
+    private fun isShiftHeld(): Boolean {
         return Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)
     }
 

--- a/src/main/kotlin/mods/eln/misc/UtilsClient.kt
+++ b/src/main/kotlin/mods/eln/misc/UtilsClient.kt
@@ -6,6 +6,7 @@ import mods.eln.Eln
 import mods.eln.GuiHandler
 import mods.eln.ServerKeyHandler
 import mods.eln.client.ClientKeyHandler
+import mods.eln.config.ClientConfigSyncHandler
 import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Obj3D.Obj3DPart
 import mods.eln.node.six.SixNodeEntity
@@ -620,10 +621,10 @@ object UtilsClient {
         if (realisticEnum != null)
             dst.add("§r${realisticEnum.color}${realisticEnum.name}§r")
         if (details.isNotEmpty()) {
-            if (isShiftHeld() || (Utils.isDebugEnabled() && isWrenchKeyHeld())) {
+            if (isShiftHeld() || (isServerDebugEnabled() && isWrenchKeyHeld())) {
                 dst.addAll(details)
             } else {
-                if (Utils.isDebugEnabled()) {
+                if (isServerDebugEnabled()) {
                     dst.add("§F§o${tr("Hold [shift] or [%1$] for details", ClientKeyHandler.getKeybindKey(ServerKeyHandler.WRENCH))}")
                 } else {
                     dst.add("§F§o${tr("Hold [shift] for details")}")
@@ -631,15 +632,13 @@ object UtilsClient {
             }
         }
         if (realismDetails.isNotEmpty()) {
-            if (isControlHeld() || (Utils.isDebugEnabled() && isWrenchKeyHeld())) {
+            if (isControlHeld() || (isServerDebugEnabled() && isWrenchKeyHeld())) {
                 dst.addAll(realismDetails)
-            } else {
-                if (realisticEnum != null && realismDetails.isNotEmpty()) {
-                    if (Utils.isDebugEnabled()) {
-                        dst.add("§F§o${tr("Hold [ctrl] or [%1$] for realism details", ClientKeyHandler.getKeybindKey(ServerKeyHandler.WRENCH))}")
-                    } else {
-                        dst.add("§F§o${tr("Hold [ctrl] for realism details")}")
-                    }
+            } else if (realisticEnum != null && realismDetails.isNotEmpty()) {
+                if (isServerDebugEnabled()) {
+                    dst.add("§F§o${tr("Hold [ctrl] or [%1$] for realism details", ClientKeyHandler.getKeybindKey(ServerKeyHandler.WRENCH))}")
+                } else {
+                    dst.add("§F§o${tr("Hold [ctrl] for realism details")}")
                 }
             }
         }
@@ -668,5 +667,15 @@ object UtilsClient {
     fun getWeather(world: World): Double {
         if (world.isThundering) return 1.0
         return if (world.isRaining) 0.5 else 0.0
+    }
+
+    /**
+     * This should be used for rendering tasks (such as displaying item tooltips) where it is necessary for the client
+     * to display server-side information without the client actually enabling debug mode (think `wailaEasyMode`-type
+     * behavior).
+     */
+    @JvmStatic
+    fun isServerDebugEnabled(): Boolean {
+        return ClientConfigSyncHandler.getSyncedConfigEntry("debug.logging.enabled") as? Boolean ?: false
     }
 }

--- a/src/main/kotlin/mods/eln/node/six/SixNode.kt
+++ b/src/main/kotlin/mods/eln/node/six/SixNode.kt
@@ -15,8 +15,8 @@ import mods.eln.misc.Utils.updateAllLightTypes
 import mods.eln.misc.Utils.updateSkylight
 import mods.eln.node.ISixNodeCache
 import mods.eln.node.Node
-import mods.eln.node.NodeConnectionEndpoint
 import mods.eln.node.NodeConnection
+import mods.eln.node.NodeConnectionEndpoint
 import mods.eln.sim.ElectricalConnection
 import mods.eln.sim.ElectricalLoad
 import mods.eln.sim.ThermalConnection
@@ -36,7 +36,6 @@ import java.io.DataInputStream
 import java.io.DataOutputStream
 import java.io.IOException
 import java.lang.reflect.InvocationTargetException
-import java.util.*
 
 class SixNode : Node() {
     @JvmField
@@ -433,7 +432,7 @@ class SixNode : Node() {
             var b = Blocks.air
             if (stack != null) b = Block.getBlockFromItem(stack.item)
             var isWrenchReplacingBlock = false
-            if (ServerKeyHandler.get(ServerKeyHandler.WRENCH) && stack != null) {
+            if (ServerKeyHandler.get(ServerKeyHandler.WRENCH, entityPlayer) && stack != null) {
                 for (a in sixNodeCacheList) {
                     if (a.accept(stack)) {
                         isWrenchReplacingBlock = true

--- a/src/main/kotlin/mods/eln/railroad/OverheadLines.kt
+++ b/src/main/kotlin/mods/eln/railroad/OverheadLines.kt
@@ -3,22 +3,19 @@ package mods.eln.railroad
 import mods.eln.Eln
 import mods.eln.cable.CableRenderDescriptor
 import mods.eln.i18n.I18N
-import mods.eln.misc.Coordinate
-import mods.eln.misc.Direction
-import mods.eln.misc.LRDU
-import mods.eln.misc.LRDUMask
-import mods.eln.misc.Obj3D
+import mods.eln.misc.*
 import mods.eln.misc.Utils.getBlock
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.misc.Utils.plotPower
 import mods.eln.misc.Utils.plotVolt
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.*
+import mods.eln.railroad.PoweredMinecartSimulationSingleton.poweredMinecartSimulationData
 import mods.eln.sim.ElectricalConnection
 import mods.eln.sim.ElectricalLoad
 import mods.eln.sim.mna.component.Resistor
 import mods.eln.sim.mna.misc.MnaConst
 import mods.eln.sim.nbt.NbtElectricalLoad
-import mods.eln.railroad.PoweredMinecartSimulationSingleton.poweredMinecartSimulationData
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import java.io.IOException
@@ -85,7 +82,7 @@ class OverheadLinesElement(node: TransparentNode?,
     override fun getWaila(): Map<String, String> {
         val info: MutableMap<String, String> = HashMap()
         info[I18N.tr("Voltage")] = plotVolt("", electricalLoad.voltage)
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[I18N.tr("Power")] = plotPower("", electricalLoad.current * electricalLoad.voltage)
         }
         val ss = electricalLoad.subSystem

--- a/src/main/kotlin/mods/eln/railroad/UnderTrackPower.kt
+++ b/src/main/kotlin/mods/eln/railroad/UnderTrackPower.kt
@@ -4,11 +4,12 @@ import mods.eln.Eln
 import mods.eln.cable.CableRenderDescriptor
 import mods.eln.i18n.I18N
 import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
 import mods.eln.node.transparent.*
+import mods.eln.railroad.PoweredMinecartSimulationSingleton.poweredMinecartSimulationData
 import mods.eln.sim.ElectricalConnection
 import mods.eln.sim.ElectricalLoad
-import mods.eln.railroad.PoweredMinecartSimulationSingleton.poweredMinecartSimulationData
 import mods.eln.sim.mna.component.Resistor
 import mods.eln.sim.mna.misc.MnaConst
 import mods.eln.sim.nbt.NbtElectricalLoad
@@ -68,7 +69,7 @@ class UnderTrackPowerElement(node: TransparentNode?,
     override fun getWaila(): Map<String, String> {
         val info: MutableMap<String, String> = HashMap()
         info[I18N.tr("Voltage")] = Utils.plotVolt("", electricalLoad.voltage)
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[I18N.tr("Power")] = Utils.plotPower("", electricalLoad.current * electricalLoad.voltage)
         }
         val ss = electricalLoad.subSystem

--- a/src/main/kotlin/mods/eln/registration/SingleNodeRegistration.kt
+++ b/src/main/kotlin/mods/eln/registration/SingleNodeRegistration.kt
@@ -22,9 +22,7 @@ import net.minecraft.tileentity.TileEntity
 object SingleNodeRegistration {
 
     fun registerSingle() {
-        if (Eln.instance.isDevelopmentRun) {
-            registerConduitSingles()
-        }
+        /* if (Eln.instance.isDevelopmentRun) */ registerConduitSingles()
         registerEnergyConverter()
         registerComputer()
     }

--- a/src/main/kotlin/mods/eln/registration/SingleNodeRegistration.kt
+++ b/src/main/kotlin/mods/eln/registration/SingleNodeRegistration.kt
@@ -22,7 +22,7 @@ import net.minecraft.tileentity.TileEntity
 object SingleNodeRegistration {
 
     fun registerSingle() {
-        /* if (Eln.instance.isDevelopmentRun) */ registerConduitSingles()
+        if (Eln.instance.isDevelopmentRun) registerConduitSingles()
         registerEnergyConverter()
         registerComputer()
     }

--- a/src/main/kotlin/mods/eln/registration/SixNodeRegistration.kt
+++ b/src/main/kotlin/mods/eln/registration/SixNodeRegistration.kt
@@ -12,11 +12,10 @@ import mods.eln.item.lampitem.LampLists
 import mods.eln.misc.Direction
 import mods.eln.misc.FunctionTableYProtect
 import mods.eln.misc.IFunction
+import mods.eln.misc.NominalVoltage
 import mods.eln.misc.SeriesFunction.Companion.newE12
 import mods.eln.misc.SeriesFunction.Companion.newE6
-import mods.eln.misc.NominalVoltage
 import mods.eln.node.six.SixNodeDescriptor
-import mods.eln.sixnode.signalinductor.SignalInductorDescriptor
 import mods.eln.sixnode.*
 import mods.eln.sixnode.TreeResinCollector.TreeResinCollectorDescriptor
 import mods.eln.sixnode.batterycharger.BatteryChargerDescriptor
@@ -25,14 +24,7 @@ import mods.eln.sixnode.currentrelay.CurrentRelayDescriptor
 import mods.eln.sixnode.diode.DiodeDescriptor
 import mods.eln.sixnode.electricalalarm.ElectricalAlarmDescriptor
 import mods.eln.sixnode.electricalbreaker.ElectricalBreakerDescriptor
-import mods.eln.sixnode.electricalcable.ElectricalCableDescriptor
-import mods.eln.sixnode.electricalcable.ElectricalSignalBusCableElement
-import mods.eln.sixnode.electricalcable.MoltenMetalPileDescriptor
-import mods.eln.sixnode.electricalcable.UtilityCableDescriptor
-import mods.eln.sixnode.electricalcable.UtilityCableElement
-import mods.eln.sixnode.electricalcable.UtilityCableMaterial
-import mods.eln.sixnode.electricalcable.UtilityCablePalette
-import mods.eln.sixnode.electricalcable.UtilityCableRender
+import mods.eln.sixnode.electricalcable.*
 import mods.eln.sixnode.electricaldatalogger.ElectricalDataLoggerDescriptor
 import mods.eln.sixnode.electricaldigitaldisplay.ElectricalDigitalDisplayDescriptor
 import mods.eln.sixnode.electricalentitysensor.ElectricalEntitySensorDescriptor
@@ -53,9 +45,6 @@ import mods.eln.sixnode.electricalwatch.ElectricalWatchDescriptor
 import mods.eln.sixnode.electricalweathersensor.ElectricalWeatherSensorDescriptor
 import mods.eln.sixnode.electricalwindsensor.ElectricalWindSensorDescriptor
 import mods.eln.sixnode.energymeter.EnergyMeterDescriptor
-import mods.eln.sixnode.mqttmeter.MqttEnergyMeterElement
-import mods.eln.sixnode.mqttmeter.MqttEnergyMeterRender
-import mods.eln.sixnode.mqttsignal.MqttSignalControllerDescriptor
 import mods.eln.sixnode.groundcable.GroundCableDescriptor
 import mods.eln.sixnode.hub.HubDescriptor
 import mods.eln.sixnode.lampsocket.LampSocketDescriptor
@@ -64,8 +53,12 @@ import mods.eln.sixnode.lampsocket.objrender.LampSocketSuspendedObjRender
 import mods.eln.sixnode.lampsupply.LampSupplyDescriptor
 import mods.eln.sixnode.logicgate.*
 import mods.eln.sixnode.modbusrtu.ModbusRtuDescriptor
+import mods.eln.sixnode.mqttmeter.MqttEnergyMeterElement
+import mods.eln.sixnode.mqttmeter.MqttEnergyMeterRender
+import mods.eln.sixnode.mqttsignal.MqttSignalControllerDescriptor
 import mods.eln.sixnode.powersocket.PowerSocketDescriptor
 import mods.eln.sixnode.resistor.ResistorDescriptor
+import mods.eln.sixnode.signalinductor.SignalInductorDescriptor
 import mods.eln.sixnode.thermalcable.ThermalCableDescriptor
 import mods.eln.sixnode.thermalsensor.ThermalSensorDescriptor
 import mods.eln.sixnode.thermometersensor.ThermometerSensorDescriptor
@@ -74,8 +67,8 @@ import mods.eln.sixnode.wirelesssignal.repeater.WirelessSignalRepeaterDescriptor
 import mods.eln.sixnode.wirelesssignal.rx.WirelessSignalRxDescriptor
 import mods.eln.sixnode.wirelesssignal.source.WirelessSignalSourceDescriptor
 import mods.eln.sixnode.wirelesssignal.tx.WirelessSignalTxDescriptor
-import java.util.Locale
 import net.minecraft.creativetab.CreativeTabs
+import java.util.*
 
 object SixNodeRegistration {
 
@@ -137,9 +130,7 @@ object SixNodeRegistration {
         registerUtilityCables(34, 35, 36, 37)
         registerThermalCable(48)
         registerCurrentRelays(126)
-        if (Eln.instance.isDevelopmentRun) {
-            registerConduit(127)
-        }
+        /* if (Eln.instance.isDevelopmentRun) */ registerConduit(127)
         registerLampSocket(64)
         registerPowerSocket(67)
         registerLampSupply(65)

--- a/src/main/kotlin/mods/eln/registration/SixNodeRegistration.kt
+++ b/src/main/kotlin/mods/eln/registration/SixNodeRegistration.kt
@@ -130,7 +130,7 @@ object SixNodeRegistration {
         registerUtilityCables(34, 35, 36, 37)
         registerThermalCable(48)
         registerCurrentRelays(126)
-        /* if (Eln.instance.isDevelopmentRun) */ registerConduit(127)
+        if (Eln.instance.isDevelopmentRun) registerConduit(127)
         registerLampSocket(64)
         registerPowerSocket(67)
         registerLampSupply(65)

--- a/src/main/kotlin/mods/eln/server/console/ElnConsoleCommands.kt
+++ b/src/main/kotlin/mods/eln/server/console/ElnConsoleCommands.kt
@@ -1,25 +1,20 @@
 package mods.eln.server.console
 
 import mods.eln.Eln
+import mods.eln.environment.BiomeClimateService
 import mods.eln.gridnode.GridElement
 import mods.eln.gridnode.GridLink
 import mods.eln.gridnode.GridSwitchElement
 import mods.eln.gridnode.electricalpole.ElectricalPoleDescriptor
 import mods.eln.gridnode.electricalpole.ElectricalPoleElement
 import mods.eln.gridnode.transformer.GridTransformerElement
-import mods.eln.mechanical.ShaftElement
-import mods.eln.environment.BiomeClimateService
 import mods.eln.item.lampitem.BoilerplateLampData
 import mods.eln.item.lampitem.LampLists
-import mods.eln.misc.Coordinate
-import mods.eln.misc.Direction
-import mods.eln.misc.FC
-import mods.eln.misc.GhostPowerNode
-import mods.eln.misc.LRDU
-import mods.eln.misc.Version
+import mods.eln.mechanical.ShaftElement
+import mods.eln.misc.*
+import mods.eln.node.GhostNode
 import mods.eln.node.NodeBase
 import mods.eln.node.NodeManager
-import mods.eln.node.GhostNode
 import mods.eln.node.simple.SimpleNode
 import mods.eln.node.six.SixNode
 import mods.eln.node.transparent.TransparentNode
@@ -33,16 +28,8 @@ import java.io.BufferedWriter
 import java.io.File
 import java.io.FileWriter
 import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.LinkedHashSet
-import kotlin.math.PI
-import kotlin.math.ceil
-import kotlin.math.cos
-import kotlin.math.hypot
-import kotlin.math.min
-import kotlin.math.max
-import kotlin.math.sin
+import java.util.*
+import kotlin.math.*
 
 private data class ZoneBounds(
     val minX: Int,
@@ -1005,7 +992,7 @@ class ElnResetLampLifeCommand: IConsoleCommand {
 
     override fun runCommand(ics: ICommandSender, args: List<String>) {
         if (args.isEmpty()) {
-            LampLists.resetLampLifeFlag = true // This flag is automatically set to false up to two seconds after this command is called.
+            LampLists.resetLampLifeFlag = true // This flag is automatically set to false ~1 tick after this command is called.
             cprint(ics, "Resetting the lives of all light bulbs to their default values...", indent = 1)
         } else {
             cprint(ics, "This command does not take any arguments.", indent = 1)

--- a/src/main/kotlin/mods/eln/server/console/ElnConsoleCommands.kt
+++ b/src/main/kotlin/mods/eln/server/console/ElnConsoleCommands.kt
@@ -1,6 +1,7 @@
 package mods.eln.server.console
 
 import mods.eln.Eln
+import mods.eln.config.ServerConfigSyncHandler
 import mods.eln.environment.BiomeClimateService
 import mods.eln.gridnode.GridElement
 import mods.eln.gridnode.GridLink
@@ -153,6 +154,7 @@ class ElnConfigCommand : IConsoleCommand {
                             return
                         } else cprint(ics, "${FC.BRIGHT_GREEN}$path = $writtenValue", indent = 1)
                     }
+                    ServerConfigSyncHandler.syncClientConfig()
                     cprint(ics, "Changes saved to config/eln/eln.json.", indent = 1)
                 } catch (e: IllegalArgumentException) {
                     cprint(ics, "${FC.BRIGHT_RED}${e.message}", indent = 1)
@@ -1050,6 +1052,7 @@ class ElnDebugCommand: IConsoleCommand {
         if (args.size == 1) {
             val debug = getArgBool(ics, args[0])?: return
             saveConfigPath("debug.logging.enabled", debug)
+            ServerConfigSyncHandler.syncClientConfig()
             cprint(ics, "Debug mode: ${FC.DARK_GREEN}${boolToStr(debug)}", indent = 1)
         } else {
             cprint(ics, "This command only takes one argument - true or false")

--- a/src/main/kotlin/mods/eln/sim/BatteryProcess.kt
+++ b/src/main/kotlin/mods/eln/sim/BatteryProcess.kt
@@ -2,6 +2,7 @@ package mods.eln.sim
 
 import mods.eln.Eln
 import mods.eln.misc.FunctionTable
+import mods.eln.misc.Utils
 import mods.eln.sim.mna.component.VoltageSource
 import mods.eln.sim.mna.state.VoltageState
 
@@ -28,7 +29,7 @@ open class BatteryProcess(
         var wasteQ = 0.0
         val deltaQ = voltageSource.current * time / QNominal
         if (!isRechargeable && deltaQ < 0.0) {
-            if (Eln.config.getBooleanOrElse("debug.logging.enabled", false)) {
+            if (Utils.isDebugEnabled()) {
                 Eln.logger.warn("Battery is recharging when it shouldn't! current=${voltageSource.current}")
             }
             wasteQ = -deltaQ

--- a/src/main/kotlin/mods/eln/sim/MnaMatrixDebugger.kt
+++ b/src/main/kotlin/mods/eln/sim/MnaMatrixDebugger.kt
@@ -14,8 +14,7 @@ import mods.eln.sim.mna.state.State
 import java.io.File
 import java.io.IOException
 import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import java.util.*
 
 /**
  * Logs the conductance matrices that the MNA solver builds for a given node or element.
@@ -26,7 +25,7 @@ object MnaMatrixDebugger {
     private val TIMESTAMP_FORMAT = SimpleDateFormat("yyyyMMdd-HHmmss-SSS", Locale.ROOT)
 
     fun dump(target: Any?, reason: String? = null) {
-        if (!Eln.config.getBooleanOrElse("debug.logging.enabled", false) || !Eln.config.getBooleanOrElse("debug.logging.simSnapshot", false)) {
+        if (!Utils.isDebugEnabled() || !Eln.config.getBooleanOrElse("debug.logging.simSnapshot", false)) {
             return
         }
 

--- a/src/main/kotlin/mods/eln/sixnode/AnalogChips.kt
+++ b/src/main/kotlin/mods/eln/sixnode/AnalogChips.kt
@@ -6,6 +6,7 @@ import mods.eln.gui.*
 import mods.eln.i18n.I18N.tr
 import mods.eln.item.IConfigurable
 import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
 import mods.eln.node.Synchronizable
 import mods.eln.node.six.*
@@ -17,7 +18,6 @@ import mods.eln.sim.nbt.NbtElectricalGateOutputProcess
 import mods.eln.sixnode.SummingUnitElement.Companion.GainChangedEvents
 import mods.eln.solver.Constant
 import mods.eln.solver.Equation
-import mods.eln.solver.IValue
 import mods.eln.wiki.Data
 import net.minecraft.client.gui.GuiScreen
 import net.minecraft.entity.player.EntityPlayer
@@ -265,7 +265,7 @@ class PIDRegulator : AnalogFunction() {
     override fun getWaila(inputs: Array<Double?>, output: Double): MutableMap<String, String> {
         val info = super.getWaila(inputs, output)
         info[tr("Params")] = "Kp = $Kp, Ki = $Ki, Kd = $Kd"
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("State")] = "Si = ${pid.iStack}"
         }
         return info

--- a/src/main/kotlin/mods/eln/sixnode/CurrentSourceSix.kt
+++ b/src/main/kotlin/mods/eln/sixnode/CurrentSourceSix.kt
@@ -5,10 +5,10 @@ import mods.eln.cable.CableRenderDescriptor
 import mods.eln.gui.GuiHelper
 import mods.eln.gui.GuiScreenEln
 import mods.eln.gui.GuiTextFieldEln
-import mods.eln.i18n.I18N
 import mods.eln.i18n.I18N.tr
 import mods.eln.item.IConfigurable
 import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
 import mods.eln.node.six.*
 import mods.eln.sim.ElectricalLoad
@@ -108,7 +108,7 @@ class CurrentSourceElement(sixNode: SixNode, side: Direction, descriptor: SixNod
         val info: MutableMap<String, String> = HashMap()
         info[tr("Voltage")] = Utils.plotVolt("", electricalLoad.voltage)
         info[tr("Current")] = Utils.plotAmpere("", electricalLoad.current)
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Power")] = Utils.plotPower("", electricalLoad.voltage * electricalLoad.current)
         }
         return info

--- a/src/main/kotlin/mods/eln/sixnode/PortableNaN.kt
+++ b/src/main/kotlin/mods/eln/sixnode/PortableNaN.kt
@@ -1,10 +1,10 @@
 package mods.eln.sixnode
 
-import mods.eln.Eln
 import mods.eln.cable.CableRender
 import mods.eln.cable.CableRenderDescriptor
 import mods.eln.i18n.I18N.tr
 import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
 import mods.eln.node.six.*
 import mods.eln.sim.ElectricalLoad
@@ -19,7 +19,6 @@ import net.minecraft.item.ItemStack
 import net.minecraft.util.ResourceLocation
 import net.minecraftforge.client.IItemRenderer
 import org.lwjgl.opengl.GL11
-import java.util.HashMap
 
 class PortableNaNDescriptor(name: String, renderIn: CableRenderDescriptor): GenericCableDescriptor(name, PortableNaNElement::class.java, PortableNaNRender::class.java) {
 
@@ -118,7 +117,7 @@ class PortableNaNElement(sixNode: SixNode, side: Direction, descriptor: SixNodeD
 
         info[tr("Current")] = Utils.plotAmpere("", electricalLoad.current)
         info[tr("Temperature")] = plotAmbientCelsius("", thermalLoad.temperature)
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Voltage")] = Utils.plotVolt("", electricalLoad.voltage)
         }
         info[tr("Subsystem Matrix Size")] = Utils.renderSubSystemWaila(electricalLoad.subSystem)

--- a/src/main/kotlin/mods/eln/sixnode/PowerCapacitor.kt
+++ b/src/main/kotlin/mods/eln/sixnode/PowerCapacitor.kt
@@ -3,25 +3,15 @@ package mods.eln.sixnode
 import mods.eln.Eln
 import mods.eln.generic.GenericItemUsingDamageDescriptor
 import mods.eln.generic.GenericItemUsingDamageSlot
-import mods.eln.gui.GuiContainerEln
-import mods.eln.gui.GuiHelperContainer
-import mods.eln.gui.IGuiObject
-import mods.eln.gui.ISlotSkin
-import mods.eln.gui.ItemStackFilter
-import mods.eln.gui.SlotFilter
-import mods.eln.i18n.I18N
+import mods.eln.gui.*
 import mods.eln.i18n.I18N.tr
 import mods.eln.item.DielectricItem
 import mods.eln.item.IConfigurable
 import mods.eln.item.ItemMovingHelper
 import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
-import mods.eln.node.six.SixNode
-import mods.eln.node.six.SixNodeDescriptor
-import mods.eln.node.six.SixNodeElement
-import mods.eln.node.six.SixNodeElementInventory
-import mods.eln.node.six.SixNodeElementRender
-import mods.eln.node.six.SixNodeEntity
+import mods.eln.node.six.*
 import mods.eln.sim.ElectricalLoad
 import mods.eln.sim.IProcess
 import mods.eln.sim.ThermalLoad
@@ -41,7 +31,6 @@ import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraftforge.client.IItemRenderer
 import org.lwjgl.opengl.GL11
-import java.util.HashMap
 import kotlin.math.abs
 import kotlin.math.pow
 
@@ -180,7 +169,7 @@ class PowerCapacitorSixElement(SixNode: SixNode, side: Direction, descriptor: Si
         val info: MutableMap<String, String> = HashMap()
         info[tr("Capacity")] = Utils.plotValue(capacitor.coulombs, "F")
         info[tr("Charge")] = Utils.plotEnergy("", capacitor.energy)
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Voltage drop")] = Utils.plotVolt("", Math.abs(capacitor.voltage))
             info[tr("Current")] = Utils.plotAmpere("", Math.abs(capacitor.current))
         }

--- a/src/main/kotlin/mods/eln/sixnode/PowerInductorSix.kt
+++ b/src/main/kotlin/mods/eln/sixnode/PowerInductorSix.kt
@@ -13,13 +13,9 @@ import mods.eln.item.FerromagneticCoreDescriptor
 import mods.eln.item.IConfigurable
 import mods.eln.item.ItemMovingHelper
 import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
-import mods.eln.node.six.SixNode
-import mods.eln.node.six.SixNodeDescriptor
-import mods.eln.node.six.SixNodeElement
-import mods.eln.node.six.SixNodeElementInventory
-import mods.eln.node.six.SixNodeElementRender
-import mods.eln.node.six.SixNodeEntity
+import mods.eln.node.six.*
 import mods.eln.sim.ElectricalLoad
 import mods.eln.sim.ThermalLoad
 import mods.eln.sim.mna.component.Inductor
@@ -36,7 +32,6 @@ import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraftforge.client.IItemRenderer
 import org.lwjgl.opengl.GL11
-import java.util.HashMap
 import kotlin.math.abs
 
 class PowerInductorSixDescriptor(name: String,
@@ -155,7 +150,7 @@ class PowerInductorSixElement(SixNode: SixNode, side: Direction, descriptor: Six
         val info: MutableMap<String, String> = HashMap()
         info[tr("Inductance")] = Utils.plotValue(inductor.inductance, "H")
         info[tr("Charge")] = Utils.plotEnergy("", inductor.energy)
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Voltage drop")] = Utils.plotVolt("", abs(inductor.voltage))
             info[tr("Current")] = Utils.plotAmpere("", abs(inductor.current))
         }

--- a/src/main/kotlin/mods/eln/sixnode/PowerSinkSix.kt
+++ b/src/main/kotlin/mods/eln/sixnode/PowerSinkSix.kt
@@ -7,17 +7,10 @@ import mods.eln.gui.GuiScreenEln
 import mods.eln.gui.GuiTextFieldEln
 import mods.eln.i18n.I18N.tr
 import mods.eln.item.IConfigurable
-import mods.eln.misc.Direction
-import mods.eln.misc.LRDU
-import mods.eln.misc.Obj3D
-import mods.eln.misc.Utils
-import mods.eln.misc.VoltageLevelColor
+import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
-import mods.eln.node.six.SixNode
-import mods.eln.node.six.SixNodeDescriptor
-import mods.eln.node.six.SixNodeElement
-import mods.eln.node.six.SixNodeElementRender
-import mods.eln.node.six.SixNodeEntity
+import mods.eln.node.six.*
 import mods.eln.sim.ElectricalLoad
 import mods.eln.sim.ThermalLoad
 import mods.eln.sim.mna.component.CurrentSource
@@ -110,7 +103,7 @@ class PowerSinkElement(sixNode: SixNode, side: Direction, descriptor: SixNodeDes
         val info: MutableMap<String, String> = HashMap()
         info[tr("Voltage")] = Utils.plotVolt("", electricalLoad.voltage)
         info[tr("Current")] = Utils.plotAmpere("", electricalLoad.current)
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Power")] = Utils.plotPower("", electricalLoad.voltage * electricalLoad.current)
         }
         return info

--- a/src/main/kotlin/mods/eln/sixnode/PowerSourceSix.kt
+++ b/src/main/kotlin/mods/eln/sixnode/PowerSourceSix.kt
@@ -7,17 +7,10 @@ import mods.eln.gui.GuiScreenEln
 import mods.eln.gui.GuiTextFieldEln
 import mods.eln.i18n.I18N.tr
 import mods.eln.item.IConfigurable
-import mods.eln.misc.Direction
-import mods.eln.misc.LRDU
-import mods.eln.misc.Obj3D
-import mods.eln.misc.Utils
-import mods.eln.misc.VoltageLevelColor
+import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
-import mods.eln.node.six.SixNode
-import mods.eln.node.six.SixNodeDescriptor
-import mods.eln.node.six.SixNodeElement
-import mods.eln.node.six.SixNodeElementRender
-import mods.eln.node.six.SixNodeEntity
+import mods.eln.node.six.*
 import mods.eln.sim.ElectricalLoad
 import mods.eln.sim.ThermalLoad
 import mods.eln.sim.mna.component.CurrentSource
@@ -110,7 +103,7 @@ class PowerSourceElement(sixNode: SixNode, side: Direction, descriptor: SixNodeD
         val info: MutableMap<String, String> = HashMap()
         info[tr("Voltage")] = Utils.plotVolt("", electricalLoad.voltage)
         info[tr("Current")] = Utils.plotAmpere("", electricalLoad.current)
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Power")] = Utils.plotPower("", electricalLoad.voltage * electricalLoad.current)
         }
         return info

--- a/src/main/kotlin/mods/eln/sixnode/VariableInductorSix.kt
+++ b/src/main/kotlin/mods/eln/sixnode/VariableInductorSix.kt
@@ -10,21 +10,10 @@ import mods.eln.gui.IGuiObject
 import mods.eln.gui.ISlotSkin
 import mods.eln.i18n.I18N.tr
 import mods.eln.item.FerromagneticCoreDescriptor
-import mods.eln.misc.BasicContainer
-import mods.eln.misc.Direction
-import mods.eln.misc.IFunction
-import mods.eln.misc.LRDU
-import mods.eln.misc.Obj3D
-import mods.eln.misc.RealisticEnum
-import mods.eln.misc.Utils
-import mods.eln.misc.VoltageLevelColor
+import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
-import mods.eln.node.six.SixNode
-import mods.eln.node.six.SixNodeDescriptor
-import mods.eln.node.six.SixNodeElement
-import mods.eln.node.six.SixNodeElementInventory
-import mods.eln.node.six.SixNodeElementRender
-import mods.eln.node.six.SixNodeEntity
+import mods.eln.node.six.*
 import mods.eln.sim.ElectricalLoad
 import mods.eln.sim.IProcess
 import mods.eln.sim.ThermalLoad
@@ -37,13 +26,11 @@ import net.minecraft.client.gui.GuiScreen
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.inventory.Container
 import net.minecraft.inventory.IInventory
-import net.minecraft.inventory.Slot
 import net.minecraft.item.Item
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraftforge.client.IItemRenderer
 import org.lwjgl.opengl.GL11
-import java.util.HashMap
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
@@ -239,7 +226,7 @@ class VariableInductorSixElement(
         info[tr("Inductance")] = Utils.plotValue(inductor.inductance, "H")
         info[tr("Charge")] = Utils.plotEnergy("", inductor.energy)
         info[tr("Control")] = Utils.plotPercent("", controlNormalized())
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Voltage drop")] = Utils.plotVolt("", abs(inductor.voltage))
             info[tr("Current")] = Utils.plotAmpere("", abs(inductor.current))
         }

--- a/src/main/kotlin/mods/eln/sixnode/currentcable/CurrentCable.kt
+++ b/src/main/kotlin/mods/eln/sixnode/currentcable/CurrentCable.kt
@@ -11,8 +11,8 @@ import mods.eln.misc.LRDU
 import mods.eln.misc.RealisticEnum
 import mods.eln.misc.Utils.addChatMessage
 import mods.eln.misc.Utils.isPlayerUsingWrench
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.misc.Utils.plotAmpere
-import mods.eln.misc.Utils.plotCelsius
 import mods.eln.misc.Utils.plotPower
 import mods.eln.misc.Utils.plotUIP
 import mods.eln.misc.Utils.plotValue
@@ -200,7 +200,7 @@ open class CurrentCableElement(sixNode: SixNode?, side: Direction?, descriptor: 
         val info: MutableMap<String, String> = HashMap()
         info[tr("Current")] = plotAmpere("", electricalLoad.current)
         info[tr("Temperature")] = plotAmbientCelsius("", thermalLoad.temperature)
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Voltage")] = plotVolt("", electricalLoad.voltage)
         }
         info[tr("Subsystem Matrix Size")] = renderSubSystemWaila(electricalLoad.subSystem)

--- a/src/main/kotlin/mods/eln/sixnode/currentrelay/CurrentRelay.kt
+++ b/src/main/kotlin/mods/eln/sixnode/currentrelay/CurrentRelay.kt
@@ -10,6 +10,7 @@ import mods.eln.item.IConfigurable
 import mods.eln.misc.*
 import mods.eln.misc.LRDU.Companion.fromInt
 import mods.eln.misc.Obj3D.Obj3DPart
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.misc.Utils.plotAmpere
 import mods.eln.misc.Utils.plotVolt
 import mods.eln.misc.Utils.renderSubSystemWaila
@@ -249,7 +250,7 @@ class CurrentRelayElement(sixNode: SixNode, side: Direction, descriptor: SixNode
         info[tr("Position")] = if (switchState) tr("Closed") else tr("Open")
         info[tr("Current")] = plotAmpere("", aLoad.current)
         info[tr("Temperature")] = plotAmbientCelsius("", thermalLoad.temperatureCelsius)
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Default position")] = if (defaultOutput) tr("Closed") else tr("Open")
             info[tr("Voltages")] =
                 plotVolt("", aLoad.voltage) + plotVolt(" ", bLoad.voltage)

--- a/src/main/kotlin/mods/eln/sixnode/lampsocket/LampSocketElement.kt
+++ b/src/main/kotlin/mods/eln/sixnode/lampsocket/LampSocketElement.kt
@@ -322,7 +322,7 @@ class LampSocketElement(sixNode: SixNode, side: Direction, sixNodeDescriptor: Si
         if (lampStack != null) info[I18N.tr("Bulb")] = lampStack.displayName
         else info[I18N.tr("Bulb")] = I18N.tr("None")
 
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info[I18N.tr("Voltage")] = plotVolt("", electricalLoad.voltage)
 
             if (lampStack != null) {
@@ -333,7 +333,7 @@ class LampSocketElement(sixNode: SixNode, side: Direction, sixNodeDescriptor: Si
             if (poweredByLampSupply) info[I18N.tr("Channel")] = lampSupplyChannel
         }
 
-        if (Eln.config.getBooleanOrElse("debug.logging.enabled", false)) {
+        if (Utils.isDebugEnabled()) {
             info[I18N.tr("Lamp Brightness")] = plotValue(sixNode!!.lightValue.toDouble())
         }
 

--- a/src/main/kotlin/mods/eln/sixnode/lampsocket/LampSocketProcess.kt
+++ b/src/main/kotlin/mods/eln/sixnode/lampsocket/LampSocketProcess.kt
@@ -16,8 +16,6 @@ import kotlin.math.abs
 
 class LampSocketProcess(var element: LampSocketElement) : IProcess {
 
-    private var processElapsedTime = 0.0
-
     var cachedBestChannelHandle: Pair<Double, LampSupplyElement.PowerSupplyChannelHandle>? = null
     var stableLightProbability = 0.0
     var fastLightValue = 0
@@ -83,19 +81,11 @@ class LampSocketProcess(var element: LampSocketElement) : IProcess {
                 updateNearbyBlocks(lampData.technology.cropGrowthRateFactor, lampData.nominalLightValue, newLightValue, time)
             }
 
-            /* Only decrease the life of a bulb once a second. This reduces the update rate at which the NBT is changed
-             * to once per second from once per tick, reducing the probability of an NBT mismatch bug occurring when
-             * shift-clicking. When the bug is eventually fixed, the processElapsedTime variable and supporting code can
-             * be deleted. Also update the decreaseLampLife function definition according to the note there.
-             */
-            if (processElapsedTime in -0.001..0.001) {
-                val lampLife = lampDescriptor.decreaseLampLife(lampStack, lampVoltage)
-
-                if (lampLife <= 0.0) {
-                    newLightValue = BoilerplateLampData.MIN_LIGHT_VALUE
-                    element.inventory.setInventorySlotContents(LampSocketContainer.LAMP_SLOT_ID, null)
-                    element.inventory.markDirty()
-                }
+            val lampLife = lampDescriptor.decreaseLampLife(lampStack, lampVoltage)
+            if (lampLife <= 0.0) {
+                newLightValue = BoilerplateLampData.MIN_LIGHT_VALUE
+                element.inventory.setInventorySlotContents(LampSocketContainer.LAMP_SLOT_ID, null)
+                element.inventory.markDirty()
             }
         } else {
             stableLightProbability = 0.0
@@ -106,9 +96,6 @@ class LampSocketProcess(var element: LampSocketElement) : IProcess {
 
         updateFastLight(newLightValue)
         updateInventoryAndPublish(lampStack, cableStack, activeLampSupplyConnection, newLightValue)
-
-        processElapsedTime += time
-        if (processElapsedTime >= 1.0) processElapsedTime = 0.0
     }
 
     private fun findBestLampSupply(coordinate: Coordinate, forceUpdate: Boolean = false) {

--- a/src/main/kotlin/mods/eln/transparentnode/DcDc.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/DcDc.kt
@@ -12,18 +12,13 @@ import mods.eln.gui.ISlotSkin.SlotSkin
 import mods.eln.i18n.I18N.tr
 import mods.eln.item.CaseItemDescriptor
 import mods.eln.item.ConfigCopyToolDescriptor
-import mods.eln.item.CopperCableDescriptor
 import mods.eln.item.FerromagneticCoreDescriptor
 import mods.eln.item.IConfigurable
 import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
 import mods.eln.node.NodePeriodicPublishProcess
-import mods.eln.node.transparent.TransparentNode
-import mods.eln.node.transparent.TransparentNodeDescriptor
-import mods.eln.node.transparent.TransparentNodeElement
-import mods.eln.node.transparent.TransparentNodeElementInventory
-import mods.eln.node.transparent.TransparentNodeElementRender
-import mods.eln.node.transparent.TransparentNodeEntity
+import mods.eln.node.transparent.*
 import mods.eln.sim.ElectricalLoad
 import mods.eln.sim.IProcess
 import mods.eln.sim.ThermalLoad
@@ -431,7 +426,7 @@ class DcDcElement(transparentNode: TransparentNode, descriptor: TransparentNodeD
             secondaryVoltageSource.current,
             secondaryThermalLoad
         )
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Voltages")] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
                 "\u00A7e" + Utils.plotVolt("", secondaryLoad.voltage)
         }

--- a/src/main/kotlin/mods/eln/transparentnode/LegacyDcDc.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/LegacyDcDc.kt
@@ -14,25 +14,12 @@ import mods.eln.item.CaseItemDescriptor
 import mods.eln.item.ConfigCopyToolDescriptor
 import mods.eln.item.FerromagneticCoreDescriptor
 import mods.eln.item.IConfigurable
-import mods.eln.misc.BasicContainer
-import mods.eln.misc.Coordinate
-import mods.eln.misc.Direction
-import mods.eln.misc.LRDU
-import mods.eln.misc.LRDUMask
-import mods.eln.misc.Obj3D
-import mods.eln.misc.PhysicalInterpolator
-import mods.eln.misc.SlewLimiter
-import mods.eln.misc.Utils
-import mods.eln.misc.VoltageLevelColor
+import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
 import mods.eln.node.NodePeriodicPublishProcess
 import mods.eln.node.six.SixNodeItemSlot
-import mods.eln.node.transparent.TransparentNode
-import mods.eln.node.transparent.TransparentNodeDescriptor
-import mods.eln.node.transparent.TransparentNodeElement
-import mods.eln.node.transparent.TransparentNodeElementInventory
-import mods.eln.node.transparent.TransparentNodeElementRender
-import mods.eln.node.transparent.TransparentNodeEntity
+import mods.eln.node.transparent.*
 import mods.eln.sim.ElectricalLoad
 import mods.eln.sim.IProcess
 import mods.eln.sim.ThermalLoad
@@ -341,7 +328,7 @@ class LegacyDcDcElement(transparentNode: TransparentNode, descriptor: Transparen
     override fun getWaila(): Map<String, String> {
         val info = HashMap<String, String>()
         info[tr("Ratio")] = Utils.plotValue(interSystemProcess.ratio)
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Voltages")] = "\u00A7a" + Utils.plotVolt("", primaryLoad.voltage) + " " +
                 "\u00A7e" + Utils.plotVolt("", secondaryLoad.voltage)
         }

--- a/src/main/kotlin/mods/eln/transparentnode/OneWayDcDc.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/OneWayDcDc.kt
@@ -14,33 +14,19 @@ import mods.eln.item.CaseItemDescriptor
 import mods.eln.item.ConfigCopyToolDescriptor
 import mods.eln.item.FerromagneticCoreDescriptor
 import mods.eln.item.IConfigurable
-import mods.eln.misc.BasicContainer
-import mods.eln.misc.Coordinate
-import mods.eln.misc.Direction
-import mods.eln.misc.LRDU
-import mods.eln.misc.LRDUMask
-import mods.eln.misc.Obj3D
-import mods.eln.misc.PhysicalInterpolator
-import mods.eln.misc.RealisticEnum
-import mods.eln.misc.SlewLimiter
-import mods.eln.misc.Utils
-import mods.eln.misc.VoltageLevelColor
+import mods.eln.misc.*
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
 import mods.eln.node.NodePeriodicPublishProcess
 import mods.eln.node.six.SixNodeEntity
-import mods.eln.node.transparent.TransparentNode
-import mods.eln.node.transparent.TransparentNodeDescriptor
-import mods.eln.node.transparent.TransparentNodeElement
-import mods.eln.node.transparent.TransparentNodeElementInventory
-import mods.eln.node.transparent.TransparentNodeElementRender
-import mods.eln.node.transparent.TransparentNodeEntity
+import mods.eln.node.transparent.*
 import mods.eln.sim.ElectricalLoad
 import mods.eln.sim.IProcess
 import mods.eln.sim.ThermalLoad
+import mods.eln.sim.mna.SubSystem
 import mods.eln.sim.mna.component.VoltageSource
 import mods.eln.sim.mna.misc.IRootSystemPreStepProcess
 import mods.eln.sim.mna.misc.MnaConst
-import mods.eln.sim.mna.SubSystem
 import mods.eln.sim.mna.state.State
 import mods.eln.sim.nbt.NbtElectricalGateInput
 import mods.eln.sim.nbt.NbtElectricalLoad
@@ -64,7 +50,7 @@ import org.lwjgl.opengl.GL11
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import java.io.IOException
-import java.util.Collections
+import java.util.*
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -490,7 +476,7 @@ class OneWayDcDcElement(
             secondaryThermalLoad
         )
         if (oneWayDescriptor.variable) info[tr("Control Voltage")] = Utils.plotVolt(control.voltage)
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false) || oneWayDescriptor.variable) {
+        if (isWailaEasyModeEnabled() || oneWayDescriptor.variable) {
             val primaryVoltage = primaryLoad.voltage - if (oneWayDescriptor.isolated) primaryReferenceLoad.voltage else 0.0
             val secondaryVoltage = secondaryLoad.voltage - if (oneWayDescriptor.isolated) secondaryReferenceLoad.voltage else 0.0
             info[tr("Voltages")] = "\u00A7a" + Utils.plotVolt("", primaryVoltage) + " " +

--- a/src/main/kotlin/mods/eln/transparentnode/battery/BatteryElement.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/battery/BatteryElement.kt
@@ -1,10 +1,10 @@
 package mods.eln.transparentnode.battery
 
-import mods.eln.Eln
 import mods.eln.i18n.I18N.tr
 import mods.eln.misc.Direction
 import mods.eln.misc.LRDU
 import mods.eln.misc.Utils
+import mods.eln.misc.Utils.isWailaEasyModeEnabled
 import mods.eln.node.NodeBase
 import mods.eln.node.NodePeriodicPublishProcess
 import mods.eln.node.transparent.TransparentNode
@@ -26,7 +26,6 @@ import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.nbt.NBTTagCompound
 import java.io.DataOutputStream
 import java.io.IOException
-import java.util.*
 
 class BatteryElement(transparentNode: TransparentNode, descriptor: TransparentNodeDescriptor) : TransparentNodeElement(transparentNode, descriptor) {
     override var descriptor: BatteryDescriptor = descriptor as BatteryDescriptor
@@ -134,7 +133,7 @@ class BatteryElement(transparentNode: TransparentNode, descriptor: TransparentNo
         info[tr("Charge")] = Utils.plotPercent("", batteryProcess.charge)
         info[tr("Energy")] = Utils.plotEnergy("", batteryProcess.energy)
         info[tr("Life")] = Utils.plotPercent("", batteryProcess.life)
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (isWailaEasyModeEnabled()) {
             info[tr("Voltage")] = Utils.plotVolt("", batteryProcess.u)
             info[tr("Current")] = Utils.plotAmpere("", batteryProcess.dischargeCurrent)
             info[tr("Temperature")] = plotAmbientCelsius("", thermalLoad.temperatureCelsius)

--- a/src/main/kotlin/mods/eln/transparentnode/floodlight/FloodlightElement.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/floodlight/FloodlightElement.kt
@@ -292,7 +292,7 @@ class FloodlightElement(transparentNode: TransparentNode, transparentNodeDescrip
         if (lamp2Stack != null) info[I18N.tr("Bulb 2")] = lamp2Stack.displayName
         else info[I18N.tr("Bulb 2")] = I18N.tr("None")
 
-        if (Eln.config.getBooleanOrElse("ui.waila.easyMode", false)) {
+        if (Utils.isWailaEasyModeEnabled()) {
             info[I18N.tr("Voltage")] = plotVolt("", electricalLoad.voltage)
 
             if (lamp1Stack != null) {
@@ -306,7 +306,7 @@ class FloodlightElement(transparentNode: TransparentNode, transparentNodeDescrip
             }
         }
 
-        if (Eln.config.getBooleanOrElse("debug.logging.enabled", false)) {
+        if (Utils.isDebugEnabled()) {
             info[I18N.tr("Lamp Brightness")] = plotValue(node!!.lightValue.toDouble())
         }
 

--- a/src/main/kotlin/mods/eln/transparentnode/floodlight/FloodlightProcess.kt
+++ b/src/main/kotlin/mods/eln/transparentnode/floodlight/FloodlightProcess.kt
@@ -23,8 +23,6 @@ class FloodlightProcess(val element: FloodlightElement) : IProcess {
         const val BASE_THROW_DISTANCE = 16
     }
 
-    private var processElapsedTime = 0.0
-
     override fun process(time: Double) {
         if (element.motorized) {
             element.swivelAngle = (element.swivelControl.normalized) * FloodlightGui.MAX_HORIZONTAL_ANGLE
@@ -60,19 +58,11 @@ class FloodlightProcess(val element: FloodlightElement) : IProcess {
                     lampLightRanges.add(0)
                 }
 
-                /* Only decrease the life of a bulb once a second. This reduces the update rate at which the NBT is changed
-                 * to once per second from once per tick, reducing the probability of an NBT mismatch bug occurring when
-                 * shift-clicking. When the bug is eventually fixed, the processElapsedTime variable and supporting code can
-                 * be deleted. Also update the decreaseLampLife function definition according to the note there.
-                */
-                if (processElapsedTime in -0.001..0.001) {
-                    val lampLife = lampDescriptor.decreaseLampLife(lampStack, lampVoltage)
-
-                    if (lampLife <= 0.0) {
-                        lampLightValues[idx] = BoilerplateLampData.MIN_LIGHT_VALUE
-                        element.inventory.setInventorySlotContents(idx, null)
-                        element.inventory.markDirty()
-                    }
+                val lampLife = lampDescriptor.decreaseLampLife(lampStack, lampVoltage)
+                if (lampLife <= 0.0) {
+                    lampLightValues[idx] = BoilerplateLampData.MIN_LIGHT_VALUE
+                    element.inventory.setInventorySlotContents(idx, null)
+                    element.inventory.markDirty()
                 }
             } else {
                 lampLightValues.add(BoilerplateLampData.MIN_LIGHT_VALUE)
@@ -91,9 +81,6 @@ class FloodlightProcess(val element: FloodlightElement) : IProcess {
             element.powered = newLightValue > BoilerplateLampData.MIN_LIGHT_VALUE
             element.needPublish()
         }
-
-        processElapsedTime += time
-        if (processElapsedTime >= 1.0) processElapsedTime = 0.0
     }
 
     /**

--- a/src/test/kotlin/mods/eln/sim/mna/RootSystemSimMetricsProfilingTest.kt
+++ b/src/test/kotlin/mods/eln/sim/mna/RootSystemSimMetricsProfilingTest.kt
@@ -29,7 +29,6 @@ class RootSystemSimMetricsProfilingTest {
     @Test
     fun keepsSimulatorMetricsInactiveWhenMqttIsDisabled() {
         disableLog4jJmx()
-        Eln.debugEnabled = false
         Eln.mqttEnabled = false
         Eln.simMetricsEnabled = true
         Eln.simMetricsMqttServer = "dummy"
@@ -55,7 +54,6 @@ class RootSystemSimMetricsProfilingTest {
     @Test
     fun profilesMnaWithAndWithoutDummyMqttMetrics() {
         disableLog4jJmx()
-        Eln.debugEnabled = false
 
         val withoutMetrics = runScenario(
             enableMetrics = false,
@@ -93,7 +91,6 @@ class RootSystemSimMetricsProfilingTest {
     @Test
     fun profilesLargeMatrixWithMultiIterationSummary() {
         disableLog4jJmx()
-        Eln.debugEnabled = false
 
         val matrixSize = 220
         val withoutMetrics = runScenario(
@@ -141,7 +138,6 @@ class RootSystemSimMetricsProfilingTest {
     @Test
     fun comparesSmallAndLargeMatrixOverhead() {
         disableLog4jJmx()
-        Eln.debugEnabled = false
 
         val sizes = listOf(4, 10, 40, 220)
         val summaries = ArrayList<Pair<Int, Triple<Double, Double, Double>>>()
@@ -195,7 +191,6 @@ class RootSystemSimMetricsProfilingTest {
     @Test
     fun profilesManySubsystemWorldOverhead() {
         disableLog4jJmx()
-        Eln.debugEnabled = false
 
         val withoutMetrics = runScenario(
             enableMetrics = false,


### PR DESCRIPTION
1. **Properly address NBT desync bug:** The server now detects when a player has a lamp socket/floodlight GUI open and/or is holding either shift key. If both of these conditions are true, all bulb(s) within the particular lamp socket/floodlight stop losing life (meaning they stop updating their NBT tags). Thus, when the player shift-clicks a bulb out of a lamp socket/floodlight, its NBT tag has had time to sync between the server and the client, so it is not duplicated. Additionally, this behavior is multiplayer-safe - if two players have the same GUI open and one player is holding shift, bulbs in that container stop losing life for both players.
2. **Improve keyhandler:** The ELN keyhandler now maintains a unique server-side list of which keys are pressed for each connected client. Essentially, this means that if one player is holding the wrench key (for example), wrench mode is no longer enabled for every player on the server. Also, the ELN keyhandler can be programmed to listen to certain keys (like the shift keys) without creating keybind entries. This is mainly useful for the NBT desync fix mentioned above, where the relevant keys are hardcoded into Minecraft's code. Finally, the ELN keyhandler can also be programmed to listen for key presses within GUIs. Again, this is really only useful for the NBT desync fix.
3. **Add server-to-client config sync:** The server now has the ability to send certain config entries to all connected clients, where the clients are expected to use these config entries in place of their own in certain contexts. At the moment, only the "debug.logging.enabled" config entry is sent to clients from the server in order to force clients to display certain additional item tooltips. This mirrors the behavior of `wailaEasyMode`, where the server controls what the client is able to display. Server config entries are sent to all clients every time a new client connects, as well as every time a client executes the `/eln config` or `/eln debug` commands.
4. **Other miscellaneous changes:** When in debug mode, the wrench key (as defined by the client-side keybind) can be used to activate both the information and realism tooltips for all ELN items. This was used for testing the NBT desync fix, but it is still a useful feature to keep around. Also, all raw `JsonConfig` reads of "debug.logging.enabled" and "ui.waila.easyMode" have been replaced with calls to `isDebugEnabled()` and `isWailaEasyModeEnabled()`, respectively, in `Utils.kt`.