### PR TITLE
Fixed nondeterministic solar panel series voltage test

### DIFF
--- a/src/main/java/mods/eln/sim/mna/SubSystem.java
+++ b/src/main/java/mods/eln/sim/mna/SubSystem.java
@@ -242,7 +242,7 @@ public class SubSystem {
 
     public void addToI(State s, double v) {
         if (s == null) return;
-        Idata[s.getId()] = v;
+        Idata[s.getId()] += v;
     }
 
     public void step() {

--- a/src/test/kotlin/mods/eln/sim/mna/component/CurrentSourceUtilityTest.kt
+++ b/src/test/kotlin/mods/eln/sim/mna/component/CurrentSourceUtilityTest.kt
@@ -21,6 +21,25 @@ class CurrentSourceUtilityTest {
     }
 
     @Test
+    fun currentsIntoSameNodeAreAccumulated() {
+        disableLog4jJmx()
+        val node = VoltageState()
+        val sourceA = CurrentSource("a", node, null).setCurrent(2.0)
+        val sourceB = CurrentSource("b", node, null).setCurrent(3.0)
+        val load = Resistor(node, null).setResistance(1.0)
+
+        val subSystem = SubSystem(null, 0.1)
+        subSystem.addState(node)
+        subSystem.addComponent(sourceA)
+        subSystem.addComponent(sourceB)
+        subSystem.addComponent(load)
+
+        subSystem.step()
+
+        assertEquals(5.0, node.state)
+    }
+
+    @Test
     fun quitSubSystemRemovesProcess() {
         disableLog4jJmx()
         val a = VoltageState()


### PR DESCRIPTION
Im out of funny titles

## What changed

Fixes #482 

This fixes a nondeterministic MNA solver bug where multiple current contributions to the same node overwrote each other instead of accumulating. The solar panel series test exposed this because panel current source ordering could change between runs.

Added a regression test for same-node current source accumulation